### PR TITLE
[PM-37282] feat: Add Upgrade to Premium CTA to File Send dialog

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendGraphNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendGraphNavigation.kt
@@ -41,6 +41,7 @@ fun NavGraphBuilder.sendGraph(
                 navController.navigateToSendItemListing(VaultItemListingType.SendText)
             },
             onNavigateToSearchSend = onNavigateToSearchSend,
+            onNavigateToPlan = onNavigateToPlan,
         )
         sendItemListingDestination(
             onNavigateBack = { navController.popBackStack() },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendNavigation.kt
@@ -25,6 +25,7 @@ fun NavGraphBuilder.sendDestination(
     onNavigateToSendFilesList: () -> Unit,
     onNavigateToSendTextList: () -> Unit,
     onNavigateToSearchSend: (searchType: SearchType.Sends) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     composableWithRootPushTransitions<SendRoute> {
         SendScreen(
@@ -33,6 +34,7 @@ fun NavGraphBuilder.sendDestination(
             onNavigateToSendFilesList = onNavigateToSendFilesList,
             onNavigateToSendTextList = onNavigateToSendTextList,
             onNavigateToSearchSend = onNavigateToSearchSend,
+            onNavigateToPlan = onNavigateToPlan,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
@@ -30,6 +30,7 @@ import com.bitwarden.ui.platform.components.content.BitwardenLoadingContent
 import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
 import com.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
+import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.bitwarden.ui.platform.components.dialog.row.BitwardenBasicDialogRow
 import com.bitwarden.ui.platform.components.fab.BitwardenFloatingActionButton
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
@@ -69,6 +70,7 @@ fun SendScreen(
     onNavigateToSendFilesList: () -> Unit,
     onNavigateToSendTextList: () -> Unit,
     onNavigateToSearchSend: (searchType: SearchType.Sends) -> Unit,
+    onNavigateToPlan: () -> Unit,
     viewModel: SendViewModel = hiltViewModel(),
     intentManager: IntentManager = LocalIntentManager.current,
     appResumeStateManager: AppResumeStateManager = LocalAppResumeStateManager.current,
@@ -122,12 +124,16 @@ fun SendScreen(
             SendEvent.NavigateToFileSends -> onNavigateToSendFilesList()
             SendEvent.NavigateToTextSends -> onNavigateToSendTextList()
             is SendEvent.NavigateToUrl -> intentManager.launchUri(event.url.toUri())
+            SendEvent.NavigateToPlanModal -> onNavigateToPlan()
         }
     }
 
     SendDialogs(
         dialogState = state.dialogState,
         onAddSendSelected = { viewModel.trySendAction(SendAction.AddSendSelected(it)) },
+        onUpgradeToPremiumClick = {
+            viewModel.trySendAction(SendAction.UpgradeToPremiumClick)
+        },
         onDismissRequest = { viewModel.trySendAction(SendAction.DismissDialog) },
     )
 
@@ -229,6 +235,7 @@ fun SendScreen(
 private fun SendDialogs(
     dialogState: SendState.DialogState?,
     onAddSendSelected: (SendItemType) -> Unit,
+    onUpgradeToPremiumClick: () -> Unit,
     onDismissRequest: () -> Unit,
 ) {
     when (dialogState) {
@@ -253,6 +260,18 @@ private fun SendDialogs(
                     onClick = { onAddSendSelected(it) },
                 )
             }
+        }
+
+        SendState.DialogState.FileTypeRequiresPremium -> {
+            BitwardenTwoButtonDialog(
+                title = stringResource(id = BitwardenString.premium_subscription_required),
+                message = stringResource(id = BitwardenString.send_file_premium_required),
+                confirmButtonText = stringResource(id = BitwardenString.upgrade_to_premium),
+                dismissButtonText = stringResource(id = BitwardenString.cancel),
+                onConfirmClick = onUpgradeToPremiumClick,
+                onDismissClick = onDismissRequest,
+                onDismissRequest = onDismissRequest,
+            )
         }
 
         null -> Unit

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
@@ -132,6 +132,7 @@ class SendViewModel @Inject constructor(
         SendAction.RefreshPull -> handleRefreshPull()
         SendAction.UpgradedToPremiumCardClick -> handleUpgradedToPremiumCardClick()
         SendAction.UpgradedToPremiumCardDismiss -> handleUpgradedToPremiumCardDismiss()
+        SendAction.UpgradeToPremiumClick -> handleUpgradeToPremiumClick()
         is SendAction.Internal -> handleInternalAction(action)
     }
 
@@ -348,14 +349,15 @@ class SendViewModel @Inject constructor(
                 return
             }
             if (!state.isPremiumUser) {
-                mutableStateFlow.update {
-                    it.copy(
-                        dialogState = SendState.DialogState.Error(
-                            title = BitwardenString.send.asText(),
-                            message = BitwardenString.send_file_premium_required.asText(),
-                        ),
+                val dialog = if (premiumStateManager.isInAppUpgradeAvailable()) {
+                    SendState.DialogState.FileTypeRequiresPremium
+                } else {
+                    SendState.DialogState.Error(
+                        title = BitwardenString.send.asText(),
+                        message = BitwardenString.send_file_premium_required.asText(),
                     )
                 }
+                mutableStateFlow.update { it.copy(dialogState = dialog) }
                 return
             }
         }
@@ -447,6 +449,11 @@ class SendViewModel @Inject constructor(
 
     private fun handleFileTypeClick() {
         sendEvent(SendEvent.NavigateToFileSends)
+    }
+
+    private fun handleUpgradeToPremiumClick() {
+        mutableStateFlow.update { it.copy(dialogState = null) }
+        sendEvent(SendEvent.NavigateToPlanModal)
     }
 
     private fun handleTextTypeClick() {
@@ -627,6 +634,13 @@ data class SendState(
          */
         @Parcelize
         data object SelectSendAddType : DialogState()
+
+        /**
+         * Displays a dialog to the user indicating that creating a File-type Send
+         * requires a Premium account.
+         */
+        @Parcelize
+        data object FileTypeRequiresPremium : DialogState()
     }
 }
 
@@ -744,6 +758,11 @@ sealed class SendAction {
      * User clicked the "Learn more" CTA on the "Upgraded to Premium" action card.
      */
     data object UpgradedToPremiumCardClick : SendAction()
+
+    /**
+     * User clicked the upgrade to premium button in a dialog.
+     */
+    data object UpgradeToPremiumClick : SendAction()
 
     /**
      * User clicked the dismiss icon on the "Upgraded to Premium" action card.
@@ -871,6 +890,11 @@ sealed class SendEvent {
     data class NavigateToUrl(
         val url: String,
     ) : SendEvent()
+
+    /**
+     * Navigate to the in-app Plan (upgrade) modal.
+     */
+    data object NavigateToPlanModal : SendEvent()
 
     /**
      * Show a snackbar to the user.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -418,6 +418,18 @@ private fun VaultItemListingDialogs(
             )
         }
 
+        is VaultItemListingState.DialogState.FileTypeRequiresPremium -> {
+            BitwardenTwoButtonDialog(
+                title = stringResource(id = BitwardenString.premium_subscription_required),
+                message = stringResource(id = BitwardenString.send_file_premium_required),
+                confirmButtonText = stringResource(id = BitwardenString.upgrade_to_premium),
+                dismissButtonText = stringResource(id = BitwardenString.cancel),
+                onConfirmClick = vaultItemListingHandlers.upgradeToPremiumClick,
+                onDismissClick = vaultItemListingHandlers.dismissDialogRequest,
+                onDismissRequest = vaultItemListingHandlers.dismissDialogRequest,
+            )
+        }
+
         null -> Unit
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -860,6 +860,16 @@ class VaultItemListingViewModel @Inject constructor(
         )
     }
 
+    private fun fileSendRequiresPremiumDialog(): VaultItemListingState.DialogState =
+        if (premiumStateManager.isInAppUpgradeAvailable()) {
+            VaultItemListingState.DialogState.FileTypeRequiresPremium
+        } else {
+            VaultItemListingState.DialogState.Error(
+                title = BitwardenString.send.asText(),
+                message = BitwardenString.send_file_premium_required.asText(),
+            )
+        }
+
     private fun handleAddVaultItemClick() {
         when (val itemListingType = state.itemListingType) {
             is VaultItemListingState.ItemListingType.Vault.Collection -> {
@@ -897,14 +907,7 @@ class VaultItemListingViewModel @Inject constructor(
                             sendEvent(VaultItemListingEvent.NavigateToAddSendItem(sendType))
                         } else {
                             mutableStateFlow.update {
-                                it.copy(
-                                    dialogState = VaultItemListingState.DialogState.Error(
-                                        title = BitwardenString.send.asText(),
-                                        message = BitwardenString
-                                            .send_file_premium_required
-                                            .asText(),
-                                    ),
-                                )
+                                it.copy(dialogState = fileSendRequiresPremiumDialog())
                             }
                         }
                     }
@@ -3206,6 +3209,13 @@ data class VaultItemListingState(
          */
         @Parcelize
         data object ArchiveRequiresPremium : DialogState()
+
+        /**
+         * Displays a dialog to the user indicating that creating a File-type Send
+         * requires a Premium account.
+         */
+        @Parcelize
+        data object FileTypeRequiresPremium : DialogState()
     }
 
     /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
@@ -54,6 +54,7 @@ class SendScreenTest : BitwardenComposeTest() {
     private var onNavigateToSendTextListCalled = false
     private var onNavigateToSendSearchCalled = false
     private var onNavigateToViewSendRoute: ViewSendRoute? = null
+    private var onNavigateToPlanCalled = false
 
     private val intentManager = mockk<IntentManager> {
         every { launchUri(any()) } just runs
@@ -80,6 +81,7 @@ class SendScreenTest : BitwardenComposeTest() {
                 onNavigateToSendFilesList = { onNavigateToSendFilesListCalled = true },
                 onNavigateToSendTextList = { onNavigateToSendTextListCalled = true },
                 onNavigateToSearchSend = { onNavigateToSendSearchCalled = true },
+                onNavigateToPlan = { onNavigateToPlanCalled = true },
             )
         }
     }
@@ -943,6 +945,59 @@ class SendScreenTest : BitwardenComposeTest() {
         verify(exactly = 1) {
             viewModel.trySendAction(SendAction.AddSendSelected(sendType = SendItemType.TEXT))
         }
+    }
+
+    @Test
+    fun `FileTypeRequiresPremium dialog should be displayed according to state`() {
+        composeTestRule.assertNoDialogExists()
+
+        mutableStateFlow.update {
+            it.copy(dialogState = SendState.DialogState.FileTypeRequiresPremium)
+        }
+
+        composeTestRule
+            .onNodeWithText("Premium subscription required")
+            .assertIsDisplayed()
+            .assert(hasAnyAncestor(isDialog()))
+        composeTestRule
+            .onNodeWithText(
+                "Free accounts are restricted to sharing text only. " +
+                    "A Premium membership is required to use files with Send.",
+            )
+            .assertIsDisplayed()
+            .assert(hasAnyAncestor(isDialog()))
+    }
+
+    @Test
+    fun `FileTypeRequiresPremium dialog Cancel click should send DismissDialog`() {
+        mutableStateFlow.update {
+            it.copy(dialogState = SendState.DialogState.FileTypeRequiresPremium)
+        }
+
+        composeTestRule
+            .onNodeWithText("Cancel")
+            .performClick()
+
+        verify { viewModel.trySendAction(SendAction.DismissDialog) }
+    }
+
+    @Test
+    fun `FileTypeRequiresPremium dialog Upgrade click should send UpgradeToPremiumClick`() {
+        mutableStateFlow.update {
+            it.copy(dialogState = SendState.DialogState.FileTypeRequiresPremium)
+        }
+
+        composeTestRule
+            .onNodeWithText("Upgrade to Premium")
+            .performClick()
+
+        verify { viewModel.trySendAction(SendAction.UpgradeToPremiumClick) }
+    }
+
+    @Test
+    fun `on NavigateToPlanModal event should call onNavigateToPlan`() {
+        mutableEventFlow.tryEmit(SendEvent.NavigateToPlanModal)
+        assertTrue(onNavigateToPlanCalled)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
@@ -155,7 +155,8 @@ class SendViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `AddSendSelected with file type and non Premium user should display dialog`() {
+    fun `AddSendSelected file without Premium and upgrade unavailable shows Error dialog`() {
+        every { premiumStateManager.isInAppUpgradeAvailable() } returns false
         val state = DEFAULT_STATE.copy(isPremiumUser = false, policyDisablesSend = false)
         val viewModel = createViewModel(state = state)
         viewModel.trySendAction(SendAction.AddSendSelected(sendType = SendItemType.FILE))
@@ -168,6 +169,31 @@ class SendViewModelTest : BaseViewModelTest() {
             ),
             viewModel.stateFlow.value,
         )
+    }
+
+    @Test
+    fun `AddSendSelected file without Premium with upgrade available shows premium dialog`() {
+        every { premiumStateManager.isInAppUpgradeAvailable() } returns true
+        val state = DEFAULT_STATE.copy(isPremiumUser = false, policyDisablesSend = false)
+        val viewModel = createViewModel(state = state)
+        viewModel.trySendAction(SendAction.AddSendSelected(sendType = SendItemType.FILE))
+        assertEquals(
+            state.copy(dialogState = SendState.DialogState.FileTypeRequiresPremium),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `UpgradeToPremiumClick clears dialog and emits NavigateToPlanModal`() = runTest {
+        val state = DEFAULT_STATE.copy(
+            dialogState = SendState.DialogState.FileTypeRequiresPremium,
+        )
+        val viewModel = createViewModel(state = state)
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(SendAction.UpgradeToPremiumClick)
+            assertEquals(SendEvent.NavigateToPlanModal, awaitItem())
+        }
+        assertEquals(state.copy(dialogState = null), viewModel.stateFlow.value)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -2591,6 +2591,42 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
             viewModel.trySendAction(VaultItemListingsAction.UpgradeToPremiumClick)
         }
     }
+
+    @Test
+    fun `FileTypeRequiresPremium dialog should display based on state`() {
+        composeTestRule.assertNoDialogExists()
+        mutableStateFlow.update {
+            it.copy(dialogState = VaultItemListingState.DialogState.FileTypeRequiresPremium)
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Premium subscription required")
+            .assert(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                text = "Free accounts are restricted to sharing text only. " +
+                    "A Premium membership is required to use files with Send.",
+            )
+            .assert(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `FileTypeRequiresPremium dialog Upgrade click should send UpgradeToPremiumClick`() {
+        mutableStateFlow.update {
+            it.copy(dialogState = VaultItemListingState.DialogState.FileTypeRequiresPremium)
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Upgrade to Premium")
+            .assert(hasAnyAncestor(isDialog()))
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(VaultItemListingsAction.UpgradeToPremiumClick)
+        }
+    }
 }
 
 private val ACTIVE_ACCOUNT_SUMMARY = AccountSummary(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -1822,8 +1822,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `AddVaultItemClick for file send item without Premium should display error dialog`() =
+    fun `AddVaultItemClick for file send without Premium and upgrade unavailable shows Error`() =
         runTest {
+            every { premiumStateManager.isInAppUpgradeAvailable() } returns false
             mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
                 accounts = listOf(DEFAULT_ACCOUNT.copy(isPremium = false)),
             )
@@ -1841,6 +1842,31 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                         title = BitwardenString.send.asText(),
                         message = BitwardenString.send_file_premium_required.asText(),
                     ),
+                    isPremium = false,
+                ),
+                viewModel.stateFlow.value,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `AddVaultItemClick for file send without Premium and upgrade available shows Upgrade to Premium dialog`() =
+        runTest {
+            every { premiumStateManager.isInAppUpgradeAvailable() } returns true
+            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+                accounts = listOf(DEFAULT_ACCOUNT.copy(isPremium = false)),
+            )
+            val viewModel = createVaultItemListingViewModel(
+                createSavedStateHandleWithVaultItemListingType(VaultItemListingType.SendFile),
+            )
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultItemListingsAction.AddVaultItemClick)
+                expectNoEvents()
+            }
+            assertEquals(
+                createVaultItemListingState(
+                    itemListingType = VaultItemListingState.ItemListingType.Send.SendFile,
+                    dialogState = VaultItemListingState.DialogState.FileTypeRequiresPremium,
                     isPremium = false,
                 ),
                 viewModel.stateFlow.value,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37282](https://bitwarden.atlassian.net/browse/PM-37282)

## 📔 Objective

Replace the free-tier "File Sends require Premium" dead-end "Okay" dialog with a two-button "Cancel" / "Upgrade to Premium" CTA at both real entry points — the Send tab "+" FAB and the Send file item-listing screen — matching how other premium gates in the app surface an in-line upgrade path. Gated on `PremiumStateManager.isInAppUpgradeAvailable()` so the original single-button dialog still appears when the in-app upgrade path isn't actually offered.

## 📸 Screenshots

| Figma | Before | After |
|--------|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/b6fea13c-7dd1-461d-aa07-34eba3a6eb1b" /> | <img width="365" src="https://github.com/user-attachments/assets/9e0986cb-9f38-4bc0-a56b-69c7d9f352ad" /> | <img width="365" src="https://github.com/user-attachments/assets/ce6a2ff1-b0a0-4d96-8156-3df9b7445210" /> | 

[PM-37282]: https://bitwarden.atlassian.net/browse/PM-37282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ