### PR TITLE
PM-37985: Feat: Use PolicyView in the app

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManagerImpl.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.auth.manager
 
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
@@ -168,8 +168,8 @@ class UserStateManagerImpl(
 
     private fun existingPolicies(
         userId: String,
-        policyType: PolicyTypeJson,
-    ): List<SyncResponseJson.Policy> = policyManager.getUserPolicies(
+        policyType: PolicyType,
+    ): List<PolicyView> = policyManager.getUserPolicies(
         userId = userId,
         type = policyType,
     )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -27,7 +27,6 @@ import com.bitwarden.network.model.OrganizationAutoEnrollStatusResponseJson
 import com.bitwarden.network.model.OrganizationKeysResponseJson
 import com.bitwarden.network.model.OrganizationType
 import com.bitwarden.network.model.PasswordHintResponseJson
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.PrevalidateSsoResponseJson
 import com.bitwarden.network.model.RefreshTokenResponseJson
 import com.bitwarden.network.model.RegisterFinishRequestJson
@@ -38,7 +37,6 @@ import com.bitwarden.network.model.ResetPasswordRequestJson
 import com.bitwarden.network.model.SendVerificationEmailRequestJson
 import com.bitwarden.network.model.SendVerificationEmailResponseJson
 import com.bitwarden.network.model.SetPasswordRequestJson
-import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.bitwarden.network.model.TwoFactorAuthMethod
 import com.bitwarden.network.model.TwoFactorDataModel
@@ -52,6 +50,8 @@ import com.bitwarden.network.service.HaveIBeenPwnedService
 import com.bitwarden.network.service.IdentityService
 import com.bitwarden.network.service.OrganizationService
 import com.bitwarden.network.util.isSslHandShakeError
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
@@ -366,7 +366,7 @@ class AuthRepositoryImpl(
 
         // When the policies for the user have been set, complete the login process.
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.MASTER_PASSWORD)
+            .getActivePoliciesFlow(type = PolicyType.MASTER_PASSWORD)
             .onEach { policies ->
                 val userId = activeUserId ?: return@onEach
 
@@ -1706,7 +1706,7 @@ class AuthRepositoryImpl(
      */
     private suspend fun passwordPassesPolicies(
         password: String,
-        policies: List<SyncResponseJson.Policy>,
+        policies: List<PolicyView>,
     ): Boolean {
         // If there are no master password policies that are enabled and should be
         // enforced on login, the check should complete.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensions.kt
@@ -1,8 +1,9 @@
 package com.x8bit.bitwarden.data.auth.repository.util
 
 import com.bitwarden.core.data.util.decodeFromStringOrNull
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import kotlinx.serialization.json.Json
@@ -39,25 +40,24 @@ fun List<SyncResponseJson.Profile.Organization>.toOrganizations(): List<Organiza
     this.mapNotNull { it.toOrganization() }
 
 /**
- * Convert the JSON data of the [SyncResponseJson.Policy] object into [PolicyInformation] data.
+ * Convert the JSON data of the [PolicyView] object into [PolicyInformation] data.
  */
-val SyncResponseJson.Policy.policyInformation: PolicyInformation?
-    get() = data?.toString()?.let {
-
+val PolicyView.policyInformation: PolicyInformation?
+    get() = data?.let {
         when (type) {
-            PolicyTypeJson.MASTER_PASSWORD -> {
+            PolicyType.MASTER_PASSWORD -> {
                 JSON.decodeFromStringOrNull<PolicyInformation.MasterPassword>(it)
             }
 
-            PolicyTypeJson.PASSWORD_GENERATOR -> {
+            PolicyType.PASSWORD_GENERATOR -> {
                 JSON.decodeFromStringOrNull<PolicyInformation.PasswordGenerator>(it)
             }
 
-            PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT -> {
+            PolicyType.MAXIMUM_VAULT_TIMEOUT -> {
                 JSON.decodeFromStringOrNull<PolicyInformation.VaultTimeout>(it)
             }
 
-            PolicyTypeJson.SEND_OPTIONS -> {
+            PolicyType.SEND_OPTIONS -> {
                 JSON.decodeFromStringOrNull<PolicyInformation.SendOptions>(it)
             }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
@@ -5,9 +5,10 @@ import com.bitwarden.data.repository.util.toEnvironmentUrlsOrDefault
 import com.bitwarden.network.model.KdfTypeJson
 import com.bitwarden.network.model.MasterPasswordUnlockDataJson
 import com.bitwarden.network.model.OrganizationType
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.UserDecryptionOptionsJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.base.util.toHexColorRepresentation
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
@@ -192,7 +193,7 @@ fun UserStateJson.toUserState(
     isBiometricsEnabledProvider: (userId: String) -> Boolean,
     vaultUnlockTypeProvider: (userId: String) -> VaultUnlockType,
     isDeviceTrustedProvider: (userId: String) -> Boolean,
-    getUserPolicies: (userId: String, policy: PolicyTypeJson) -> List<SyncResponseJson.Policy>,
+    getUserPolicies: (userId: String, policy: PolicyType) -> List<PolicyView>,
 ): UserState =
     UserState(
         activeUserId = this.activeUserId,
@@ -235,15 +236,15 @@ fun UserStateJson.toUserState(
 
                 val hasPersonalOwnershipRestrictedOrg = getUserPolicies(
                     userId,
-                    PolicyTypeJson.PERSONAL_OWNERSHIP,
+                    PolicyType.ORGANIZATION_DATA_OWNERSHIP,
                 )
-                    .any { it.isEnabled }
+                    .any { it.enabled }
 
                 val hasPersonalVaultExportRestrictedOrg = getUserPolicies(
                     userId,
-                    PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT,
+                    PolicyType.DISABLE_PERSONAL_VAULT_EXPORT,
                 )
-                    .any { it.isEnabled }
+                    .any { it.enabled }
 
                 UserState.Account(
                     userId = userId,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
@@ -6,7 +6,7 @@ import android.service.autofill.FillRequest
 import android.service.autofill.SaveCallback
 import android.service.autofill.SaveRequest
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.x8bit.bitwarden.data.autofill.builder.FillResponseBuilder
 import com.x8bit.bitwarden.data.autofill.builder.FilledDataBuilder
 import com.x8bit.bitwarden.data.autofill.builder.SaveInfoBuilder
@@ -80,7 +80,7 @@ class AutofillProcessorImpl(
             return
         }
 
-        if (policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP).any()) {
+        if (policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP).any()) {
             saveCallback.onSuccess()
             return
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/provider/AutofillCipherProviderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/provider/AutofillCipherProviderImpl.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.autofill.provider
 
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.vault.CipherListView
 import com.bitwarden.vault.CipherListViewType
 import com.bitwarden.vault.CipherRepromptType
@@ -58,7 +58,7 @@ class AutofillCipherProviderImpl(
     override suspend fun getCardAutofillCiphers(): List<AutofillCipher.Card> {
         val cipherListViews = getUnlockedCipherListViewsOrNull() ?: return emptyList()
         val organizationIdsWithCardTypeRestrictions = policyManager
-            .getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            .getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
             .map { it.organizationId }
         return cipherListViews
             .mapNotNull { cipherListView ->

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManager.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager
 
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -11,20 +11,20 @@ interface PolicyManager {
     /**
      * Returns a flow of all the active policies of the given type.
      */
-    fun getActivePoliciesFlow(type: PolicyTypeJson): Flow<List<SyncResponseJson.Policy>>
+    fun getActivePoliciesFlow(type: PolicyType): Flow<List<PolicyView>>
 
     /**
      * Get all the policies of the given [type] that are enabled and applicable to the user.
      */
-    fun getActivePolicies(type: PolicyTypeJson): List<SyncResponseJson.Policy>
+    fun getActivePolicies(type: PolicyType): List<PolicyView>
 
     /**
      * Get all the policies of the given [type] that are enabled and applicable to the [userId].
      */
     fun getUserPolicies(
         userId: String,
-        type: PolicyTypeJson,
-    ): List<SyncResponseJson.Policy>
+        type: PolicyType,
+    ): List<PolicyView>
 
     /**
      * Get the organization id of the personal ownership policy.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerImpl.kt
@@ -2,15 +2,18 @@ package com.x8bit.bitwarden.data.platform.manager
 
 import com.bitwarden.network.model.OrganizationStatusType
 import com.bitwarden.network.model.OrganizationType
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
+import com.x8bit.bitwarden.data.vault.repository.util.toSdkPolicyViews
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 
 /**
@@ -21,14 +24,15 @@ class PolicyManagerImpl(
     private val authDiskSource: AuthDiskSource,
 ) : PolicyManager {
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun getActivePoliciesFlow(type: PolicyTypeJson): Flow<List<SyncResponseJson.Policy>> =
+    override fun getActivePoliciesFlow(type: PolicyType): Flow<List<PolicyView>> =
         authDiskSource
             .activeUserIdChangesFlow
             .flatMapLatest { activeUserId ->
                 activeUserId
                     ?.let { userId ->
                         authDiskSource
-                            .getPoliciesFlow(userId)
+                            .getPoliciesFlow(userId = userId)
+                            .map { it?.toSdkPolicyViews() }
                             .mapNotNull {
                                 filterPolicies(
                                     userId = userId,
@@ -41,7 +45,7 @@ class PolicyManagerImpl(
             }
             .distinctUntilChanged()
 
-    override fun getActivePolicies(type: PolicyTypeJson): List<SyncResponseJson.Policy> =
+    override fun getActivePolicies(type: PolicyType): List<PolicyView> =
         authDiskSource
             .userState
             ?.activeUserId
@@ -49,26 +53,26 @@ class PolicyManagerImpl(
                 filterPolicies(
                     userId = userId,
                     type = type,
-                    policies = authDiskSource.getPolicies(userId = userId),
+                    policies = getPolicyViews(userId = userId),
                 )
             }
-            ?: emptyList()
+            .orEmpty()
 
     override fun getUserPolicies(
         userId: String,
-        type: PolicyTypeJson,
-    ): List<SyncResponseJson.Policy> =
+        type: PolicyType,
+    ): List<PolicyView> =
         this
             .filterPolicies(
                 userId = userId,
                 type = type,
-                policies = authDiskSource.getPolicies(userId = userId),
+                policies = getPolicyViews(userId = userId),
             )
             .orEmpty()
 
     override fun getPersonalOwnershipPolicyOrganizationId(): String? =
         this
-            .getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            .getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             .sortedBy { it.revisionDate }
             .firstOrNull()
             ?.organizationId
@@ -78,9 +82,9 @@ class PolicyManagerImpl(
      */
     private fun filterPolicies(
         userId: String,
-        type: PolicyTypeJson,
-        policies: List<SyncResponseJson.Policy>?,
-    ): List<SyncResponseJson.Policy>? {
+        type: PolicyType,
+        policies: List<PolicyView>?,
+    ): List<PolicyView>? {
         policies ?: return null
         if (policies.isEmpty()) return emptyList()
 
@@ -90,7 +94,7 @@ class PolicyManagerImpl(
             ?.filter {
                 it.shouldUsePolicies &&
                     it.status >= OrganizationStatusType.ACCEPTED &&
-                    !isOrganizationExemptFromPolicies(it, type)
+                    !isOrganizationExemptFromPolicies(organization = it, policyType = type)
             }
             ?.map { it.id }
             .orEmpty()
@@ -99,7 +103,7 @@ class PolicyManagerImpl(
         // and whether the organization rules except the user from the policy.
         return policies.filter {
             it.type == type &&
-                it.isEnabled &&
+                it.enabled &&
                 organizationIdsWithActivePolicies.contains(it.organizationId)
         }
     }
@@ -109,16 +113,16 @@ class PolicyManagerImpl(
      */
     private fun isOrganizationExemptFromPolicies(
         organization: SyncResponseJson.Profile.Organization,
-        policyType: PolicyTypeJson,
+        policyType: PolicyType,
     ): Boolean =
         when (policyType) {
-            PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT -> {
+            PolicyType.MAXIMUM_VAULT_TIMEOUT -> {
                 organization.type == OrganizationType.OWNER
             }
 
-            PolicyTypeJson.PASSWORD_GENERATOR,
-            PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN,
-            PolicyTypeJson.RESTRICT_ITEM_TYPES,
+            PolicyType.PASSWORD_GENERATOR,
+            PolicyType.REMOVE_UNLOCK_WITH_PIN,
+            PolicyType.RESTRICTED_ITEM_TYPES,
                 -> {
                 false
             }
@@ -129,4 +133,10 @@ class PolicyManagerImpl(
                     organization.permissions.shouldManagePolicies
             }
         }
+
+    private fun getPolicyViews(
+        userId: String,
+    ): List<PolicyView>? = authDiskSource
+        .getPolicies(userId = userId)
+        ?.toSdkPolicyViews()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/util/PolicyManagerExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/util/PolicyManagerExtensions.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.platform.manager.util
 
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.map
  */
 inline fun <reified T : PolicyInformation> PolicyManager.getActivePolicies(): List<T> =
     this
-        .getActivePolicies(type = getPolicyTypeJson<T>())
+        .getActivePolicies(type = getPolicyType<T>())
         .mapNotNull { it.policyInformation as? T }
 
 /**
@@ -20,21 +20,21 @@ inline fun <reified T : PolicyInformation> PolicyManager.getActivePolicies(): Li
  */
 inline fun <reified T : PolicyInformation> PolicyManager.getActivePoliciesFlow(): Flow<List<T>> =
     this
-        .getActivePoliciesFlow(type = getPolicyTypeJson<T>())
+        .getActivePoliciesFlow(type = getPolicyType<T>())
         .map { policies ->
             policies.mapNotNull { policy -> policy.policyInformation as? T }
         }
 
 /**
- * Helper method for mapping a specific [PolicyInformation] type to its [PolicyTypeJson]
+ * Helper method for mapping a specific [PolicyInformation] type to its [PolicyType]
  * counterpart.
  */
-inline fun <reified T : PolicyInformation> getPolicyTypeJson(): PolicyTypeJson =
+inline fun <reified T : PolicyInformation> getPolicyType(): PolicyType =
     when (T::class.java) {
-        PolicyInformation.MasterPassword::class.java -> PolicyTypeJson.MASTER_PASSWORD
-        PolicyInformation.PasswordGenerator::class.java -> PolicyTypeJson.PASSWORD_GENERATOR
-        PolicyInformation.SendOptions::class.java -> PolicyTypeJson.SEND_OPTIONS
-        PolicyInformation.VaultTimeout::class.java -> PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT
+        PolicyInformation.MasterPassword::class.java -> PolicyType.MASTER_PASSWORD
+        PolicyInformation.PasswordGenerator::class.java -> PolicyType.PASSWORD_GENERATOR
+        PolicyInformation.SendOptions::class.java -> PolicyType.SEND_OPTIONS
+        PolicyInformation.VaultTimeout::class.java -> PolicyType.MAXIMUM_VAULT_TIMEOUT
 
         else -> {
             throw IllegalStateException(
@@ -43,9 +43,10 @@ inline fun <reified T : PolicyInformation> getPolicyTypeJson(): PolicyTypeJson =
             )
         }
     }
+
 /**
  * Helper method for verifying if user has enabled the restrict item policy.
  */
 fun PolicyManager.hasRestrictItemTypes(): Boolean =
-    getActivePolicies(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
-        .any { it.isEnabled }
+    getActivePolicies(type = PolicyType.RESTRICTED_ITEM_TYPES)
+        .any { it.enabled }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -4,8 +4,8 @@ import android.view.autofill.AutofillManager
 import com.bitwarden.authenticatorbridge.util.generateSecretKey
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.data.manager.flightrecorder.FlightRecorderManager
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
@@ -374,7 +374,7 @@ class SettingsRepositoryImpl(
 
     init {
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT)
+            .getActivePoliciesFlow(type = PolicyType.MAXIMUM_VAULT_TIMEOUT)
             .onEach { updateVaultUnlockSettingsIfNecessary(it) }
             .launchIn(unconfinedScope)
     }
@@ -676,7 +676,7 @@ class SettingsRepositoryImpl(
      * settings to determine whether to update the user's settings.
      */
     private fun updateVaultUnlockSettingsIfNecessary(
-        policies: List<SyncResponseJson.Policy>,
+        policies: List<PolicyView>,
     ) {
         // The vault timeout policy can only be implemented in organizations that have
         // the single organization policy, meaning that if this is enabled, the user is

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultMigrationManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultMigrationManagerImpl.kt
@@ -8,10 +8,10 @@ import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.core.data.util.flatMap
 import com.bitwarden.network.model.BulkShareCiphersJsonRequest
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.toCipherWithIdJsonRequest
 import com.bitwarden.network.service.CiphersService
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
@@ -167,9 +167,7 @@ class VaultMigrationManagerImpl(
         hasPersonalCiphers: Boolean,
         isNetworkConnected: Boolean,
     ): Boolean =
-        policyManager
-            .getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
-            .any() &&
+        policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP).any() &&
             featureFlagManager.getFeatureFlag(FlagKey.MigrateMyVaultToMyItems) &&
             isNetworkConnected &&
             hasPersonalCiphers

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkPolicyExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkPolicyExtensions.kt
@@ -1,0 +1,55 @@
+package com.x8bit.bitwarden.data.vault.repository.util
+
+import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
+import kotlinx.serialization.json.Json
+
+/**
+ * Converts a list of network [SyncResponseJson.Policy] models to a list of SDK [PolicyView].
+ */
+fun List<SyncResponseJson.Policy>.toSdkPolicyViews(): List<PolicyView> =
+    this.map { it.toSdkPolicyView() }
+
+/**
+ * Converts a network [SyncResponseJson.Policy] model to an SDK [PolicyView].
+ */
+private fun SyncResponseJson.Policy.toSdkPolicyView(): PolicyView =
+    PolicyView(
+        organizationId = this.organizationId,
+        id = this.id,
+        type = this.type.toSdkPolicyType,
+        enabled = this.isEnabled,
+        data = this.data?.let { Json.encodeToString(it) },
+        revisionDate = this.revisionDate,
+    )
+
+private val PolicyTypeJson.toSdkPolicyType: PolicyType
+    get() = when (this) {
+        PolicyTypeJson.TWO_FACTOR_AUTHENTICATION -> PolicyType.TWO_FACTOR_AUTHENTICATION
+        PolicyTypeJson.MASTER_PASSWORD -> PolicyType.MASTER_PASSWORD
+        PolicyTypeJson.PASSWORD_GENERATOR -> PolicyType.PASSWORD_GENERATOR
+        PolicyTypeJson.ONLY_ORG -> PolicyType.SINGLE_ORG
+        PolicyTypeJson.REQUIRE_SSO -> PolicyType.REQUIRE_SSO
+        PolicyTypeJson.PERSONAL_OWNERSHIP -> PolicyType.ORGANIZATION_DATA_OWNERSHIP
+        PolicyTypeJson.DISABLE_SEND -> PolicyType.DISABLE_SEND
+        PolicyTypeJson.SEND_OPTIONS -> PolicyType.SEND_OPTIONS
+        PolicyTypeJson.RESET_PASSWORD -> PolicyType.RESET_PASSWORD
+        PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT -> PolicyType.MAXIMUM_VAULT_TIMEOUT
+        PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT -> PolicyType.DISABLE_PERSONAL_VAULT_EXPORT
+        PolicyTypeJson.ACTIVATE_AUTOFILL -> PolicyType.ACTIVATE_AUTOFILL
+        PolicyTypeJson.AUTOMATIC_APP_LOG_IN -> PolicyType.AUTOMATIC_APP_LOG_IN
+        PolicyTypeJson.FREE_FAMILIES_SPONSORSHIP_POLICY -> PolicyType.FREE_FAMILIES_SPONSORSHIP
+        PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN -> PolicyType.REMOVE_UNLOCK_WITH_PIN
+        PolicyTypeJson.RESTRICT_ITEM_TYPES -> PolicyType.RESTRICTED_ITEM_TYPES
+        PolicyTypeJson.URI_MATCH_DEFAULTS -> PolicyType.URI_MATCH_DEFAULTS
+        PolicyTypeJson.AUTOTYPE_DEFAULT_SETTING -> PolicyType.AUTOTYPE_DEFAULT_SETTING
+        PolicyTypeJson.AUTOMATIC_USER_CONFIRMATION -> PolicyType.AUTOMATIC_USER_CONFIRMATION
+        PolicyTypeJson.BLOCK_CLAIMED_DOMAIN_ACCOUNT_CREATION -> {
+            PolicyType.BLOCK_CLAIMED_DOMAIN_ACCOUNT_CREATION
+        }
+
+        PolicyTypeJson.ORGANIZATION_USER_NOTIFICATION -> PolicyType.ORGANIZATION_USER_NOTIFICATION
+        PolicyTypeJson.SEND_CONTROLS -> PolicyType.SEND_CONTROLS
+    }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -8,7 +8,7 @@ import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.data.repository.util.baseWebSendUrl
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.send.SendType
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
@@ -127,7 +127,7 @@ class SearchViewModel @Inject constructor(
                     is SearchType.Sends -> null
                     is SearchType.Vault -> userState.activeAccount.toVaultFilterData(
                         isIndividualVaultDisabled = policyManager
-                            .getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+                            .getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
                             .any(),
                     )
                 },
@@ -156,7 +156,7 @@ class SearchViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            .getActivePoliciesFlow(type = PolicyType.RESTRICTED_ITEM_TYPES)
             .map { policies -> policies.map { it.organizationId } }
             .map { SearchAction.Internal.RestrictItemTypesPolicyUpdateReceive(it) }
             .onEach(::sendAction)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.util.isBuildVersionAtLeast
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.resource.BitwardenPlurals
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -94,7 +94,7 @@ class AccountSecurityViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT)
+            .getActivePoliciesFlow(type = PolicyType.MAXIMUM_VAULT_TIMEOUT)
             .map { policies ->
                 AccountSecurityAction.Internal.PolicyUpdateReceive(
                     vaultTimeoutPolicies = policies.mapNotNull {
@@ -106,7 +106,7 @@ class AccountSecurityViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN)
+            .getActivePoliciesFlow(type = PolicyType.REMOVE_UNLOCK_WITH_PIN)
             .map { policies ->
                 AccountSecurityAction.Internal.RemovePinPolicyUpdateReceive(
                     removeUnlockWithPinPolicyEnabled = policies.isNotEmpty(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.util.toFormattedPattern
 import com.bitwarden.data.manager.file.FileManager
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -66,7 +66,7 @@ class ExportVaultViewModel @Inject constructor(
             passwordInput = "",
             passwordStrengthState = PasswordStrengthState.NONE,
             policyPreventsExport = policyManager
-                .getActivePolicies(type = PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT)
+                .getActivePolicies(type = PolicyType.DISABLE_PERSONAL_VAULT_EXPORT)
                 .any(),
             showSendCodeButton = authRepository
                 .userStateFlow

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
@@ -2,7 +2,7 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.vault
 
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.manager.BuildInfoManager
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
@@ -54,7 +54,7 @@ class VaultSettingsViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            .getActivePoliciesFlow(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             .map { policies ->
                 VaultSettingsAction.Internal.CredentialExchangeAvailabilityChanged(
                     isEnabled = !buildInfoManager.isFdroid && policies.isEmpty(),
@@ -133,7 +133,7 @@ class VaultSettingsViewModel @Inject constructor(
 
     private fun handleImportItemsClicked() {
         if (!buildInfoManager.isFdroid &&
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP).isEmpty()
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP).isEmpty()
         ) {
             sendEvent(VaultSettingsEvent.NavigateToImportItems)
         } else {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
@@ -2,7 +2,7 @@ package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar
 
 import androidx.annotation.StringRes
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.DeferredBackgroundEvent
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -36,7 +36,7 @@ class VaultUnlockedNavBarViewModel @Inject constructor(
             settingsTabNotificationCount = firstTimeActionManager.allSettingsBadgeCountFlow.value,
         ),
         areSendsDisabled = policyManager
-            .getActivePolicies(type = PolicyTypeJson.DISABLE_SEND)
+            .getActivePolicies(type = PolicyType.DISABLE_SEND)
             .any(),
     ),
 ) {
@@ -56,7 +56,7 @@ class VaultUnlockedNavBarViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.DISABLE_SEND)
+            .getActivePoliciesFlow(type = PolicyType.DISABLE_SEND)
             .map { VaultUnlockedNavBarAction.Internal.SendPolicyUpdateReceive(it.any()) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
@@ -820,8 +820,9 @@ class GeneratorViewModel @Inject constructor(
             }
 
             is GeneratedRandomWordUsernameResult.InvalidRequest -> {
-                sendEvent(GeneratorEvent.ShowSnackbar(
-                    BitwardenString.an_error_has_occurred.asText()))
+                sendEvent(
+                    GeneratorEvent.ShowSnackbar(BitwardenString.an_error_has_occurred.asText()),
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.data.repository.util.baseWebSendUrl
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.components.icon.model.IconData
@@ -70,7 +70,7 @@ class SendViewModel @Inject constructor(
             dialogState = null,
             isPullToRefreshSettingEnabled = settingsRepo.getPullToRefreshEnabledFlow().value,
             policyDisablesSend = policyManager
-                .getActivePolicies(type = PolicyTypeJson.DISABLE_SEND)
+                .getActivePolicies(type = PolicyType.DISABLE_SEND)
                 .any(),
             isRefreshing = false,
             isPremiumUser = authRepo.userStateFlow.value?.activeAccount?.isPremium == true,
@@ -85,7 +85,7 @@ class SendViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.DISABLE_SEND)
+            .getActivePoliciesFlow(type = PolicyType.DISABLE_SEND)
             .map { SendAction.Internal.PolicyUpdateReceive(it.any()) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -8,7 +8,7 @@ import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.takeUntilLoaded
 import com.bitwarden.data.repository.util.baseWebSendUrl
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.send.SendView
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
@@ -149,7 +149,7 @@ class AddEditSendViewModel @Inject constructor(
             dialogState = null,
             baseWebSendUrl = environmentRepo.environment.environmentUrlData.baseWebSendUrl,
             policyDisablesSend = policyManager
-                .getActivePolicies(type = PolicyTypeJson.DISABLE_SEND)
+                .getActivePolicies(type = PolicyType.DISABLE_SEND)
                 .any(),
             isPremium = authRepo.userStateFlow.value?.activeAccount?.isPremium == true,
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -11,7 +11,7 @@ import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.takeUntilLoaded
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.DeferredBackgroundEvent
@@ -157,7 +157,7 @@ class VaultAddEditViewModel @Inject constructor(
             val selectedFolderId = args.selectedFolderId
             val selectedCollectionId = args.selectedCollectionId
             val isIndividualVaultDisabled = policyManager
-                .getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+                .getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
                 .any()
 
             val specialCircumstance = specialCircumstanceManager.specialCircumstance
@@ -2247,7 +2247,7 @@ class VaultAddEditViewModel @Inject constructor(
                 sendViewList = emptyList(),
             )
         val isIndividualVaultDisabled = policyManager
-            .getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            .getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             .any()
         return copy(
             viewState = internalVaultData.decryptCipherListResult.successes

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.cxf.manager.model.ExportCredentialsResult
 import com.bitwarden.cxf.model.ImportCredentialsRequestData
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
@@ -223,8 +223,8 @@ class ReviewExportViewModel @Inject constructor(
             ?.map { it.id }
             ?: return this
         val itemRestrictedOrgIds = policyManager
-            .getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
-            .filter { it.isEnabled }
+            .getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
+            .filter { it.enabled }
             .map { it.organizationId }
 
         return if (activeUserOrgIds.any { itemRestrictedOrgIds.contains(it) }) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/selectaccount/SelectAccountViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/selectaccount/SelectAccountViewModel.kt
@@ -3,8 +3,8 @@ package com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount
 import android.os.Parcelable
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.cxf.model.ImportCredentialsRequestData
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -118,7 +118,7 @@ class SelectAccountViewModel @Inject constructor(
         action: SelectAccountAction.Internal.SelectionDataReceive,
     ) {
         val itemRestrictedOrgIds = action.itemRestrictedOrgs
-            .filter { it.isEnabled }
+            .filter { it.enabled }
             .map { it.organizationId }
 
         val accountSelectionListItems = action.userState
@@ -159,7 +159,7 @@ class SelectAccountViewModel @Inject constructor(
     private fun observeSelectionData() {
         combine(
             authRepository.userStateFlow,
-            policyManager.getActivePoliciesFlow(PolicyTypeJson.RESTRICT_ITEM_TYPES),
+            policyManager.getActivePoliciesFlow(PolicyType.RESTRICTED_ITEM_TYPES),
         ) { userState, itemRestrictedOrgs ->
             SelectAccountAction.Internal.SelectionDataReceive(
                 userState = userState,
@@ -248,7 +248,7 @@ sealed class SelectAccountAction {
          */
         data class SelectionDataReceive(
             val userState: UserState?,
-            val itemRestrictedOrgs: List<SyncResponseJson.Policy>,
+            val itemRestrictedOrgs: List<PolicyView>,
         ) : Internal()
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModel.kt
@@ -3,7 +3,7 @@ package com.x8bit.bitwarden.ui.vault.feature.exportitems.verifypassword
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -59,8 +59,8 @@ class VerifyPasswordViewModel @Inject constructor(
             val singleAccount = !args.hasOtherAccounts
 
             val restrictedItemPolicyOrgIds = policyManager
-                .getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
-                .filter { it.isEnabled }
+                .getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
+                .filter { it.enabled }
                 .map { it.organizationId }
 
             VerifyPasswordState(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -19,7 +19,7 @@ import com.bitwarden.core.util.persistentListOfNotNull
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.data.repository.util.baseWebSendUrl
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.send.SendType
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
@@ -185,7 +185,7 @@ class VaultItemListingViewModel @Inject constructor(
                     VaultItemListingState.DialogState.Loading(BitwardenString.loading.asText())
                 },
             policyDisablesSend = policyManager
-                .getActivePolicies(type = PolicyTypeJson.DISABLE_SEND)
+                .getActivePolicies(type = PolicyType.DISABLE_SEND)
                 .any(),
             restrictItemTypesPolicyOrgIds = persistentListOf(),
             autofillSelectionData = specialCircumstance?.toAutofillSelectionDataOrNull(),
@@ -214,13 +214,13 @@ class VaultItemListingViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.DISABLE_SEND)
+            .getActivePoliciesFlow(type = PolicyType.DISABLE_SEND)
             .map { VaultItemListingsAction.Internal.PolicyUpdateReceive(it.any()) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            .getActivePoliciesFlow(type = PolicyType.RESTRICTED_ITEM_TYPES)
             .map { policies -> policies.map { it.organizationId } }
             .map { VaultItemListingsAction.Internal.RestrictItemTypesPolicyUpdateReceive(it) }
             .onEach(::sendAction)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -11,7 +11,7 @@ import com.bitwarden.core.util.persistentListOfNotNull
 import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.util.hexToColor
@@ -137,7 +137,7 @@ class VaultViewModel @Inject constructor(
         val activeAccountSummary = activeAccount.toAccountSummary(isActive = true)
         val vaultFilterData = activeAccount.toVaultFilterData(
             isIndividualVaultDisabled = policyManager
-                .getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+                .getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
                 .any(),
         )
         VaultState(
@@ -286,7 +286,7 @@ class VaultViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         policyManager
-            .getActivePoliciesFlow(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            .getActivePoliciesFlow(type = PolicyType.RESTRICTED_ITEM_TYPES)
             .map { policies -> policies.map { it.organizationId } }
             .map { VaultAction.Internal.PolicyUpdateReceive(it) }
             .onEach(::sendAction)
@@ -1369,7 +1369,7 @@ class VaultViewModel @Inject constructor(
 
         val vaultFilterData = userState.activeAccount.toVaultFilterData(
             isIndividualVaultDisabled = policyManager
-                .getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+                .getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
                 .any(),
         )
         val appBarTitle = vaultFilterData.toAppBarTitle()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManagerTest.kt
@@ -6,9 +6,8 @@ import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
 import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
 import com.bitwarden.network.model.GetTokenResponseJson
 import com.bitwarden.network.model.KdfTypeJson
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.createMockOrganizationNetwork
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
@@ -20,6 +19,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.toUserState
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.manager.VaultLockManager
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import io.mockk.every
@@ -259,12 +259,11 @@ class UserStateManagerTest {
     @Test
     fun `userStateFlow should update isExportable when getUserPolicies returns policies`() =
         runTest {
-            val policy = createMockPolicy(
+            val policy = createMockPolicyView(
                 id = "policyId",
                 organizationId = "mockId-1",
-                type = PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT,
-                data = null,
-                isEnabled = true,
+                type = PolicyType.DISABLE_PERSONAL_VAULT_EXPORT,
+                enabled = true,
             )
             every { policyManager.getUserPolicies(any(), any()) } returns listOf(policy)
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -46,7 +46,6 @@ import com.bitwarden.network.model.OrganizationAutoEnrollStatusResponseJson
 import com.bitwarden.network.model.OrganizationKeysResponseJson
 import com.bitwarden.network.model.OrganizationType
 import com.bitwarden.network.model.PasswordHintResponseJson
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.PreLoginResponseJson
 import com.bitwarden.network.model.PrevalidateSsoResponseJson
 import com.bitwarden.network.model.RefreshTokenResponseJson
@@ -57,7 +56,6 @@ import com.bitwarden.network.model.ResetPasswordRequestJson
 import com.bitwarden.network.model.SendVerificationEmailRequestJson
 import com.bitwarden.network.model.SendVerificationEmailResponseJson
 import com.bitwarden.network.model.SetPasswordRequestJson
-import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.bitwarden.network.model.TwoFactorAuthMethod
 import com.bitwarden.network.model.TwoFactorDataModel
@@ -69,12 +67,13 @@ import com.bitwarden.network.model.VerifyEmailTokenResponseJson
 import com.bitwarden.network.model.createMockAccountKeysJson
 import com.bitwarden.network.model.createMockAccountKeysJsonWithNullFields
 import com.bitwarden.network.model.createMockOrganizationNetwork
-import com.bitwarden.network.model.createMockPolicy
 import com.bitwarden.network.service.AccountsService
 import com.bitwarden.network.service.DevicesService
 import com.bitwarden.network.service.HaveIBeenPwnedService
 import com.bitwarden.network.service.IdentityService
 import com.bitwarden.network.service.OrganizationService
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
@@ -148,6 +147,7 @@ import com.x8bit.bitwarden.data.platform.manager.model.NotificationLogoutData
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
@@ -168,8 +168,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -266,14 +264,14 @@ class AuthRepositoryTest {
 
     private val mutableLogoutFlow = bufferedMutableSharedFlow<NotificationLogoutData>()
     private val mutableSyncOrgKeysFlow = bufferedMutableSharedFlow<String>()
-    private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Policy>>()
+    private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<PolicyView>>()
     private val pushManager: PushManager = mockk {
         every { logoutFlow } returns mutableLogoutFlow
         every { syncOrgKeysFlow } returns mutableSyncOrgKeysFlow
     }
     private val policyManager: PolicyManager = mockk {
         every {
-            getActivePoliciesFlow(type = PolicyTypeJson.MASTER_PASSWORD)
+            getActivePoliciesFlow(type = PolicyType.MASTER_PASSWORD)
         } returns mutableActivePolicyFlow
     }
     private val logsManager: LogsManager = mockk {
@@ -470,18 +468,20 @@ class AuthRepositoryTest {
             // Set policies that will fail the password.
             mutableActivePolicyFlow.emit(
                 listOf(
-                    createMockPolicy(
-                        type = PolicyTypeJson.MASTER_PASSWORD,
-                        isEnabled = true,
-                        data = buildJsonObject {
-                            put(key = "minLength", value = 100)
-                            put(key = "minComplexity", value = null)
-                            put(key = "requireUpper", value = null)
-                            put(key = "requireLower", value = null)
-                            put(key = "requireNumbers", value = null)
-                            put(key = "requireSpecial", value = null)
-                            put(key = "enforceOnLogin", value = true)
-                        },
+                    createMockPolicyView(
+                        type = PolicyType.MASTER_PASSWORD,
+                        enabled = true,
+                        data = """
+                            {
+                              "minLength":100,
+                              "minComplexity":null,
+                              "requireUpper":null,
+                              "requireLower":null,
+                              "requireNumbers":null,
+                              "requireSpecial":null,
+                              "enforceOnLogin":true
+                            }
+                        """,
                     ),
                 ),
             )
@@ -7344,20 +7344,22 @@ class AuthRepositoryTest {
             requireSpecial: Boolean = false,
         ) {
             every {
-                policyManager.getActivePolicies(type = PolicyTypeJson.MASTER_PASSWORD)
+                policyManager.getActivePolicies(type = PolicyType.MASTER_PASSWORD)
             } returns listOf(
-                createMockPolicy(
-                    type = PolicyTypeJson.MASTER_PASSWORD,
-                    isEnabled = true,
-                    data = buildJsonObject {
-                        put(key = "minLength", value = minLength)
-                        put(key = "minComplexity", value = minComplexity)
-                        put(key = "requireUpper", value = requireUpper)
-                        put(key = "requireLower", value = requireLower)
-                        put(key = "requireNumbers", value = requireNumbers)
-                        put(key = "requireSpecial", value = requireSpecial)
-                        put(key = "enforceOnLogin", value = true)
-                    },
+                createMockPolicyView(
+                    type = PolicyType.MASTER_PASSWORD,
+                    enabled = true,
+                    data = """
+                      {
+                        "minLength":$minLength,
+                        "minComplexity":$minComplexity,
+                        "requireUpper":$requireUpper,
+                        "requireLower":$requireLower,
+                        "requireNumbers":$requireNumbers,
+                        "requireSpecial":$requireSpecial,
+                        "enforceOnLogin":true
+                      }
+                    """,
                 ),
             )
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformationUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformationUtil.kt
@@ -1,9 +1,5 @@
 package com.x8bit.bitwarden.data.auth.repository.model
 
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
-
 /**
  * Create a mock [PolicyInformation.MasterPassword] with a given parameters.
  */
@@ -42,34 +38,32 @@ fun createMockVaultTimeoutPolicy(
     )
 
 /**
- * Create a mock [JsonObject] representing a [PolicyInformation.VaultTimeout].
+ * Create a mock `String` representing a [PolicyInformation.VaultTimeout].
  */
-fun createMockVaultTimeoutPolicyJsonObject(
+fun createMockVaultTimeoutPolicyJsonString(
     vaultTimeout: PolicyInformation.VaultTimeout,
-): JsonObject =
-    buildJsonObject {
-        put(key = "minutes", element = JsonPrimitive(value = vaultTimeout.minutes))
-        put(
-            key = "action",
-            element = JsonPrimitive(
-                value = when (vaultTimeout.action) {
-                    PolicyInformation.VaultTimeout.Action.LOCK -> "lock"
-                    PolicyInformation.VaultTimeout.Action.LOGOUT -> "logOut"
-                    null -> null
-                },
-            ),
-        )
-        put(
-            key = "type",
-            element = JsonPrimitive(
-                value = when (vaultTimeout.type) {
-                    PolicyInformation.VaultTimeout.Type.NEVER -> "never"
-                    PolicyInformation.VaultTimeout.Type.ON_APP_RESTART -> "onAppRestart"
-                    PolicyInformation.VaultTimeout.Type.ON_SYSTEM_LOCK -> "onSystemLock"
-                    PolicyInformation.VaultTimeout.Type.IMMEDIATELY -> "immediately"
-                    PolicyInformation.VaultTimeout.Type.CUSTOM -> "custom"
-                    null -> null
-                },
-            ),
-        )
+): String =
+    """
+      {
+        "minutes":${vaultTimeout.minutes},
+        "action":${vaultTimeout.toActionString?.let { "\"$it\"" }},
+        "type":${vaultTimeout.toTypeString?.let { "\"$it\"" }}
+      }
+    """
+
+private val PolicyInformation.VaultTimeout.toActionString: String?
+    get() = when (this.action) {
+        PolicyInformation.VaultTimeout.Action.LOCK -> "lock"
+        PolicyInformation.VaultTimeout.Action.LOGOUT -> "logOut"
+        null -> null
+    }
+
+private val PolicyInformation.VaultTimeout.toTypeString: String?
+    get() = when (this.type) {
+        PolicyInformation.VaultTimeout.Type.NEVER -> "never"
+        PolicyInformation.VaultTimeout.Type.ON_APP_RESTART -> "onAppRestart"
+        PolicyInformation.VaultTimeout.Type.ON_SYSTEM_LOCK -> "onSystemLock"
+        PolicyInformation.VaultTimeout.Type.IMMEDIATELY -> "immediately"
+        PolicyInformation.VaultTimeout.Type.CUSTOM -> "custom"
+        null -> null
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensionsTest.kt
@@ -1,15 +1,13 @@
 package com.x8bit.bitwarden.data.auth.repository.util
 
 import com.bitwarden.network.model.OrganizationType
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.createMockOrganizationNetwork
 import com.bitwarden.network.model.createMockPermissions
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.createMockOrganization
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -60,9 +58,9 @@ class SyncResponseJsonExtensionsTest {
             requireSpecial = null,
             enforceOnLogin = true,
         )
-        val policy = createMockPolicy(
-            type = PolicyTypeJson.MASTER_PASSWORD,
-            data = Json.encodeToJsonElement(policyInformation).jsonObject,
+        val policy = createMockPolicyView(
+            type = PolicyType.MASTER_PASSWORD,
+            data = Json.encodeToString(policyInformation),
         )
 
         assertEquals(
@@ -86,9 +84,9 @@ class SyncResponseJsonExtensionsTest {
             capitalize = true,
             includeNumber = null,
         )
-        val policy = createMockPolicy(
-            type = PolicyTypeJson.PASSWORD_GENERATOR,
-            data = Json.encodeToJsonElement(policyInformation).jsonObject,
+        val policy = createMockPolicyView(
+            type = PolicyType.PASSWORD_GENERATOR,
+            data = Json.encodeToString(policyInformation),
         )
 
         assertEquals(
@@ -104,9 +102,9 @@ class SyncResponseJsonExtensionsTest {
             action = PolicyInformation.VaultTimeout.Action.LOCK,
             type = PolicyInformation.VaultTimeout.Type.CUSTOM,
         )
-        val policy = createMockPolicy(
-            type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-            data = Json.encodeToJsonElement(policyInformation).jsonObject,
+        val policy = createMockPolicyView(
+            type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+            data = Json.encodeToString(policyInformation),
         )
 
         assertEquals(
@@ -117,8 +115,8 @@ class SyncResponseJsonExtensionsTest {
 
     @Test
     fun `policyInformation returns null policy information for null data`() {
-        val masterPasswordPolicy = createMockPolicy(
-            type = PolicyTypeJson.MASTER_PASSWORD,
+        val masterPasswordPolicy = createMockPolicyView(
+            type = PolicyType.MASTER_PASSWORD,
             data = null,
         )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
@@ -9,12 +9,11 @@ import com.bitwarden.network.model.KdfTypeJson
 import com.bitwarden.network.model.KeyConnectorUserDecryptionOptionsJson
 import com.bitwarden.network.model.MasterPasswordUnlockDataJson
 import com.bitwarden.network.model.OrganizationType
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.bitwarden.network.model.UserDecryptionJson
 import com.bitwarden.network.model.UserDecryptionOptionsJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
@@ -29,6 +28,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.auth.repository.model.createMockOrganization
 import com.x8bit.bitwarden.data.auth.util.KdfParamsConstants.DEFAULT_PBKDF2_ITERATIONS
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import io.mockk.every
 import io.mockk.mockk
@@ -321,19 +321,27 @@ class UserStateJsonExtensionsTest {
             .accounts
             .first()
 
-        val freeAccount = toAccount(stateWith(hasPremiumPersonally = false, hasPremiumFromOrg = false))
+        val freeAccount = toAccount(
+            stateWith(hasPremiumPersonally = false, hasPremiumFromOrg = false),
+        )
         assertFalse(freeAccount.isPremium)
         assertFalse(freeAccount.isPremiumFromSelf)
 
-        val personalAccount = toAccount(stateWith(hasPremiumPersonally = true, hasPremiumFromOrg = false))
+        val personalAccount = toAccount(
+            stateWith(hasPremiumPersonally = true, hasPremiumFromOrg = false),
+        )
         assertTrue(personalAccount.isPremium)
         assertTrue(personalAccount.isPremiumFromSelf)
 
-        val orgOnlyAccount = toAccount(stateWith(hasPremiumPersonally = false, hasPremiumFromOrg = true))
+        val orgOnlyAccount = toAccount(
+            stateWith(hasPremiumPersonally = false, hasPremiumFromOrg = true),
+        )
         assertTrue(orgOnlyAccount.isPremium)
         assertFalse(orgOnlyAccount.isPremiumFromSelf)
 
-        val bothAccount = toAccount(stateWith(hasPremiumPersonally = true, hasPremiumFromOrg = true))
+        val bothAccount = toAccount(
+            stateWith(hasPremiumPersonally = true, hasPremiumFromOrg = true),
+        )
         assertTrue(bothAccount.isPremium)
         assertTrue(bothAccount.isPremiumFromSelf)
     }
@@ -1816,12 +1824,11 @@ class UserStateJsonExtensionsTest {
                     firstTimeState = FirstTimeState(showImportLoginsCard = true),
                     getUserPolicies = { _, _ ->
                         listOf(
-                            createMockPolicy(
+                            createMockPolicyView(
                                 id = "policyId",
                                 organizationId = "organizationId",
-                                type = PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT,
-                                data = null,
-                                isEnabled = true,
+                                type = PolicyType.DISABLE_PERSONAL_VAULT_EXPORT,
+                                enabled = true,
                             ),
                         )
                     },
@@ -1938,12 +1945,11 @@ class UserStateJsonExtensionsTest {
                     firstTimeState = FirstTimeState(showImportLoginsCard = true),
                     getUserPolicies = { _, _ ->
                         listOf(
-                            createMockPolicy(
+                            createMockPolicyView(
                                 id = "policyId",
                                 organizationId = "organizationId",
-                                type = PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT,
-                                data = null,
-                                isEnabled = false,
+                                type = PolicyType.DISABLE_PERSONAL_VAULT_EXPORT,
+                                enabled = false,
                             ),
                         )
                     },

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillCipherProviderTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillCipherProviderTest.kt
@@ -1,8 +1,7 @@
 package com.x8bit.bitwarden.data.autofill.processor
 
 import com.bitwarden.core.data.repository.model.DataState
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.vault.CardListView
 import com.bitwarden.vault.CardView
 import com.bitwarden.vault.CipherListView
@@ -22,6 +21,7 @@ import com.x8bit.bitwarden.data.autofill.util.login
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
 import com.x8bit.bitwarden.data.platform.util.subtitle
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.manager.model.GetCipherResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
@@ -152,7 +152,7 @@ class AutofillCipherProviderTest {
     }
     private val policyManager: PolicyManager = mockk {
         every {
-            getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
         } returns emptyList()
     }
 
@@ -317,12 +317,9 @@ class AutofillCipherProviderTest {
             )
 
             every {
-                policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                policyManager.getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
             } returns listOf(
-                createMockPolicy(
-                    number = 1,
-                    organizationId = ORGANIZATION_ID_WITH_CARD_TYPE_RESTRICTIONS,
-                ),
+                createMockPolicyView(organizationId = ORGANIZATION_ID_WITH_CARD_TYPE_RESTRICTIONS),
             )
             coEvery {
                 vaultRepository.getCipher(CARD_CIPHER_ID)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
@@ -11,8 +11,8 @@ import android.service.autofill.SaveCallback
 import android.service.autofill.SaveInfo
 import android.service.autofill.SaveRequest
 import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.x8bit.bitwarden.data.autofill.builder.FillResponseBuilder
 import com.x8bit.bitwarden.data.autofill.builder.FilledDataBuilder
 import com.x8bit.bitwarden.data.autofill.builder.SaveInfoBuilder
@@ -306,10 +306,10 @@ class AutofillProcessorTest {
             every { onSuccess() } just runs
         }
         val saveRequest: SaveRequest = mockk()
-        val policies: List<SyncResponseJson.Policy> = listOf(mockk())
+        val policies: List<PolicyView> = listOf(mockk())
         every { settingsRepository.isAutofillSavePromptDisabled } returns false
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns policies
 
         // Test
@@ -322,7 +322,7 @@ class AutofillProcessorTest {
         // Verify
         verify(exactly = 1) {
             settingsRepository.isAutofillSavePromptDisabled
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             saveCallback.onSuccess()
         }
     }
@@ -338,7 +338,7 @@ class AutofillProcessorTest {
         }
         every { settingsRepository.isAutofillSavePromptDisabled } returns false
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns emptyList()
 
         // Test
@@ -351,7 +351,7 @@ class AutofillProcessorTest {
         // Verify
         verify(exactly = 1) {
             settingsRepository.isAutofillSavePromptDisabled
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             saveCallback.onSuccess()
         }
     }
@@ -380,7 +380,7 @@ class AutofillProcessorTest {
         }
         every { settingsRepository.isAutofillSavePromptDisabled } returns false
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns emptyList()
         every {
             parser.parse(
@@ -405,7 +405,7 @@ class AutofillProcessorTest {
         // Verify
         verify(exactly = 1) {
             settingsRepository.isAutofillSavePromptDisabled
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             parser.parse(
                 autofillAppInfo = appInfo,
                 assistStructure = assistStructure,
@@ -435,7 +435,7 @@ class AutofillProcessorTest {
         val autofillRequest = AutofillRequest.Unfillable
         every { settingsRepository.isAutofillSavePromptDisabled } returns false
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns emptyList()
         every {
             parser.parse(
@@ -454,7 +454,7 @@ class AutofillProcessorTest {
         // Verify
         verify(exactly = 1) {
             settingsRepository.isAutofillSavePromptDisabled
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             parser.parse(
                 autofillAppInfo = appInfo,
                 assistStructure = assistStructure,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerTest.kt
@@ -6,8 +6,10 @@ import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.createMockOrganizationNetwork
 import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -52,31 +54,43 @@ class PolicyManagerTest {
                 isEnabled = true,
                 shouldUsePolicies = true,
             )
-            val expectedPolicyOne = createMockPolicy(
+            val storedPolicyOne = createMockPolicy(
                 isEnabled = true,
                 number = 1,
                 organizationId = organizationsOne.id,
                 type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
             )
-            val expectedPolicyTwo = createMockPolicy(
+            val storedPolicyTwo = createMockPolicy(
                 isEnabled = true,
                 number = 2,
                 organizationId = organizationsTwo.id,
                 type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
+            )
+            val expectedPolicyOne = createMockPolicyView(
+                enabled = true,
+                number = 1,
+                organizationId = organizationsOne.id,
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+            )
+            val expectedPolicyTwo = createMockPolicyView(
+                enabled = true,
+                number = 2,
+                organizationId = organizationsTwo.id,
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
             )
             every {
                 authDiskSource.getOrganizations(USER_ID)
             } returns listOf(organizationsOne) andThen listOf(organizationsTwo)
 
             mutableUserStateFlow.value = userStateJson
-            mutablePolicyFlow.value = listOf(expectedPolicyOne)
+            mutablePolicyFlow.value = listOf(storedPolicyOne)
 
             policyManager
-                .getActivePoliciesFlow(type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT)
+                .getActivePoliciesFlow(type = PolicyType.MAXIMUM_VAULT_TIMEOUT)
                 .test {
                     assertEquals(listOf(expectedPolicyOne), awaitItem())
 
-                    mutablePolicyFlow.value = listOf(expectedPolicyTwo)
+                    mutablePolicyFlow.value = listOf(storedPolicyTwo)
 
                     assertEquals(listOf(expectedPolicyTwo), awaitItem())
                 }
@@ -88,7 +102,7 @@ class PolicyManagerTest {
             authDiskSource.userState
         } returns null
 
-        assertTrue(policyManager.getActivePolicies(type = PolicyTypeJson.MASTER_PASSWORD).isEmpty())
+        assertTrue(policyManager.getActivePolicies(type = PolicyType.MASTER_PASSWORD).isEmpty())
     }
 
     @Test
@@ -114,7 +128,7 @@ class PolicyManagerTest {
             ),
         )
 
-        assertTrue(policyManager.getActivePolicies(type = PolicyTypeJson.MASTER_PASSWORD).isEmpty())
+        assertTrue(policyManager.getActivePolicies(type = PolicyType.MASTER_PASSWORD).isEmpty())
     }
 
     @Test
@@ -140,7 +154,7 @@ class PolicyManagerTest {
             ),
         )
 
-        assertTrue(policyManager.getActivePolicies(type = PolicyTypeJson.MASTER_PASSWORD).isEmpty())
+        assertTrue(policyManager.getActivePolicies(type = PolicyType.MASTER_PASSWORD).isEmpty())
     }
 
     @Test
@@ -148,7 +162,8 @@ class PolicyManagerTest {
         val userState: UserStateJson = mockk {
             every { activeUserId } returns USER_ID
         }
-        val policy = createMockPolicy(organizationId = "mockId-3", isEnabled = true)
+        val storedPolicy = createMockPolicy(organizationId = "mockId-3", isEnabled = true)
+        val expectedPolicy = createMockPolicyView(organizationId = "mockId-3", enabled = true)
         every { authDiskSource.userState } returns userState
         every {
             authDiskSource.getOrganizations(USER_ID)
@@ -160,11 +175,11 @@ class PolicyManagerTest {
                 type = OrganizationType.USER,
             ),
         )
-        every { authDiskSource.getPolicies(USER_ID) } returns listOf(policy)
+        every { authDiskSource.getPolicies(USER_ID) } returns listOf(storedPolicy)
 
         assertEquals(
-            listOf(policy),
-            policyManager.getActivePolicies(type = PolicyTypeJson.MASTER_PASSWORD),
+            listOf(expectedPolicy),
+            policyManager.getActivePolicies(type = PolicyType.MASTER_PASSWORD),
         )
     }
 
@@ -193,7 +208,7 @@ class PolicyManagerTest {
             ),
         )
 
-        assertTrue(policyManager.getActivePolicies(type = PolicyTypeJson.PASSWORD_GENERATOR).any())
+        assertTrue(policyManager.getActivePolicies(type = PolicyType.PASSWORD_GENERATOR).any())
     }
 
     @Test
@@ -221,7 +236,9 @@ class PolicyManagerTest {
             ),
         )
 
-        assertTrue(policyManager.getActivePolicies(type = PolicyTypeJson.RESTRICT_ITEM_TYPES).any())
+        assertTrue(
+            policyManager.getActivePolicies(type = PolicyType.RESTRICTED_ITEM_TYPES).any(),
+        )
     }
 
     @Test
@@ -238,7 +255,7 @@ class PolicyManagerTest {
             emptyList<SyncResponseJson.Policy>(),
             policyManager.getUserPolicies(
                 userId = USER_ID,
-                type = PolicyTypeJson.PERSONAL_OWNERSHIP,
+                type = PolicyType.ORGANIZATION_DATA_OWNERSHIP,
             ),
         )
     }
@@ -260,22 +277,29 @@ class PolicyManagerTest {
             ),
         )
 
-        val listOfPolicies = listOf(
+        val storedListOfPolicies = listOf(
             createMockPolicy(
                 organizationId = "mockId-3",
                 isEnabled = true,
                 type = PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT,
             ),
         )
+        val expectedListOfPolicies = listOf(
+            createMockPolicyView(
+                organizationId = "mockId-3",
+                enabled = true,
+                type = PolicyType.DISABLE_PERSONAL_VAULT_EXPORT,
+            ),
+        )
         every {
             authDiskSource.getPolicies(USER_ID)
-        } returns listOfPolicies
+        } returns storedListOfPolicies
 
         assertEquals(
-            listOfPolicies,
+            expectedListOfPolicies,
             policyManager.getUserPolicies(
                 userId = USER_ID,
-                type = PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT,
+                type = PolicyType.DISABLE_PERSONAL_VAULT_EXPORT,
             ),
         )
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/util/PolicyManagerExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/util/PolicyManagerExtensionsTest.kt
@@ -2,22 +2,19 @@ package com.x8bit.bitwarden.data.platform.manager.util
 
 import app.cash.turbine.test
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class PolicyManagerExtensionsTest {
-    private val mutablePolicyFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Policy>>()
+    private val mutablePolicyFlow = bufferedMutableSharedFlow<List<PolicyView>>()
     private val policyManager: PolicyManager = mockk {
         every { getActivePoliciesFlow(any()) } returns mutablePolicyFlow
     }
@@ -50,54 +47,54 @@ class PolicyManagerExtensionsTest {
         }
 
     @Test
-    fun `getPolicyTypeJson with MasterPassword should map to appropriate PolicyTypeJson`() {
+    fun `getPolicyType with MasterPassword should map to appropriate PolicyTypeJson`() {
         assertEquals(
-            PolicyTypeJson.MASTER_PASSWORD,
-            getPolicyTypeJson<PolicyInformation.MasterPassword>(),
+            PolicyType.MASTER_PASSWORD,
+            getPolicyType<PolicyInformation.MasterPassword>(),
         )
     }
 
     @Test
-    fun `getPolicyTypeJson with PasswordGenerator should map to appropriate PolicyTypeJson`() {
+    fun `getPolicyType with PasswordGenerator should map to appropriate PolicyTypeJson`() {
         assertEquals(
-            PolicyTypeJson.PASSWORD_GENERATOR,
-            getPolicyTypeJson<PolicyInformation.PasswordGenerator>(),
+            PolicyType.PASSWORD_GENERATOR,
+            getPolicyType<PolicyInformation.PasswordGenerator>(),
         )
     }
 
     @Test
-    fun `getPolicyTypeJson with SendOptions should map to appropriate PolicyTypeJson`() {
+    fun `getPolicyType with SendOptions should map to appropriate PolicyTypeJson`() {
         assertEquals(
-            PolicyTypeJson.SEND_OPTIONS,
-            getPolicyTypeJson<PolicyInformation.SendOptions>(),
+            PolicyType.SEND_OPTIONS,
+            getPolicyType<PolicyInformation.SendOptions>(),
         )
     }
 
     @Test
-    fun `getPolicyTypeJson with VaultTimeout should map to appropriate PolicyTypeJson`() {
+    fun `getPolicyType with VaultTimeout should map to appropriate PolicyTypeJson`() {
         assertEquals(
-            PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-            getPolicyTypeJson<PolicyInformation.VaultTimeout>(),
+            PolicyType.MAXIMUM_VAULT_TIMEOUT,
+            getPolicyType<PolicyInformation.VaultTimeout>(),
         )
     }
 }
 
-private val MASTER_PASSWORD_POLICY = createMockPolicy(
+private val MASTER_PASSWORD_POLICY = createMockPolicyView(
     organizationId = "organizationId",
     id = "master_password_id",
-    type = PolicyTypeJson.MASTER_PASSWORD,
-    isEnabled = true,
-    data = JsonObject(
-        mapOf(
-            "minLength" to JsonPrimitive(10),
-            "minComplexity" to JsonPrimitive(10),
-            "requireUpper" to JsonPrimitive(false),
-            "requireLower" to JsonPrimitive(true),
-            "requireNumbers" to JsonNull,
-            "requireSpecial" to JsonPrimitive(false),
-            "enforceOnLogin" to JsonPrimitive(true),
-        ),
-    ),
+    type = PolicyType.MASTER_PASSWORD,
+    enabled = true,
+    data = """
+      {
+        "minLength":10,
+        "minComplexity":10,
+        "requireUpper":false,
+        "requireLower":true,
+        "requireNumbers":null,
+        "requireSpecial":false,
+        "enforceOnLogin":true
+      }
+    """,
 )
 
 private val MASTER_PASSWORD_POLICY_INFO = PolicyInformation.MasterPassword(
@@ -110,24 +107,24 @@ private val MASTER_PASSWORD_POLICY_INFO = PolicyInformation.MasterPassword(
     enforceOnLogin = true,
 )
 
-private val PASSWORD_GENERATOR_POLICY = createMockPolicy(
+private val PASSWORD_GENERATOR_POLICY = createMockPolicyView(
     organizationId = "organizationId",
     id = "password_generator_id",
-    type = PolicyTypeJson.PASSWORD_GENERATOR,
-    isEnabled = true,
-    data = JsonObject(
-        mapOf(
-            "defaultType" to JsonNull,
-            "minLength" to JsonPrimitive(10),
-            "useUpper" to JsonPrimitive(true),
-            "useNumbers" to JsonPrimitive(true),
-            "useSpecial" to JsonPrimitive(true),
-            "minNumbers" to JsonPrimitive(3),
-            "minSpecial" to JsonPrimitive(3),
-            "minNumberWords" to JsonPrimitive(5),
-            "capitalize" to JsonPrimitive(true),
-            "includeNumber" to JsonPrimitive(true),
-            "useLower" to JsonPrimitive(true),
-        ),
-    ),
+    type = PolicyType.PASSWORD_GENERATOR,
+    enabled = true,
+    data = """
+      {
+        "defaultType":null,
+        "minLength":10,
+        "useUpper":true,
+        "useNumbers":true,
+        "useSpecial":true,
+        "minNumbers":3,
+        "minSpecial":3,
+        "minNumberWords":5,
+        "capitalize":true,
+        "includeNumber":true,
+        "useLower":true
+      }
+    """,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -11,11 +11,10 @@ import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
 import com.bitwarden.data.manager.flightrecorder.FlightRecorderManager
 import com.bitwarden.network.model.KdfTypeJson
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.bitwarden.network.model.UserDecryptionOptionsJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
@@ -23,7 +22,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.UserFingerprintResult
 import com.x8bit.bitwarden.data.auth.repository.model.createMockVaultTimeoutPolicy
-import com.x8bit.bitwarden.data.auth.repository.model.createMockVaultTimeoutPolicyJsonObject
+import com.x8bit.bitwarden.data.auth.repository.model.createMockVaultTimeoutPolicyJsonString
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.FakeAccessibilityEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManagerImpl
@@ -36,6 +35,7 @@ import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -68,10 +68,10 @@ class SettingsRepositoryTest {
     private val fakeAuthDiskSource = FakeAuthDiskSource()
     private val fakeSettingsDiskSource = FakeSettingsDiskSource()
     private val vaultSdkSource: VaultSdkSource = mockk()
-    private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Policy>>()
+    private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<PolicyView>>()
     private val policyManager: PolicyManager = mockk {
         every {
-            getActivePoliciesFlow(type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT)
+            getActivePoliciesFlow(type = PolicyType.MAXIMUM_VAULT_TIMEOUT)
         } returns mutableActivePolicyFlow
     }
     private val flightRecorderManager = mockk<FlightRecorderManager>()
@@ -1345,7 +1345,7 @@ class SettingsRepositoryTest {
             fakeSettingsDiskSource.assertVaultTimeoutAction(userId = USER_ID, expected = null)
             fakeSettingsDiskSource.assertVaultTimeoutInMinutes(userId = USER_ID, expected = null)
 
-            mutableActivePolicyFlow.emit(listOf(createMockPolicy()))
+            mutableActivePolicyFlow.emit(listOf(createMockPolicyView()))
             fakeSettingsDiskSource.assertVaultTimeoutAction(userId = USER_ID, expected = null)
             fakeSettingsDiskSource.assertVaultTimeoutInMinutes(userId = USER_ID, expected = null)
         }
@@ -1356,9 +1356,9 @@ class SettingsRepositoryTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             fakeSettingsDiskSource.assertVaultTimeoutAction(userId = USER_ID, expected = null)
 
-            val lockPolicy = createMockPolicy(
-                type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-                data = createMockVaultTimeoutPolicyJsonObject(
+            val lockPolicy = createMockPolicyView(
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+                data = createMockVaultTimeoutPolicyJsonString(
                     vaultTimeout = createMockVaultTimeoutPolicy(
                         action = PolicyInformation.VaultTimeout.Action.LOCK,
                     ),
@@ -1370,9 +1370,9 @@ class SettingsRepositoryTest {
                 expected = VaultTimeoutAction.LOCK,
             )
 
-            val logoutPolicy = createMockPolicy(
-                type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-                data = createMockVaultTimeoutPolicyJsonObject(
+            val logoutPolicy = createMockPolicyView(
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+                data = createMockVaultTimeoutPolicyJsonString(
                     vaultTimeout = createMockVaultTimeoutPolicy(
                         action = PolicyInformation.VaultTimeout.Action.LOGOUT,
                     ),
@@ -1396,18 +1396,18 @@ class SettingsRepositoryTest {
                 vaultTimeoutInMinutes = 100,
             )
 
-            val nullTypeWithMinutesPolicy = createMockPolicy(
-                type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-                data = createMockVaultTimeoutPolicyJsonObject(
+            val nullTypeWithMinutesPolicy = createMockPolicyView(
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+                data = createMockVaultTimeoutPolicyJsonString(
                     vaultTimeout = createMockVaultTimeoutPolicy(minutes = 5),
-                ),
+                ).apply { println(this) },
             )
             mutableActivePolicyFlow.emit(listOf(nullTypeWithMinutesPolicy))
             fakeSettingsDiskSource.assertVaultTimeoutInMinutes(userId = USER_ID, expected = 5)
 
-            val customMinutesPolicy = createMockPolicy(
-                type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-                data = createMockVaultTimeoutPolicyJsonObject(
+            val customMinutesPolicy = createMockPolicyView(
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+                data = createMockVaultTimeoutPolicyJsonString(
                     vaultTimeout = createMockVaultTimeoutPolicy(
                         minutes = 10,
                         type = PolicyInformation.VaultTimeout.Type.CUSTOM,
@@ -1418,9 +1418,9 @@ class SettingsRepositoryTest {
             // No change since 5 is within the range
             fakeSettingsDiskSource.assertVaultTimeoutInMinutes(userId = USER_ID, expected = 5)
 
-            val onSystemLockPolicy = createMockPolicy(
-                type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-                data = createMockVaultTimeoutPolicyJsonObject(
+            val onSystemLockPolicy = createMockPolicyView(
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+                data = createMockVaultTimeoutPolicyJsonString(
                     vaultTimeout = createMockVaultTimeoutPolicy(
                         minutes = 10,
                         type = PolicyInformation.VaultTimeout.Type.ON_SYSTEM_LOCK,
@@ -1431,9 +1431,9 @@ class SettingsRepositoryTest {
             // Set to on app restart
             fakeSettingsDiskSource.assertVaultTimeoutInMinutes(userId = USER_ID, expected = -1)
 
-            val onAppRestartPolicy = createMockPolicy(
-                type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-                data = createMockVaultTimeoutPolicyJsonObject(
+            val onAppRestartPolicy = createMockPolicyView(
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+                data = createMockVaultTimeoutPolicyJsonString(
                     vaultTimeout = createMockVaultTimeoutPolicy(
                         minutes = 10,
                         type = PolicyInformation.VaultTimeout.Type.ON_APP_RESTART,
@@ -1444,9 +1444,9 @@ class SettingsRepositoryTest {
             // No change, ON_APP_RESTART is treated the same as ON_SYSTEM_RESTART
             fakeSettingsDiskSource.assertVaultTimeoutInMinutes(userId = USER_ID, expected = -1)
 
-            val immediatePolicy = createMockPolicy(
-                type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-                data = createMockVaultTimeoutPolicyJsonObject(
+            val immediatePolicy = createMockPolicyView(
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+                data = createMockVaultTimeoutPolicyJsonString(
                     vaultTimeout = createMockVaultTimeoutPolicy(
                         minutes = 10,
                         type = PolicyInformation.VaultTimeout.Type.IMMEDIATELY,
@@ -1457,9 +1457,9 @@ class SettingsRepositoryTest {
             // Set to Immediate
             fakeSettingsDiskSource.assertVaultTimeoutInMinutes(userId = USER_ID, expected = 0)
 
-            val neverPolicy = createMockPolicy(
-                type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-                data = createMockVaultTimeoutPolicyJsonObject(
+            val neverPolicy = createMockPolicyView(
+                type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+                data = createMockVaultTimeoutPolicyJsonString(
                     vaultTimeout = createMockVaultTimeoutPolicy(
                         minutes = 10,
                         type = PolicyInformation.VaultTimeout.Type.NEVER,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/PolicyViewUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/PolicyViewUtil.kt
@@ -1,0 +1,27 @@
+package com.x8bit.bitwarden.data.vault.datasource.sdk.model
+
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
+import java.time.Instant
+
+/**
+ * Create a mock [PolicyView] with a given [number].
+ */
+@Suppress("LongParameterList")
+fun createMockPolicyView(
+    number: Int = 1,
+    id: String = "mockId-$number",
+    organizationId: String = "mockOrganizationId-$number",
+    type: PolicyType = PolicyType.MASTER_PASSWORD,
+    data: String? = null,
+    enabled: Boolean = false,
+    revisionDate: Instant? = null,
+): PolicyView =
+    PolicyView(
+        id = id,
+        organizationId = organizationId,
+        type = type,
+        data = data,
+        enabled = enabled,
+        revisionDate = revisionDate,
+    )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerTest.kt
@@ -8,12 +8,12 @@ import com.bitwarden.cxf.model.CredentialExchangePayload
 import com.bitwarden.cxf.parser.CredentialExchangePayloadParser
 import com.bitwarden.network.model.ImportCiphersJsonRequest
 import com.bitwarden.network.model.ImportCiphersResponseJson
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.createMockPolicy
 import com.bitwarden.network.service.CiphersService
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.vault.Cipher
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkCipher
 import com.x8bit.bitwarden.data.vault.manager.model.ImportCxfPayloadResult
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
@@ -336,13 +336,12 @@ class CredentialExchangeImportManagerTest {
         fun `when user has restrict item types policy, card ciphers should be filtered out`() =
             runTest {
                 every {
-                    policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                    policyManager.getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
                 } returns listOf(
-                    createMockPolicy(
-                        id = "mockId-1",
+                    createMockPolicyView(
                         organizationId = "mockId-1",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = true,
                         data = null,
                     ),
                 )
@@ -385,7 +384,7 @@ class CredentialExchangeImportManagerTest {
         fun `when user has no restrict item types policy, card ciphers should not be filtered`() =
             runTest {
                 every {
-                    policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                    policyManager.getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
                 } returns emptyList()
 
                 val loginCipher = createMockSdkCipher(number = 1)
@@ -426,13 +425,12 @@ class CredentialExchangeImportManagerTest {
         fun `when user has restrict policy disabled, card ciphers should not be filtered`() =
             runTest {
                 every {
-                    policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                    policyManager.getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
                 } returns listOf(
-                    createMockPolicy(
-                        id = "mockId-1",
+                    createMockPolicyView(
                         organizationId = "mockId-1",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = false,
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = false,
                         data = null,
                     ),
                 )
@@ -475,13 +473,12 @@ class CredentialExchangeImportManagerTest {
         fun `when user has restrict policy and all ciphers are cards, should return NoItems`() =
             runTest {
                 every {
-                    policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                    policyManager.getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
                 } returns listOf(
-                    createMockPolicy(
-                        id = "mockId-1",
+                    createMockPolicyView(
                         organizationId = "mockId-1",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = true,
                         data = null,
                     ),
                 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultMigrationManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultMigrationManagerTest.kt
@@ -5,11 +5,10 @@ import com.bitwarden.collections.CollectionView
 import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
-import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.createMockCipher
 import com.bitwarden.network.model.createMockCipherMiniResponseJson
-import com.bitwarden.network.model.createMockPolicy
 import com.bitwarden.network.model.createMockSyncResponse
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.send.SendView
 import com.bitwarden.vault.CipherListView
 import com.bitwarden.vault.FolderView
@@ -30,6 +29,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCollectionView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockDecryptCipherListResult
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockEncryptionContext
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkCipher
 import com.x8bit.bitwarden.data.vault.manager.model.GetCipherResult
 import com.x8bit.bitwarden.data.vault.manager.model.VaultMigrationData
@@ -134,9 +134,9 @@ class VaultMigrationManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
         // Setup conditions for migration
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
         every {
             policyManager.getPersonalOwnershipPolicyOrganizationId()
@@ -181,7 +181,7 @@ class VaultMigrationManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns emptyList()
 
         val vaultMigrationManager = createVaultMigrationManager()
@@ -210,9 +210,9 @@ class VaultMigrationManagerTest {
         val userId = "mockId-1"
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
 
         every {
@@ -246,9 +246,9 @@ class VaultMigrationManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         fakeNetworkConnectionManager.fakeIsNetworkConnected = false
 
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
         every {
             policyManager.getPersonalOwnershipPolicyOrganizationId()
@@ -286,9 +286,9 @@ class VaultMigrationManagerTest {
         val userId = "mockId-1"
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
 
         val vaultMigrationManager = createVaultMigrationManager()
@@ -317,9 +317,9 @@ class VaultMigrationManagerTest {
         val userId = "mockId-1"
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
         every {
             policyManager.getPersonalOwnershipPolicyOrganizationId()
@@ -351,9 +351,9 @@ class VaultMigrationManagerTest {
         val userId = "mockId-1"
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
         every {
             policyManager.getPersonalOwnershipPolicyOrganizationId()
@@ -388,9 +388,9 @@ class VaultMigrationManagerTest {
         val userId = "mockId-1"
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
         // Return a different org ID that doesn't match the one in the sync response
         every {
@@ -430,9 +430,9 @@ class VaultMigrationManagerTest {
         val userId = "mockId-1"
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
         every {
             policyManager.getPersonalOwnershipPolicyOrganizationId()
@@ -469,9 +469,9 @@ class VaultMigrationManagerTest {
         // Set sync time as null (never synced)
         mutableLastSyncTimeFlow.value = null
 
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
         every {
             policyManager.getPersonalOwnershipPolicyOrganizationId()
@@ -513,9 +513,9 @@ class VaultMigrationManagerTest {
         // where lastSyncTime was cleared without clearing cipher data
         mutableLastSyncTimeFlow.value = null
 
-        val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+        val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockPolicy)
         every {
             policyManager.getPersonalOwnershipPolicyOrganizationId()
@@ -566,9 +566,9 @@ class VaultMigrationManagerTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             fakeNetworkConnectionManager.fakeIsNetworkConnected = false
 
-            val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             every {
-                policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+                policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             } returns listOf(mockPolicy)
             every {
                 policyManager.getPersonalOwnershipPolicyOrganizationId()
@@ -619,9 +619,9 @@ class VaultMigrationManagerTest {
             val userId = "mockId-1"
             fakeAuthDiskSource.userState = MOCK_USER_STATE
 
-            val mockPolicy = createMockPolicy(number = 1, type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            val mockPolicy = createMockPolicyView(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             every {
-                policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+                policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
             } returns listOf(mockPolicy)
             every {
                 policyManager.getPersonalOwnershipPolicyOrganizationId()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkPolicyExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkPolicyExtensionsTest.kt
@@ -1,0 +1,85 @@
+package com.x8bit.bitwarden.data.vault.repository.util
+
+import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class VaultSdkPolicyExtensionsTest {
+
+    @Test
+    fun `toSdkPolicyViews should return empty list when given empty list`() {
+        assertEquals(
+            emptyList<PolicyView>(),
+            emptyList<SyncResponseJson.Policy>().toSdkPolicyViews(),
+        )
+    }
+
+    @Test
+    fun `toSdkPolicyViews should convert all policies in a list`() {
+        assertEquals(
+            listOf(
+                createMockPolicyView(number = 1),
+                createMockPolicyView(number = 2),
+            ),
+            listOf(
+                createMockPolicy(number = 1),
+                createMockPolicy(number = 2),
+            )
+                .toSdkPolicyViews(),
+        )
+    }
+
+    @Test
+    fun `toSdkPolicyViews should serialize JsonObject data to a JSON string`() {
+        assertEquals(
+            listOf(createMockPolicyView(data = """{"key":"value"}""")),
+            listOf(
+                createMockPolicy(data = buildJsonObject { put("key", JsonPrimitive("value")) }),
+            )
+                .toSdkPolicyViews(),
+        )
+    }
+
+    @Test
+    fun `toSdkPolicyViews should map all PolicyTypeJson values to their SDK equivalents`() {
+        POLICY_TYPE_MAP.forEach { (inputType, expectedType) ->
+            assertEquals(
+                listOf(createMockPolicyView(type = expectedType)),
+                listOf(createMockPolicy(type = inputType)).toSdkPolicyViews(),
+            )
+        }
+    }
+}
+
+private val POLICY_TYPE_MAP: Map<PolicyTypeJson, PolicyType> = mapOf(
+    PolicyTypeJson.TWO_FACTOR_AUTHENTICATION to PolicyType.TWO_FACTOR_AUTHENTICATION,
+    PolicyTypeJson.MASTER_PASSWORD to PolicyType.MASTER_PASSWORD,
+    PolicyTypeJson.PASSWORD_GENERATOR to PolicyType.PASSWORD_GENERATOR,
+    PolicyTypeJson.ONLY_ORG to PolicyType.SINGLE_ORG,
+    PolicyTypeJson.REQUIRE_SSO to PolicyType.REQUIRE_SSO,
+    PolicyTypeJson.PERSONAL_OWNERSHIP to PolicyType.ORGANIZATION_DATA_OWNERSHIP,
+    PolicyTypeJson.DISABLE_SEND to PolicyType.DISABLE_SEND,
+    PolicyTypeJson.SEND_OPTIONS to PolicyType.SEND_OPTIONS,
+    PolicyTypeJson.RESET_PASSWORD to PolicyType.RESET_PASSWORD,
+    PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT to PolicyType.MAXIMUM_VAULT_TIMEOUT,
+    PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT to PolicyType.DISABLE_PERSONAL_VAULT_EXPORT,
+    PolicyTypeJson.ACTIVATE_AUTOFILL to PolicyType.ACTIVATE_AUTOFILL,
+    PolicyTypeJson.AUTOMATIC_APP_LOG_IN to PolicyType.AUTOMATIC_APP_LOG_IN,
+    PolicyTypeJson.FREE_FAMILIES_SPONSORSHIP_POLICY to PolicyType.FREE_FAMILIES_SPONSORSHIP,
+    PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN to PolicyType.REMOVE_UNLOCK_WITH_PIN,
+    PolicyTypeJson.RESTRICT_ITEM_TYPES to PolicyType.RESTRICTED_ITEM_TYPES,
+    PolicyTypeJson.URI_MATCH_DEFAULTS to PolicyType.URI_MATCH_DEFAULTS,
+    PolicyTypeJson.AUTOTYPE_DEFAULT_SETTING to PolicyType.AUTOTYPE_DEFAULT_SETTING,
+    PolicyTypeJson.AUTOMATIC_USER_CONFIRMATION to PolicyType.AUTOMATIC_USER_CONFIRMATION,
+    PolicyTypeJson.BLOCK_CLAIMED_DOMAIN_ACCOUNT_CREATION to
+        PolicyType.BLOCK_CLAIMED_DOMAIN_ACCOUNT_CREATION,
+    PolicyTypeJson.ORGANIZATION_USER_NOTIFICATION to PolicyType.ORGANIZATION_USER_NOTIFICATION,
+    PolicyTypeJson.SEND_CONTROLS to PolicyType.SEND_CONTROLS,
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorViewModelTest.kt
@@ -2,7 +2,7 @@ package com.x8bit.bitwarden.ui.auth.feature.masterpasswordgenerator
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test
 class MasterPasswordGeneratorViewModelTest : BaseViewModelTest() {
     private val fakeGeneratorRepository = FakeGeneratorRepository()
     private val mockPolicyManager = mockk<PolicyManager>(relaxed = true) {
-        every { getActivePolicies(type = PolicyTypeJson.MASTER_PASSWORD) } returns emptyList()
+        every { getActivePolicies(type = PolicyType.MASTER_PASSWORD) } returns emptyList()
     }
 
     @BeforeEach
@@ -64,7 +64,7 @@ class MasterPasswordGeneratorViewModelTest : BaseViewModelTest() {
     fun `Verify passphrase request is created and attempts to check for policy constraints`() {
         createViewModel()
 
-        verify { mockPolicyManager.getActivePolicies(type = PolicyTypeJson.MASTER_PASSWORD) }
+        verify { mockPolicyManager.getActivePolicies(type = PolicyType.MASTER_PASSWORD) }
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -8,9 +8,8 @@ import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.send.SendType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
@@ -44,15 +43,16 @@ import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockBankAccountView
-import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockDriversLicenseView
-import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPassportView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCardView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCollectionView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockDecryptCipherListResult
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockDriversLicenseView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockFolderView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockLoginView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPassportView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFido2CredentialList
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSendView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockUriView
@@ -116,14 +116,14 @@ class SearchViewModelTest : BaseViewModelTest() {
         every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
     }
 
-    private val mutableActivePoliciesFlow: MutableStateFlow<List<SyncResponseJson.Policy>> =
+    private val mutableActivePoliciesFlow: MutableStateFlow<List<PolicyView>> =
         MutableStateFlow(emptyList())
     private val policyManager: PolicyManager = mockk<PolicyManager> {
         every {
-            getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns emptyList()
         every {
-            getActivePoliciesFlow(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            getActivePoliciesFlow(type = PolicyType.RESTRICTED_ITEM_TYPES)
         } returns mutableActivePoliciesFlow
     }
     private val mutableVaultDataStateFlow =
@@ -198,20 +198,19 @@ class SearchViewModelTest : BaseViewModelTest() {
     @Test
     fun `initial state should be correct when user has PERSONAL_OWNERSHIP policy`() {
         every {
-            policyManager.getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(
-            createMockPolicy(
+            createMockPolicyView(
                 organizationId = "Test Org",
                 id = "testId",
-                type = PolicyTypeJson.PERSONAL_OWNERSHIP,
-                isEnabled = true,
-                data = null,
+                type = PolicyType.ORGANIZATION_DATA_OWNERSHIP,
+                enabled = true,
             ),
         )
         val viewModel = createViewModel()
         assertEquals(DEFAULT_STATE, viewModel.stateFlow.value)
         verify {
-            policyManager.getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         }
     }
 
@@ -2215,12 +2214,11 @@ class SearchViewModelTest : BaseViewModelTest() {
             )
             mutableActivePoliciesFlow.emit(
                 listOf(
-                    createMockPolicy(
+                    createMockPolicyView(
                         organizationId = "Test Organization",
                         id = "testId",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
-                        data = null,
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = true,
                     ),
                 ),
             )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -8,9 +8,8 @@ import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.util.isBuildVersionAtLeast
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.network.model.OrganizationType
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson.Policy
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
@@ -32,6 +31,7 @@ import com.x8bit.bitwarden.data.platform.repository.model.BiometricsKeyResult
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.components.toggle.UnlockWithPinState
 import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.AccountSecurityAction.AuthenticatorSyncToggle
@@ -48,8 +48,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -95,14 +93,14 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         every { firstTimeStateFlow } returns mutableFirstTimeStateFlow
         every { storeShowUnlockSettingBadge(any()) } just runs
     }
-    private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<Policy>>()
-    private val mutableRemovePinPolicyFlow = bufferedMutableSharedFlow<List<Policy>>()
+    private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<PolicyView>>()
+    private val mutableRemovePinPolicyFlow = bufferedMutableSharedFlow<List<PolicyView>>()
     private val policyManager: PolicyManager = mockk {
         every {
-            getActivePoliciesFlow(type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT)
+            getActivePoliciesFlow(type = PolicyType.MAXIMUM_VAULT_TIMEOUT)
         } returns mutableActivePolicyFlow
         every {
-            getActivePoliciesFlow(type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN)
+            getActivePoliciesFlow(type = PolicyType.REMOVE_UNLOCK_WITH_PIN)
         } returns mutableRemovePinPolicyFlow
     }
 
@@ -144,10 +142,10 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         )
         mutableActivePolicyFlow.emit(
             listOf(
-                createMockPolicy(
-                    isEnabled = true,
-                    type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,
-                    data = Json.encodeToJsonElement(policyInformation).jsonObject,
+                createMockPolicyView(
+                    enabled = true,
+                    type = PolicyType.MAXIMUM_VAULT_TIMEOUT,
+                    data = Json.encodeToString(policyInformation),
                 ),
             ),
         )
@@ -172,9 +170,9 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
         mutableRemovePinPolicyFlow.emit(
             listOf(
-                createMockPolicy(
-                    isEnabled = true,
-                    type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN,
+                createMockPolicyView(
+                    enabled = true,
+                    type = PolicyType.REMOVE_UNLOCK_WITH_PIN,
                     organizationId = "organizationUser",
                 ),
             ),
@@ -196,10 +194,10 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
         mutableRemovePinPolicyFlow.emit(
             listOf(
-                createMockPolicy(
+                createMockPolicyView(
                     organizationId = "organizationAdmin",
-                    isEnabled = true,
-                    type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN,
+                    enabled = true,
+                    type = PolicyType.REMOVE_UNLOCK_WITH_PIN,
                 ),
             ),
         )
@@ -220,10 +218,10 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
         mutableRemovePinPolicyFlow.emit(
             listOf(
-                createMockPolicy(
+                createMockPolicyView(
                     organizationId = "organizationOwner",
-                    isEnabled = true,
-                    type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN,
+                    enabled = true,
+                    type = PolicyType.REMOVE_UNLOCK_WITH_PIN,
                 ),
             ),
         )
@@ -244,10 +242,10 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
         mutableRemovePinPolicyFlow.emit(
             listOf(
-                createMockPolicy(
+                createMockPolicyView(
                     organizationId = "organizationCustom",
-                    isEnabled = true,
-                    type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN,
+                    enabled = true,
+                    type = PolicyType.REMOVE_UNLOCK_WITH_PIN,
                 ),
             ),
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
@@ -6,8 +6,7 @@ import app.cash.turbine.test
 import com.bitwarden.data.manager.file.FileManager
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.exporters.ExportFormat
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
@@ -24,6 +23,7 @@ import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.PasswordStrengthState
@@ -52,10 +52,10 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
 
     private val policyManager: PolicyManager = mockk {
         every {
-            getActivePolicies(type = PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT)
+            getActivePolicies(type = PolicyType.DISABLE_PERSONAL_VAULT_EXPORT)
         } returns emptyList()
         every {
-            getActivePolicies(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            getActivePolicies(type = PolicyType.RESTRICTED_ITEM_TYPES)
         } returns emptyList()
     }
 
@@ -86,8 +86,8 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
     @Test
     fun `initial state should be correct`() = runTest {
         every {
-            policyManager.getActivePolicies(type = PolicyTypeJson.DISABLE_PERSONAL_VAULT_EXPORT)
-        } returns listOf(createMockPolicy())
+            policyManager.getActivePolicies(type = PolicyType.DISABLE_PERSONAL_VAULT_EXPORT)
+        } returns listOf(createMockPolicyView())
 
         val viewModel = createViewModel()
         viewModel.stateFlow.test {
@@ -142,8 +142,8 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
             )
         } returns ValidatePasswordResult.Success(isValid = true)
         every {
-            policyManager.getActivePolicies(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
-        } returns listOf(createMockPolicy(isEnabled = true))
+            policyManager.getActivePolicies(type = PolicyType.RESTRICTED_ITEM_TYPES)
+        } returns listOf(createMockPolicyView(enabled = true))
 
         val viewModel = createViewModel()
         viewModel.trySendAction(ExportVaultAction.PasswordInputChanged(password))

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModelTest.kt
@@ -3,8 +3,8 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.vault
 import app.cash.turbine.test
 import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
@@ -36,7 +36,7 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
         every { firstTimeStateFlow } returns mutableFirstTimeStateFlow
         every { storeShowImportLoginsSettingsBadge(any()) } just runs
     }
-    private val mutablePoliciesFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Policy>>()
+    private val mutablePoliciesFlow = bufferedMutableSharedFlow<List<PolicyView>>()
     private val policyManager = mockk<PolicyManager> {
         every { getActivePolicies(any()) } returns emptyList()
         every { getActivePoliciesFlow(any()) } returns mutablePoliciesFlow
@@ -73,7 +73,7 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
     @Test
     fun `ImportItemsClick should emit NavigateToImportVault when policy is not empty`() = runTest {
         every {
-            policyManager.getActivePolicies(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(mockk())
 
         val viewModel = createViewModel()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
@@ -1,9 +1,8 @@
 package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar
 
 import app.cash.turbine.test
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -12,6 +11,7 @@ import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -36,14 +36,13 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
     private val firstTimeActionManager: FirstTimeActionManager = mockk {
         every { allSettingsBadgeCountFlow } returns mutableSettingsBadgeCountFlow
     }
-    private val mutableDisableSendsPolicyFlow =
-        MutableStateFlow<List<SyncResponseJson.Policy>>(emptyList())
+    private val mutableDisableSendsPolicyFlow = MutableStateFlow<List<PolicyView>>(emptyList())
     private val policyManager: PolicyManager = mockk {
         every {
-            getActivePoliciesFlow(PolicyTypeJson.DISABLE_SEND)
+            getActivePoliciesFlow(PolicyType.DISABLE_SEND)
         } returns mutableDisableSendsPolicyFlow
         every {
-            getActivePolicies(PolicyTypeJson.DISABLE_SEND)
+            getActivePolicies(PolicyType.DISABLE_SEND)
         } answers { mutableDisableSendsPolicyFlow.value }
     }
 
@@ -336,7 +335,7 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
                 assertEquals(DEFAULT_STATE.copy(areSendsDisabled = false), awaitItem())
 
                 mutableDisableSendsPolicyFlow.emit(
-                    listOf(createMockPolicy(type = PolicyTypeJson.DISABLE_SEND)),
+                    listOf(createMockPolicyView(type = PolicyType.DISABLE_SEND)),
                 )
                 assertEquals(DEFAULT_STATE.copy(areSendsDisabled = true), awaitItem())
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -7,9 +7,8 @@ import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.generators.PassphraseGeneratorRequest
 import com.bitwarden.generators.PasswordGeneratorRequest
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
@@ -32,6 +31,7 @@ import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratorResult
 import com.x8bit.bitwarden.data.tools.generator.repository.model.PasscodeGenerationOptions
 import com.x8bit.bitwarden.data.tools.generator.repository.model.UsernameGenerationOptions
 import com.x8bit.bitwarden.data.tools.generator.repository.util.FakeGeneratorRepository
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Username.UsernameType.ForwardedEmailAlias.ServiceType
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Username.UsernameType.ForwardedEmailAlias.ServiceTypeOption
 import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
@@ -45,9 +45,6 @@ import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -109,10 +106,10 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         )
     }
 
-    private val mutablePolicyFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Policy>>()
+    private val mutablePolicyFlow = bufferedMutableSharedFlow<List<PolicyView>>()
     private val policyManager: PolicyManager = mockk {
-        every { getActivePolicies(PolicyTypeJson.PASSWORD_GENERATOR) } returns emptyList()
-        every { getActivePoliciesFlow(PolicyTypeJson.PASSWORD_GENERATOR) } returns mutablePolicyFlow
+        every { getActivePolicies(PolicyType.PASSWORD_GENERATOR) } returns emptyList()
+        every { getActivePoliciesFlow(PolicyType.PASSWORD_GENERATOR) } returns mutablePolicyFlow
     }
 
     private val reviewPromptManager: ReviewPromptManager = mockk {
@@ -217,26 +214,28 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `activePolicyFlow changes should update state`() = runTest {
-        val payload = mapOf(
-            "overridePasswordType" to JsonNull,
-            "minLength" to JsonPrimitive(10),
-            "useUpper" to JsonPrimitive(true),
-            "useNumbers" to JsonPrimitive(true),
-            "useSpecial" to JsonPrimitive(true),
-            "minNumbers" to JsonPrimitive(3),
-            "minSpecial" to JsonPrimitive(3),
-            "minNumberWords" to JsonPrimitive(5),
-            "capitalize" to JsonPrimitive(true),
-            "includeNumber" to JsonPrimitive(true),
-            "useLower" to JsonPrimitive(true),
-        )
+        val payload = """
+            {
+              "overridePasswordType":null,
+              "minLength":10,
+              "useUpper":true,
+              "useNumbers":true,
+              "useSpecial":true,
+              "minNumbers":3,
+              "minSpecial":3,
+              "minNumberWords":5,
+              "capitalize":true,
+              "includeNumber":true,
+              "useLower":true
+            }
+        """
         val policies = listOf(
-            createMockPolicy(
+            createMockPolicyView(
                 organizationId = "organizationId",
                 id = "id",
-                type = PolicyTypeJson.PASSWORD_GENERATOR,
-                isEnabled = true,
-                data = JsonObject(payload),
+                type = PolicyType.PASSWORD_GENERATOR,
+                enabled = true,
+                data = payload,
             ),
         )
         val viewModel = createViewModel(state = initialPasscodeState)
@@ -244,7 +243,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         viewModel.stateFlow.test {
             assertEquals(initialPasscodeState, awaitItem())
             every {
-                policyManager.getActivePolicies(type = PolicyTypeJson.PASSWORD_GENERATOR)
+                policyManager.getActivePolicies(type = PolicyType.PASSWORD_GENERATOR)
             } returns policies
             mutablePolicyFlow.tryEmit(value = policies)
             assertEquals(
@@ -276,7 +275,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 awaitItem(),
             )
             every {
-                policyManager.getActivePolicies(type = PolicyTypeJson.PASSWORD_GENERATOR)
+                policyManager.getActivePolicies(type = PolicyType.PASSWORD_GENERATOR)
             } returns emptyList()
             mutablePolicyFlow.tryEmit(value = emptyList())
             assertEquals(
@@ -587,25 +586,24 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `Policy should overwrite password options if stricter`() {
-        val policy = createMockPolicy(
-            number = 1,
-            type = PolicyTypeJson.PASSWORD_GENERATOR,
-            isEnabled = true,
-            data = JsonObject(
-                mapOf(
-                    "overridePasswordType" to JsonNull,
-                    "minLength" to JsonPrimitive(10),
-                    "useUpper" to JsonPrimitive(true),
-                    "useNumbers" to JsonPrimitive(true),
-                    "useSpecial" to JsonPrimitive(true),
-                    "minNumbers" to JsonPrimitive(3),
-                    "minSpecial" to JsonPrimitive(3),
-                    "minNumberWords" to JsonPrimitive(5),
-                    "capitalize" to JsonPrimitive(true),
-                    "includeNumber" to JsonPrimitive(true),
-                    "useLower" to JsonPrimitive(true),
-                ),
-            ),
+        val policy = createMockPolicyView(
+            type = PolicyType.PASSWORD_GENERATOR,
+            enabled = true,
+            data = """
+              {
+                "overridePasswordType":null,
+                "minLength":10,
+                "useUpper":true,
+                "useNumbers":true,
+                "useSpecial":true,
+                "minNumbers":3,
+                "minSpecial":3,
+                "minNumberWords":5,
+                "capitalize":true,
+                "includeNumber":true,
+                "useLower":true
+              }
+            """,
         )
         every {
             policyManager.getActivePolicies(any())
@@ -638,25 +636,24 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `Policy should overwrite passphrase options if stricter`() {
-        val policy = createMockPolicy(
-            number = 1,
-            type = PolicyTypeJson.PASSWORD_GENERATOR,
-            isEnabled = true,
-            data = JsonObject(
-                mapOf(
-                    "overridePasswordType" to JsonNull,
-                    "minLength" to JsonPrimitive(10),
-                    "useUpper" to JsonPrimitive(true),
-                    "useNumbers" to JsonPrimitive(true),
-                    "useSpecial" to JsonPrimitive(true),
-                    "minNumbers" to JsonPrimitive(3),
-                    "minSpecial" to JsonPrimitive(3),
-                    "minNumberWords" to JsonPrimitive(5),
-                    "capitalize" to JsonPrimitive(true),
-                    "includeNumber" to JsonPrimitive(true),
-                    "useLower" to JsonPrimitive(true),
-                ),
-            ),
+        val policy = createMockPolicyView(
+            type = PolicyType.PASSWORD_GENERATOR,
+            enabled = true,
+            data = """
+              {
+                "overridePasswordType":null,
+                "minLength":10,
+                "useUpper":true,
+                "useNumbers":true,
+                "useSpecial":true,
+                "minNumbers":3,
+                "minSpecial":3,
+                "minNumberWords":5,
+                "capitalize":true,
+                "includeNumber":true,
+                "useLower":true
+              }
+            """,
         )
         every {
             policyManager.getActivePolicies(any())
@@ -688,15 +685,14 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `Policy should overwrite passwordType if has overridePasswordType`() {
-        val policy = createMockPolicy(
-            number = 1,
-            type = PolicyTypeJson.PASSWORD_GENERATOR,
-            isEnabled = true,
-            data = JsonObject(
-                mapOf(
-                    "overridePasswordType" to JsonPrimitive("passphrase"),
-                ),
-            ),
+        val policy = createMockPolicyView(
+            type = PolicyType.PASSWORD_GENERATOR,
+            enabled = true,
+            data = """
+              {
+                "overridePasswordType":"passphrase"
+              }
+            """,
         )
         every {
             policyManager.getActivePolicies(any())
@@ -717,25 +713,25 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     @Test
     fun `Policy should should prioritize password if multiple have OverridePasswordType`() {
         val policies = listOf(
-            createMockPolicy(
+            createMockPolicyView(
                 number = 1,
-                type = PolicyTypeJson.PASSWORD_GENERATOR,
-                isEnabled = true,
-                data = JsonObject(
-                    mapOf(
-                        "overridePasswordType" to JsonPrimitive("passphrase"),
-                    ),
-                ),
+                type = PolicyType.PASSWORD_GENERATOR,
+                enabled = true,
+                data = """
+                  {
+                    "overridePasswordType":"passphrase"
+                  }
+                """,
             ),
-            createMockPolicy(
+            createMockPolicyView(
                 number = 1,
-                type = PolicyTypeJson.PASSWORD_GENERATOR,
-                isEnabled = true,
-                data = JsonObject(
-                    mapOf(
-                        "overridePasswordType" to JsonPrimitive("password"),
-                    ),
-                ),
+                type = PolicyType.PASSWORD_GENERATOR,
+                enabled = true,
+                data = """
+                  {
+                    "overridePasswordType":"password"
+                  }
+                """,
             ),
         )
         every {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
@@ -6,7 +6,7 @@ import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.data.repository.util.baseWebSendUrl
-import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
@@ -72,8 +72,8 @@ class SendViewModelTest : BaseViewModelTest() {
         every { sendDataStateFlow } returns mutableSendDataFlow
     }
     private val policyManager: PolicyManager = mockk {
-        every { getActivePolicies(type = PolicyTypeJson.DISABLE_SEND) } returns emptyList()
-        every { getActivePoliciesFlow(type = PolicyTypeJson.DISABLE_SEND) } returns emptyFlow()
+        every { getActivePolicies(type = PolicyType.DISABLE_SEND) } returns emptyList()
+        every { getActivePoliciesFlow(type = PolicyType.DISABLE_SEND) } returns emptyFlow()
     }
 
     private val networkConnectionManager: NetworkConnectionManager = mockk {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -6,8 +6,7 @@ import app.cash.turbine.test
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.send.SendView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
@@ -29,6 +28,7 @@ import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManage
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.tools.generator.repository.GeneratorRepository
 import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratorResult
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSendView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.CreateSendResult
@@ -57,8 +57,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -98,8 +96,8 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
         every { getSendStateFlow(any()) } returns mutableSendDataStateFlow
     }
     private val policyManager: PolicyManager = mockk {
-        every { getActivePolicies(type = PolicyTypeJson.DISABLE_SEND) } returns emptyList()
-        every { getActivePolicies(type = PolicyTypeJson.SEND_OPTIONS) } returns emptyList()
+        every { getActivePolicies(type = PolicyType.DISABLE_SEND) } returns emptyList()
+        every { getActivePolicies(type = PolicyType.SEND_OPTIONS) } returns emptyList()
     }
     private val networkConnectionManager = mockk<NetworkConnectionManager> {
         every { isNetworkConnected } returns true
@@ -143,15 +141,15 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
     @Test
     fun `initial state should be correct when a sendOption includes shouldDisableHideEmail`() {
         every {
-            policyManager.getActivePolicies(type = PolicyTypeJson.SEND_OPTIONS)
+            policyManager.getActivePolicies(type = PolicyType.SEND_OPTIONS)
         } returns listOf(
-            createMockPolicy(
+            createMockPolicyView(
                 id = "123",
-                type = PolicyTypeJson.SEND_OPTIONS,
-                isEnabled = true,
-                data = Json.encodeToJsonElement(
+                type = PolicyType.SEND_OPTIONS,
+                enabled = true,
+                data = Json.encodeToString(
                     PolicyInformation.SendOptions(shouldDisableHideEmail = true),
-                ).jsonObject,
+                ),
                 organizationId = "id2",
             ),
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -14,8 +14,7 @@ import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.send.SendView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
@@ -71,6 +70,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createManageCollectio
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockDecryptCipherListResult
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkCipherPermissions
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFido2CredentialList
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createViewCollectionView
@@ -176,7 +176,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     }
     private val policyManager: PolicyManager = mockk {
         every {
-            getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns emptyList()
     }
     private val bitwardenCredentialManager = mockk<BitwardenCredentialManager> {
@@ -301,7 +301,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
         }
         verify {
-            policyManager.getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         }
     }
 
@@ -330,14 +330,13 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `initial add state should be correct with individual vault disabled`() = runTest {
         every {
-            policyManager.getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(
-            createMockPolicy(
+            createMockPolicyView(
                 organizationId = "Test Org",
                 id = "testId",
-                type = PolicyTypeJson.PERSONAL_OWNERSHIP,
-                isEnabled = true,
-                data = null,
+                type = PolicyType.ORGANIZATION_DATA_OWNERSHIP,
+                enabled = true,
             ),
         )
         val vaultAddEditType = VaultAddEditType.AddItem
@@ -382,7 +381,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             vaultRepository.vaultDataStateFlow
         }
         verify {
-            policyManager.getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         }
     }
 
@@ -5319,14 +5318,13 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         fun `CollectionSelect should update selectedOwnerId when isIndividualVaultDisabled is true`() =
             runTest {
                 every {
-                    policyManager.getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+                    policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
                 } returns listOf(
-                    createMockPolicy(
+                    createMockPolicyView(
                         organizationId = "Test Org",
                         id = "testId",
-                        type = PolicyTypeJson.PERSONAL_OWNERSHIP,
-                        isEnabled = true,
-                        data = null,
+                        type = PolicyType.ORGANIZATION_DATA_OWNERSHIP,
+                        enabled = true,
                     ),
                 )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/SelectAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/SelectAccountViewModelTest.kt
@@ -4,9 +4,8 @@ import app.cash.turbine.test
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.cxf.model.ImportCredentialsRequestData
 import com.bitwarden.data.repository.model.Environment
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
@@ -18,6 +17,7 @@ import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.model.AccountSelectionListItem
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount.SelectAccountAction
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount.SelectAccountEvent
@@ -36,20 +36,18 @@ import org.junit.jupiter.api.Test
 class SelectAccountViewModelTest : BaseViewModelTest() {
 
     private val mutableUserUserStateFlow = MutableStateFlow(DEFAULT_USER_STATE)
-    private val mutableRestrictItemTypesFlow =
-        bufferedMutableSharedFlow<List<SyncResponseJson.Policy>>()
-    private val mutablePersonalOwnershipPolicyFlow =
-        bufferedMutableSharedFlow<List<SyncResponseJson.Policy>>()
+    private val mutableRestrictItemTypesFlow = bufferedMutableSharedFlow<List<PolicyView>>()
+    private val mutablePersonalOwnershipPolicyFlow = bufferedMutableSharedFlow<List<PolicyView>>()
 
     private val authRepository = mockk<AuthRepository> {
         every { userStateFlow } returns mutableUserUserStateFlow
     }
     private val policyManager = mockk<PolicyManager> {
         every {
-            getActivePoliciesFlow(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            getActivePoliciesFlow(PolicyType.RESTRICTED_ITEM_TYPES)
         } returns mutableRestrictItemTypesFlow
         every {
-            getActivePoliciesFlow(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            getActivePoliciesFlow(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns mutablePersonalOwnershipPolicyFlow
     }
     private val specialCircumstanceManager = mockk<SpecialCircumstanceManager> {
@@ -84,8 +82,8 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
 
                 verify(exactly = 0) {
                     authRepository.userStateFlow
-                    policyManager.getActivePoliciesFlow(PolicyTypeJson.RESTRICT_ITEM_TYPES)
-                    policyManager.getActivePoliciesFlow(PolicyTypeJson.PERSONAL_OWNERSHIP)
+                    policyManager.getActivePoliciesFlow(PolicyType.RESTRICTED_ITEM_TYPES)
+                    policyManager.getActivePoliciesFlow(PolicyType.ORGANIZATION_DATA_OWNERSHIP)
                 }
             }
         }
@@ -125,7 +123,7 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
 
             verify(Ordering.ORDERED) {
                 authRepository.userStateFlow
-                policyManager.getActivePoliciesFlow(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                policyManager.getActivePoliciesFlow(PolicyType.RESTRICTED_ITEM_TYPES)
             }
         }
 
@@ -217,10 +215,9 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
                 SelectAccountAction.Internal.SelectionDataReceive(
                     userState = DEFAULT_USER_STATE.copy(accounts = listOf(accountInOrg)),
                     itemRestrictedOrgs = listOf(
-                        createMockPolicy(
-                            number = 1,
+                        createMockPolicyView(
                             id = organizationId,
-                            isEnabled = true,
+                            enabled = true,
                         ),
                     ),
                 ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModelTest.kt
@@ -8,8 +8,7 @@ import com.bitwarden.cxf.manager.model.ExportCredentialsResult
 import com.bitwarden.cxf.model.ImportCredentialsRequestData
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.network.model.OrganizationType
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
@@ -26,6 +25,7 @@ import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCardListView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockDecryptCipherListResult
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import io.mockk.awaits
 import io.mockk.coEvery
@@ -59,7 +59,7 @@ class ReviewExportViewModelTest : BaseViewModelTest() {
         )
     }
     private val policyManager = mockk<PolicyManager> {
-        every { getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES) } returns emptyList()
+        every { getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES) } returns emptyList()
     }
 
     @Nested
@@ -185,12 +185,11 @@ class ReviewExportViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 every {
-                    policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                    policyManager.getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
                 } returns listOf(
-                    createMockPolicy(
-                        number = 1,
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
+                    createMockPolicyView(
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = true,
                     ),
                 )
                 coEvery { vaultRepository.exportVaultDataToCxf(any()) } just awaits

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModelTest.kt
@@ -4,8 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.network.model.OrganizationType
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
@@ -19,6 +18,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.VerifyOtpResult
 import com.x8bit.bitwarden.data.auth.repository.model.createMockOrganization
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.model.AccountSelectionListItem
@@ -54,11 +54,10 @@ class VerifyPasswordViewModelTest : BaseViewModelTest() {
         } returns VaultUnlockResult.Success
     }
     private val policyManager = mockk<PolicyManager> {
-        every { getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES) } returns listOf(
-            createMockPolicy(
-                number = 1,
+        every { getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES) } returns listOf(
+            createMockPolicyView(
                 organizationId = DEFAULT_ORGANIZATION_ID,
-                isEnabled = false,
+                enabled = false,
             ),
         )
     }
@@ -137,12 +136,11 @@ class VerifyPasswordViewModelTest : BaseViewModelTest() {
         @Test
         fun `initial state should be correct when account has item restrictions`() = runTest {
             every {
-                policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                policyManager.getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
             } returns listOf(
-                createMockPolicy(
-                    number = 1,
+                createMockPolicyView(
                     organizationId = DEFAULT_ORGANIZATION_ID,
-                    isEnabled = true,
+                    enabled = true,
                 ),
             )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/importitems/ImportItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/importitems/ImportItemsViewModelTest.kt
@@ -5,8 +5,7 @@ import androidx.credentials.providerevents.transfer.CredentialTypes
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.cxf.importer.model.ImportCredentialsSelectionResult
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.resource.BitwardenPlurals
@@ -14,6 +13,7 @@ import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asPluralsText
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.ImportCredentialsResult
@@ -61,7 +61,7 @@ class ImportItemsViewModelTest : BaseViewModelTest() {
     fun `ImportFromAnotherAppClick sends ShowRegisteredImportSources event`() {
         runTest {
             every {
-                policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                policyManager.getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
             } returns emptyList()
 
             val viewModel = createViewModel()
@@ -98,13 +98,13 @@ class ImportItemsViewModelTest : BaseViewModelTest() {
         runTest {
             // Policy is active and enabled
             every {
-                policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                policyManager.getActivePolicies(PolicyType.RESTRICTED_ITEM_TYPES)
             } returns listOf(
-                createMockPolicy(
+                createMockPolicyView(
                     organizationId = "org-id",
                     id = "policy-id",
-                    type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                    isEnabled = true,
+                    type = PolicyType.RESTRICTED_ITEM_TYPES,
+                    enabled = true,
                     data = null,
                 ),
             )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -25,9 +25,8 @@ import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.data.repository.util.baseWebSendUrl
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.send.SendType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.account.model.AccountSummary
@@ -96,6 +95,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockDriversLice
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockFolderView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockLoginListView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPassportView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFido2CredentialList
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSendView
 import com.x8bit.bitwarden.data.vault.manager.model.GetCipherResult
@@ -218,13 +218,13 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             authRepository = mockAuthRepository,
             dispatcherManager = FakeDispatcherManager(),
         )
-    private val mutableActivePoliciesFlow: MutableStateFlow<List<SyncResponseJson.Policy>> =
+    private val mutableActivePoliciesFlow: MutableStateFlow<List<PolicyView>> =
         MutableStateFlow(emptyList())
     private val policyManager: PolicyManager = mockk {
-        every { getActivePolicies(type = PolicyTypeJson.DISABLE_SEND) } returns emptyList()
-        every { getActivePoliciesFlow(type = PolicyTypeJson.DISABLE_SEND) } returns emptyFlow()
+        every { getActivePolicies(type = PolicyType.DISABLE_SEND) } returns emptyList()
+        every { getActivePoliciesFlow(type = PolicyType.DISABLE_SEND) } returns emptyFlow()
         every {
-            getActivePoliciesFlow(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            getActivePoliciesFlow(type = PolicyType.RESTRICTED_ITEM_TYPES)
         } returns mutableActivePoliciesFlow
     }
     private val bitwardenCredentialManager: BitwardenCredentialManager = mockk {
@@ -394,12 +394,11 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
             mutableActivePoliciesFlow.emit(
                 listOf(
-                    createMockPolicy(
+                    createMockPolicyView(
                         organizationId = "Test Organization",
                         id = "testId",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
-                        data = null,
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = true,
                     ),
                 ),
             )
@@ -1681,12 +1680,11 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
             mutableActivePoliciesFlow.emit(
                 listOf(
-                    createMockPolicy(
+                    createMockPolicyView(
                         organizationId = "Test Organization",
                         id = "testId",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
-                        data = null,
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = true,
                     ),
                 ),
             )
@@ -1722,12 +1720,11 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
             mutableActivePoliciesFlow.emit(
                 listOf(
-                    createMockPolicy(
+                    createMockPolicyView(
                         organizationId = "Test Organization",
                         id = "testId",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
-                        data = null,
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = true,
                     ),
                 ),
             )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -9,9 +9,8 @@ import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.network.exception.CookieRedirectException
-import com.bitwarden.network.model.PolicyTypeJson
-import com.bitwarden.network.model.SyncResponseJson
-import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.account.model.AccountSummary
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
@@ -60,6 +59,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockFolderView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockLoginListView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockLoginView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPassportView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkCipher
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSendView
 import com.x8bit.bitwarden.data.vault.manager.model.GetCipherResult
@@ -129,14 +129,14 @@ class VaultViewModelTest : BaseViewModelTest() {
         every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
     }
 
-    private val mutableActivePoliciesFlow: MutableStateFlow<List<SyncResponseJson.Policy>> =
+    private val mutableActivePoliciesFlow: MutableStateFlow<List<PolicyView>> =
         MutableStateFlow(emptyList())
     private val policyManager: PolicyManager = mockk {
         every {
-            getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns emptyList()
         every {
-            getActivePoliciesFlow(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            getActivePoliciesFlow(type = PolicyType.RESTRICTED_ITEM_TYPES)
         } returns mutableActivePoliciesFlow
     }
 
@@ -278,7 +278,7 @@ class VaultViewModelTest : BaseViewModelTest() {
         assertEquals(DEFAULT_STATE, viewModel.stateFlow.value)
         verify {
             vaultRepository.syncIfNecessary()
-            policyManager.getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         }
     }
 
@@ -673,14 +673,13 @@ class VaultViewModelTest : BaseViewModelTest() {
     @Test
     fun `UserState updates with a non-null value when not switching accounts should update the account information in the state when personal ownership disabled`() {
         every {
-            policyManager.getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+            policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_DATA_OWNERSHIP)
         } returns listOf(
-            createMockPolicy(
+            createMockPolicyView(
                 organizationId = "Test Organization",
                 id = "testId",
-                type = PolicyTypeJson.PERSONAL_OWNERSHIP,
-                isEnabled = true,
-                data = null,
+                type = PolicyType.ORGANIZATION_DATA_OWNERSHIP,
+                enabled = true,
             ),
         )
         val viewModel = createViewModel()
@@ -767,12 +766,11 @@ class VaultViewModelTest : BaseViewModelTest() {
             )
             mutableActivePoliciesFlow.emit(
                 listOf(
-                    createMockPolicy(
+                    createMockPolicyView(
                         organizationId = "Test Organization",
                         id = "testId",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
-                        data = null,
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = true,
                     ),
                 ),
             )
@@ -4097,12 +4095,11 @@ class VaultViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             mutableActivePoliciesFlow.emit(
                 listOf(
-                    createMockPolicy(
+                    createMockPolicyView(
                         organizationId = "Test Organization",
                         id = "testId",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
-                        data = null,
+                        type = PolicyType.RESTRICTED_ITEM_TYPES,
+                        enabled = true,
                     ),
                 ),
             )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37985](https://bitwarden.atlassian.net/browse/PM-37985)

## 📔 Objective

This PR updates the `PolicyManager` to use `PolicyView` as the primary policy model. All downstream users of `PolicyManager` have been updated as well.


[PM-37985]: https://bitwarden.atlassian.net/browse/PM-37985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ