### PR TITLE
[PM-37232] fix: Hide upgrade CTAs while a Premium upgrade is pending

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -28,6 +28,14 @@ interface PremiumStateManager {
     val isUpgradedToPremiumCardEligibleFlow: StateFlow<Boolean>
 
     /**
+     * Emits `true` while the active user has a Premium upgrade awaiting server confirmation
+     * (Stripe checkout completed but `isPremium` not yet flipped), and `false` otherwise. The
+     * banner and Plan-screen Upgrade Now CTA use this to avoid advertising an upgrade that is
+     * already in flight.
+     */
+    val isPremiumUpgradePendingFlow: StateFlow<Boolean>
+
+    /**
      * Emits `true` when the active user is eligible to see the Plan row in Settings, or `false`
      * otherwise.
      */
@@ -66,4 +74,18 @@ interface PremiumStateManager {
      * never re-appears for that user.
      */
     fun dismissUpgradedToPremiumCard()
+
+    /**
+     * Marks the active user as having a Premium upgrade in flight (Stripe checkout completed
+     * but the server has not yet flipped `isPremium`). While set, upgrade CTAs are suppressed
+     * for that user.
+     */
+    fun markPremiumUpgradePending(userId: String)
+
+    /**
+     * Clears the "Premium upgrade pending" flag for the given user. Called when the user
+     * explicitly dismisses the pending-upgrade dialog (Continue) or when the upgrade resolves
+     * to a confirmed Premium status.
+     */
+    fun clearPremiumUpgradePending(userId: String)
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -42,7 +42,7 @@ interface PremiumStateManager {
     /**
      * Emits the active user's current [UpgradeLifecycleState].
      */
-    val lifecycleStateFlow: StateFlow<UpgradeLifecycleState>
+    val upgradeLifecycleStateFlow: StateFlow<UpgradeLifecycleState>
 
     /**
      * Emits whether the current state should be treated as self-hosted for premium upgrade

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -29,9 +29,7 @@ interface PremiumStateManager {
 
     /**
      * Emits `true` while the active user has a Premium upgrade awaiting server confirmation
-     * (Stripe checkout completed but `isPremium` not yet flipped), and `false` otherwise. The
-     * banner and Plan-screen Upgrade Now CTA use this to avoid advertising an upgrade that is
-     * already in flight.
+     * (Stripe checkout completed but `isPremium` not yet flipped), and `false` otherwise.
      */
     val isPremiumUpgradePendingFlow: StateFlow<Boolean>
 
@@ -77,15 +75,12 @@ interface PremiumStateManager {
 
     /**
      * Marks the active user as having a Premium upgrade in flight (Stripe checkout completed
-     * but the server has not yet flipped `isPremium`). While set, upgrade CTAs are suppressed
-     * for that user.
+     * but the server has not yet flipped `isPremium`).
      */
     fun markPremiumUpgradePending(userId: String)
 
     /**
-     * Clears the "Premium upgrade pending" flag for the given user. Called when the user
-     * explicitly dismisses the pending-upgrade dialog (Continue) or when the upgrade resolves
-     * to a confirmed Premium status.
+     * Clears the "Premium upgrade pending" flag for the given [userId].
      */
     fun clearPremiumUpgradePending(userId: String)
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.billing.manager
 
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
+import com.x8bit.bitwarden.data.billing.repository.model.UpgradeLifecycleState
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -28,12 +29,6 @@ interface PremiumStateManager {
     val isUpgradedToPremiumCardEligibleFlow: StateFlow<Boolean>
 
     /**
-     * Emits `true` while the active user has a Premium upgrade awaiting server confirmation
-     * (Stripe checkout completed but `isPremium` not yet flipped), and `false` otherwise.
-     */
-    val isPremiumUpgradePendingFlow: StateFlow<Boolean>
-
-    /**
      * Emits `true` when the active user is eligible to see the Plan row in Settings, or `false`
      * otherwise.
      */
@@ -43,6 +38,11 @@ interface PremiumStateManager {
      * Emits the active user's latest [SubscriptionStatusState].
      */
     val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState>
+
+    /**
+     * Emits the active user's current [UpgradeLifecycleState].
+     */
+    val lifecycleStateFlow: StateFlow<UpgradeLifecycleState>
 
     /**
      * Emits whether the current state should be treated as self-hosted for premium upgrade
@@ -78,9 +78,4 @@ interface PremiumStateManager {
      * but the server has not yet flipped `isPremium`).
      */
     fun markPremiumUpgradePending(userId: String)
-
-    /**
-     * Clears the "Premium upgrade pending" flag for the given [userId].
-     */
-    fun clearPremiumUpgradePending(userId: String)
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -102,7 +102,10 @@ class PremiumStateManagerImpl(
             .stateIn(
                 scope = unconfinedScope,
                 started = SharingStarted.Eagerly,
-                initialValue = false,
+                initialValue = authDiskSource.userState
+                    ?.activeUserId
+                    ?.let { settingsDiskSource.getPremiumUpgradePending(userId = it) }
+                    ?: false,
             )
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -85,6 +85,33 @@ class PremiumStateManagerImpl(
                 initialValue = SubscriptionStatusState.Loading,
             )
 
+    /**
+     * Reactive read of the per-user "Premium upgrade pending" disk flag. There is no premium /
+     * consumed gating — this is just the raw flag, set by [markPremiumUpgradePending] when sync
+     * confirms post-checkout that `isPremium` has not yet flipped, and cleared either explicitly
+     * (the Continue button on the PendingUpgrade dialog) or implicitly when
+     * `hasPremiumPersonally` transitions `false → true` in the init block below.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override val isPremiumUpgradePendingFlow: StateFlow<Boolean> =
+        authDiskSource
+            .activeUserIdChangesFlow
+            .flatMapLatest { userId ->
+                userId
+                    ?.let { id ->
+                        settingsDiskSource
+                            .getPremiumUpgradePendingFlow(id)
+                            .map { it ?: false }
+                    }
+                    ?: flowOf(false)
+            }
+            .distinctUntilChanged()
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Eagerly,
+                initialValue = false,
+            )
+
     @OptIn(ExperimentalCoroutinesApi::class)
     override val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean> =
         combine(
@@ -118,6 +145,9 @@ class PremiumStateManagerImpl(
             )
         }
             .combine(subscriptionStatusStateFlow) { inputs, subscriptionStatus ->
+                inputs to subscriptionStatus
+            }
+            .combine(isPremiumUpgradePendingFlow) { (inputs, subscriptionStatus), isPending ->
                 val profile = inputs.userState?.activeAccount?.profile
                     ?: return@combine false
                 val isAccountOldEnough = profile.creationDate.isOlderThanDays(
@@ -134,6 +164,7 @@ class PremiumStateManagerImpl(
                     inputs.isInAppBillingSupported &&
                     inputs.featureFlagEnabled &&
                     !inputs.isDismissed &&
+                    !isPending &&
                     isAccountOldEnough &&
                     itemCount >= PREMIUM_UPGRADE_MINIMUM_VAULT_ITEMS
             }
@@ -254,6 +285,10 @@ class PremiumStateManagerImpl(
                 // an upgrade.
                 if (previous?.first == currentUserId && !previous.second) {
                     markUpgradedToPremiumCardPending(userId = currentUserId)
+                    // The upgrade just resolved — clear any in-flight pending flag we set
+                    // post-Stripe checkout. Symmetric with the "upgrade succeeded" moment used
+                    // to arm the Upgraded-to-Premium card above.
+                    clearPremiumUpgradePending(userId = currentUserId)
                 }
             }
             .launchIn(unconfinedScope)
@@ -281,6 +316,20 @@ class PremiumStateManagerImpl(
         )
         settingsDiskSource.storeUpgradedToPremiumCardPending(
             userId = activeUserId,
+            isPending = false,
+        )
+    }
+
+    override fun markPremiumUpgradePending(userId: String) {
+        settingsDiskSource.storePremiumUpgradePending(
+            userId = userId,
+            isPending = true,
+        )
+    }
+
+    override fun clearPremiumUpgradePending(userId: String) {
+        settingsDiskSource.storePremiumUpgradePending(
+            userId = userId,
             isPending = false,
         )
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -85,13 +85,6 @@ class PremiumStateManagerImpl(
                 initialValue = SubscriptionStatusState.Loading,
             )
 
-    /**
-     * Reactive read of the per-user "Premium upgrade pending" disk flag. There is no premium /
-     * consumed gating — this is just the raw flag, set by [markPremiumUpgradePending] when sync
-     * confirms post-checkout that `isPremium` has not yet flipped, and cleared either explicitly
-     * (the Continue button on the PendingUpgrade dialog) or implicitly when
-     * `hasPremiumPersonally` transitions `false → true` in the init block below.
-     */
     @OptIn(ExperimentalCoroutinesApi::class)
     override val isPremiumUpgradePendingFlow: StateFlow<Boolean> =
         authDiskSource
@@ -285,9 +278,6 @@ class PremiumStateManagerImpl(
                 // an upgrade.
                 if (previous?.first == currentUserId && !previous.second) {
                     markUpgradedToPremiumCardPending(userId = currentUserId)
-                    // The upgrade just resolved — clear any in-flight pending flag we set
-                    // post-Stripe checkout. Symmetric with the "upgrade succeeded" moment used
-                    // to arm the Upgraded-to-Premium card above.
                     clearPremiumUpgradePending(userId = currentUserId)
                 }
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -11,6 +11,7 @@ import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
+import com.x8bit.bitwarden.data.billing.repository.model.UpgradeLifecycleState
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
@@ -86,26 +87,39 @@ class PremiumStateManagerImpl(
             )
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override val isPremiumUpgradePendingFlow: StateFlow<Boolean> =
-        authDiskSource
-            .activeUserIdChangesFlow
-            .flatMapLatest { userId ->
-                userId
-                    ?.let { id ->
-                        settingsDiskSource
-                            .getPremiumUpgradePendingFlow(id)
-                            .map { it ?: false }
-                    }
-                    ?: flowOf(false)
-            }
+    override val lifecycleStateFlow: StateFlow<UpgradeLifecycleState> =
+        combine(
+            authDiskSource.userStateFlow,
+            subscriptionStatusStateFlow,
+            authDiskSource.activeUserIdChangesFlow
+                .flatMapLatest { userId ->
+                    userId
+                        ?.let { id ->
+                            settingsDiskSource
+                                .getPremiumUpgradePendingFlow(id)
+                                .map { it ?: false }
+                        }
+                        ?: flowOf(false)
+                },
+        ) { userState, subscriptionStatus, isPending ->
+            deriveLifecycleState(
+                userState = userState,
+                subscriptionStatus = subscriptionStatus,
+                isPending = isPending,
+            )
+        }
             .distinctUntilChanged()
             .stateIn(
                 scope = unconfinedScope,
                 started = SharingStarted.Eagerly,
-                initialValue = authDiskSource.userState
-                    ?.activeUserId
-                    ?.let { settingsDiskSource.getPremiumUpgradePending(userId = it) }
-                    ?: false,
+                initialValue = deriveLifecycleState(
+                    userState = authDiskSource.userState,
+                    subscriptionStatus = subscriptionStatusStateFlow.value,
+                    isPending = authDiskSource.userState
+                        ?.activeUserId
+                        ?.let { settingsDiskSource.getPremiumUpgradePending(userId = it) }
+                        ?: false,
+                ),
             )
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -140,10 +154,7 @@ class PremiumStateManagerImpl(
                 vaultDataState = vaultDataState,
             )
         }
-            .combine(subscriptionStatusStateFlow) { inputs, subscriptionStatus ->
-                inputs to subscriptionStatus
-            }
-            .combine(isPremiumUpgradePendingFlow) { (inputs, subscriptionStatus), isPending ->
+            .combine(lifecycleStateFlow) { inputs, lifecycle ->
                 val profile = inputs.userState?.activeAccount?.profile
                     ?: return@combine false
                 val isAccountOldEnough = profile.creationDate.isOlderThanDays(
@@ -151,16 +162,16 @@ class PremiumStateManagerImpl(
                     clock = clock,
                 )
                 val itemCount = inputs.vaultDataState.activeVaultItemCount()
-                val hasPremium = profile.hasPremiumPersonally == true ||
-                    profile.hasPremiumFromOrganization == true
-                val isEffectivelyPremium = hasPremium &&
-                    !subscriptionStatus.isInTroubleState()
+                val lifecycleAllowsBanner = lifecycle is UpgradeLifecycleState.Free ||
+                    (
+                        lifecycle is UpgradeLifecycleState.Premium &&
+                            lifecycle.subscriptionStatus.isInTroubleState()
+                        )
 
-                !isEffectivelyPremium &&
+                lifecycleAllowsBanner &&
                     inputs.isInAppBillingSupported &&
                     inputs.featureFlagEnabled &&
                     !inputs.isDismissed &&
-                    !isPending &&
                     isAccountOldEnough &&
                     itemCount >= PREMIUM_UPGRADE_MINIMUM_VAULT_ITEMS
             }
@@ -320,11 +331,26 @@ class PremiumStateManagerImpl(
         )
     }
 
-    override fun clearPremiumUpgradePending(userId: String) {
+    private fun clearPremiumUpgradePending(userId: String) {
         settingsDiskSource.storePremiumUpgradePending(
             userId = userId,
             isPending = false,
         )
+    }
+
+    private fun deriveLifecycleState(
+        userState: UserStateJson?,
+        subscriptionStatus: SubscriptionStatusState,
+        isPending: Boolean,
+    ): UpgradeLifecycleState {
+        val profile = userState?.activeAccount?.profile ?: return UpgradeLifecycleState.Free
+        val hasPremium = profile.hasPremiumPersonally == true ||
+            profile.hasPremiumFromOrganization == true
+        return when {
+            hasPremium -> UpgradeLifecycleState.Premium(subscriptionStatus = subscriptionStatus)
+            isPending -> UpgradeLifecycleState.UpgradePending
+            else -> UpgradeLifecycleState.Free
+        }
     }
 
     private fun markUpgradedToPremiumCardPending(userId: String) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -334,7 +334,7 @@ class PremiumStateManagerImpl(
     private fun clearPremiumUpgradePending(userId: String) {
         settingsDiskSource.storePremiumUpgradePending(
             userId = userId,
-            isPending = false,
+            isPending = null,
         )
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -87,7 +87,7 @@ class PremiumStateManagerImpl(
             )
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override val lifecycleStateFlow: StateFlow<UpgradeLifecycleState> =
+    override val upgradeLifecycleStateFlow: StateFlow<UpgradeLifecycleState> =
         combine(
             authDiskSource.userStateFlow,
             subscriptionStatusStateFlow,
@@ -154,7 +154,7 @@ class PremiumStateManagerImpl(
                 vaultDataState = vaultDataState,
             )
         }
-            .combine(lifecycleStateFlow) { inputs, lifecycle ->
+            .combine(upgradeLifecycleStateFlow) { inputs, lifecycle ->
                 val profile = inputs.userState?.activeAccount?.profile
                     ?: return@combine false
                 val isAccountOldEnough = profile.creationDate.isOlderThanDays(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/UpgradeLifecycleState.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/UpgradeLifecycleState.kt
@@ -1,0 +1,33 @@
+package com.x8bit.bitwarden.data.billing.repository.model
+
+/**
+ * Represents the active user's position in the Premium upgrade lifecycle.
+ *
+ * Transitions:
+ * - [Free] → [UpgradePending] when the user completes Stripe checkout and the post-checkout
+ *   sync still reports the user as non-premium — checkout is done, backend reconciliation
+ *   is in flight.
+ * - [UpgradePending] → [Premium] when the server flips `isPremium` to `true`.
+ *
+ * Cancellation, expiration, and other terminal substates are surfaced via
+ * [Premium.subscriptionStatus] rather than as separate leaves.
+ */
+sealed class UpgradeLifecycleState {
+
+    /**
+     * The user has no Premium subscription and no upgrade is in flight.
+     */
+    data object Free : UpgradeLifecycleState()
+
+    /**
+     * Stripe checkout completed but the server has not yet flipped `isPremium`.
+     */
+    data object UpgradePending : UpgradeLifecycleState()
+
+    /**
+     * The user holds Premium; [subscriptionStatus] carries the substate (active, canceled, etc).
+     */
+    data class Premium(
+        val subscriptionStatus: SubscriptionStatusState,
+    ) : UpgradeLifecycleState()
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -184,9 +184,7 @@ interface SettingsDiskSource : FlightRecorderDiskSource {
 
     /**
      * Retrieves the stored value of whether a Premium upgrade is awaiting server confirmation
-     * for the given [userId]. When `true`, surfaces that the active user has completed Stripe
-     * checkout but the server has not yet flipped `isPremium = true` — used to suppress
-     * upgrade CTAs while the upgrade is in flight.
+     * for the given [userId].
      */
     fun getPremiumUpgradePending(userId: String): Boolean?
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -183,6 +183,27 @@ interface SettingsDiskSource : FlightRecorderDiskSource {
     fun getUpgradedToPremiumCardPendingFlow(userId: String): Flow<Boolean?>
 
     /**
+     * Retrieves the stored value of whether a Premium upgrade is awaiting server confirmation
+     * for the given [userId]. When `true`, surfaces that the active user has completed Stripe
+     * checkout but the server has not yet flipped `isPremium = true` — used to suppress
+     * upgrade CTAs while the upgrade is in flight.
+     */
+    fun getPremiumUpgradePending(userId: String): Boolean?
+
+    /**
+     * Stores whether a Premium upgrade is awaiting server confirmation for the given [userId].
+     */
+    fun storePremiumUpgradePending(
+        userId: String,
+        isPending: Boolean?,
+    )
+
+    /**
+     * Emits updates that track [getPremiumUpgradePending] for the given [userId].
+     */
+    fun getPremiumUpgradePendingFlow(userId: String): Flow<Boolean?>
+
+    /**
      * Retrieves the biometric integrity validity for the given [userId] and
      * [systemBioIntegrityState].
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -57,11 +57,13 @@ private const val UPGRADED_TO_PREMIUM_CARD_CONSUMED =
     "upgradedToPremiumCardConsumed"
 private const val UPGRADED_TO_PREMIUM_CARD_PENDING =
     "upgradedToPremiumCardPending"
+private const val PREMIUM_UPGRADE_PENDING =
+    "premiumUpgradePending"
 
 /**
  * Primary implementation of [SettingsDiskSource].
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LargeClass")
 class SettingsDiskSourceImpl(
     private val sharedPreferences: SharedPreferences,
     private val json: Json,
@@ -105,6 +107,9 @@ class SettingsDiskSourceImpl(
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     private val mutableUpgradedToPremiumCardPendingFlowMap =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutablePremiumUpgradePendingFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     private val mutableIsIconLoadingDisabledFlow = bufferedMutableSharedFlow<Boolean?>()
@@ -264,6 +269,7 @@ class SettingsDiskSourceImpl(
         // - Premium upgrade banner dismissed
         // - Upgraded to Premium action card consumed
         // - Upgraded to Premium action card pending
+        // - Premium upgrade pending
     }
 
     override fun getIntroducingArchiveActionCardDismissed(userId: String): Boolean? =
@@ -345,6 +351,26 @@ class SettingsDiskSourceImpl(
     override fun getUpgradedToPremiumCardPendingFlow(userId: String): Flow<Boolean?> =
         getMutableUpgradedToPremiumCardPendingFlow(userId = userId)
             .onSubscription { emit(getUpgradedToPremiumCardPending(userId = userId)) }
+
+    override fun getPremiumUpgradePending(userId: String): Boolean? =
+        getBoolean(
+            key = PREMIUM_UPGRADE_PENDING.appendIdentifier(identifier = userId),
+        )
+
+    override fun storePremiumUpgradePending(
+        userId: String,
+        isPending: Boolean?,
+    ) {
+        putBoolean(
+            key = PREMIUM_UPGRADE_PENDING.appendIdentifier(identifier = userId),
+            value = isPending,
+        )
+        getMutablePremiumUpgradePendingFlow(userId = userId).tryEmit(isPending)
+    }
+
+    override fun getPremiumUpgradePendingFlow(userId: String): Flow<Boolean?> =
+        getMutablePremiumUpgradePendingFlow(userId = userId)
+            .onSubscription { emit(getPremiumUpgradePending(userId = userId)) }
 
     override fun getAccountBiometricIntegrityValidity(
         userId: String,
@@ -708,6 +734,13 @@ class SettingsDiskSourceImpl(
         userId: String,
     ): MutableSharedFlow<Boolean?> =
         mutableUpgradedToPremiumCardPendingFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutablePremiumUpgradePendingFlow(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> =
+        mutablePremiumUpgradePendingFlowMap.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -294,33 +294,15 @@ private fun FreeCloudContent(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        BitwardenFilledButton(
-            label = stringResource(id = BitwardenString.upgrade_now),
-            onClick = { shouldShowUpgradeDialog = true },
-            icon = rememberVectorPainter(id = BitwardenDrawable.ic_external_link),
-            modifier = Modifier
-                .standardHorizontalMargin()
-                .fillMaxWidth()
-                .testTag("UpgradeNowButton"),
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Text(
-            text = stringResource(
-                id = BitwardenString
-                    .youll_go_to_stripes_secure_checkout_to_complete_your_purchase,
-            ),
-            style = BitwardenTheme.typography.bodyMedium,
-            color = BitwardenTheme.colorScheme.text.secondary,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .standardHorizontalMargin()
-                .testTag("StripeFooterText"),
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
+        // Hide the Upgrade Now CTA (and its Stripe footer copy) while a Stripe upgrade is
+        // already in flight for the active user. CTAs reappear once the pending flag clears
+        // — either via the PendingUpgrade dialog's Continue button or once the server flips
+        // the user to Premium.
+        if (!viewState.isPremiumUpgradePending) {
+            UpgradeNowCallToAction(
+                onUpgradeNowClick = { shouldShowUpgradeDialog = true },
+            )
+        }
         Spacer(modifier = Modifier.navigationBarsPadding())
     }
 
@@ -341,6 +323,38 @@ private fun FreeCloudContent(
             onDismissRequest = { shouldShowUpgradeDialog = false },
         )
     }
+}
+
+@Composable
+private fun UpgradeNowCallToAction(
+    onUpgradeNowClick: () -> Unit,
+) {
+    BitwardenFilledButton(
+        label = stringResource(id = BitwardenString.upgrade_now),
+        onClick = onUpgradeNowClick,
+        icon = rememberVectorPainter(id = BitwardenDrawable.ic_external_link),
+        modifier = Modifier
+            .standardHorizontalMargin()
+            .fillMaxWidth()
+            .testTag("UpgradeNowButton"),
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    Text(
+        text = stringResource(
+            id = BitwardenString.youll_go_to_stripes_secure_checkout_to_complete_your_purchase,
+        ),
+        style = BitwardenTheme.typography.bodyMedium,
+        color = BitwardenTheme.colorScheme.text.secondary,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .standardHorizontalMargin()
+            .testTag("StripeFooterText"),
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
 }
 
 @Suppress("MaxLineLength")
@@ -790,6 +804,7 @@ private fun PlanScreenFreeCloudAccount_preview() {
                     rate = "$1.67",
                     checkoutUrl = null,
                     isAwaitingPremiumStatus = false,
+                    isPremiumUpgradePending = false,
                 ),
                 handlers = PlanHandlers(
                     onBackClick = {},

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -296,8 +296,7 @@ private fun FreeCloudContent(
 
         // Hide the Upgrade Now CTA (and its Stripe footer copy) while a Stripe upgrade is
         // already in flight for the active user. CTAs reappear once the pending flag clears
-        // — either via the PendingUpgrade dialog's Continue button or once the server flips
-        // the user to Premium.
+        // once the server flips the user to Premium.
         if (!viewState.isPremiumUpgradePending) {
             UpgradeNowCallToAction(
                 onUpgradeNowClick = { shouldShowUpgradeDialog = true },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -295,8 +295,8 @@ private fun FreeCloudContent(
         Spacer(modifier = Modifier.height(24.dp))
 
         // Hide the Upgrade Now CTA (and its Stripe footer copy) while a Stripe upgrade is
-        // already in flight for the active user. CTAs reappear once the pending flag clears
-        // once the server flips the user to Premium.
+        // already in flight for the active user. CTAs reappear once the server flips the
+        // user to Premium.
         if (!viewState.isPremiumUpgradePending) {
             UpgradeNowCallToAction(
                 onUpgradeNowClick = { shouldShowUpgradeDialog = true },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -255,17 +255,6 @@ class PlanViewModel @Inject constructor(
     }
 
     private fun handleContinueClick() {
-        // Continue is the user's explicit "I'll deal with this later" signal on the
-        // PendingUpgrade dialog — clear the pending flag so CTAs reappear if Stripe never
-        // resolves and the user comes back to upgrade again.
-        authRepository
-            .userStateFlow
-            .value
-            ?.activeAccount
-            ?.userId
-            ?.let { userId ->
-                premiumStateManager.clearPremiumUpgradePending(userId = userId)
-            }
         mutableStateFlow.update { it.copy(dialogState = null) }
         sendEvent(PlanEvent.NavigateBack)
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -130,7 +130,7 @@ class PlanViewModel @Inject constructor(
 
         premiumStateManager
             .upgradeLifecycleStateFlow
-            .map { PlanAction.Internal.LifecycleStateReceive(it) }
+            .map { PlanAction.Internal.UpgradeLifecycleStateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -198,8 +198,8 @@ class PlanViewModel @Inject constructor(
                 handleSubscriptionStatusUpdateReceive(action)
             }
 
-            is PlanAction.Internal.LifecycleStateReceive -> {
-                handleLifecycleStateReceive(action)
+            is PlanAction.Internal.UpgradeLifecycleStateReceive -> {
+                handleUpgradeLifecycleStateReceive(action)
             }
         }
     }
@@ -450,8 +450,8 @@ class PlanViewModel @Inject constructor(
         }
     }
 
-    private fun handleLifecycleStateReceive(
-        action: PlanAction.Internal.LifecycleStateReceive,
+    private fun handleUpgradeLifecycleStateReceive(
+        action: PlanAction.Internal.UpgradeLifecycleStateReceive,
     ) {
         val isPending = action.state is UpgradeLifecycleState.UpgradePending
         onFreeCloudContent { freeState ->
@@ -1138,7 +1138,7 @@ sealed class PlanAction {
         /**
          * The shared [UpgradeLifecycleState] for the active user has updated.
          */
-        data class LifecycleStateReceive(
+        data class UpgradeLifecycleStateReceive(
             val state: UpgradeLifecycleState,
         ) : Internal()
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -93,7 +93,7 @@ class PlanViewModel @Inject constructor(
                     checkoutUrl = null,
                     isAwaitingPremiumStatus = false,
                     isPremiumUpgradePending = premiumStateManager
-                        .lifecycleStateFlow
+                        .upgradeLifecycleStateFlow
                         .value is UpgradeLifecycleState.UpgradePending,
                 )
             },
@@ -129,7 +129,7 @@ class PlanViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         premiumStateManager
-            .lifecycleStateFlow
+            .upgradeLifecycleStateFlow
             .map { PlanAction.Internal.LifecycleStateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
@@ -418,7 +418,7 @@ class PlanViewModel @Inject constructor(
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
                             isPremiumUpgradePending = premiumStateManager
-                                .lifecycleStateFlow
+                                .upgradeLifecycleStateFlow
                                 .value is UpgradeLifecycleState.UpgradePending,
                         ),
                         dialogState = PlanState.DialogState.Loading(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -91,6 +91,9 @@ class PlanViewModel @Inject constructor(
                     rate = PLACEHOLDER_TEXT,
                     checkoutUrl = null,
                     isAwaitingPremiumStatus = false,
+                    isPremiumUpgradePending = premiumStateManager
+                        .isPremiumUpgradePendingFlow
+                        .value,
                 )
             },
             dialogState = null,
@@ -121,6 +124,12 @@ class PlanViewModel @Inject constructor(
         premiumStateManager
             .subscriptionStatusStateFlow
             .map { PlanAction.Internal.SubscriptionStatusUpdateReceive(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
+        premiumStateManager
+            .isPremiumUpgradePendingFlow
+            .map { PlanAction.Internal.PremiumUpgradePendingUpdateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -187,6 +196,10 @@ class PlanViewModel @Inject constructor(
             is PlanAction.Internal.SubscriptionStatusUpdateReceive -> {
                 handleSubscriptionStatusUpdateReceive(action)
             }
+
+            is PlanAction.Internal.PremiumUpgradePendingUpdateReceive -> {
+                handlePremiumUpgradePendingUpdateReceive(action)
+            }
         }
     }
 
@@ -242,6 +255,17 @@ class PlanViewModel @Inject constructor(
     }
 
     private fun handleContinueClick() {
+        // Continue is the user's explicit "I'll deal with this later" signal on the
+        // PendingUpgrade dialog — clear the pending flag so CTAs reappear if Stripe never
+        // resolves and the user comes back to upgrade again.
+        authRepository
+            .userStateFlow
+            .value
+            ?.activeAccount
+            ?.userId
+            ?.let { userId ->
+                premiumStateManager.clearPremiumUpgradePending(userId = userId)
+            }
         mutableStateFlow.update { it.copy(dialogState = null) }
         sendEvent(PlanEvent.NavigateBack)
     }
@@ -403,6 +427,9 @@ class PlanViewModel @Inject constructor(
                             rate = PLACEHOLDER_TEXT,
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = premiumStateManager
+                                .isPremiumUpgradePendingFlow
+                                .value,
                         ),
                         dialogState = PlanState.DialogState.Loading(
                             message = BitwardenString.loading.asText(),
@@ -429,6 +456,21 @@ class PlanViewModel @Inject constructor(
                         ),
                     )
                 }
+            }
+        }
+    }
+
+    private fun handlePremiumUpgradePendingUpdateReceive(
+        action: PlanAction.Internal.PremiumUpgradePendingUpdateReceive,
+    ) {
+        onFreeCloudContent { freeState ->
+            if (freeState.isPremiumUpgradePending == action.isPending) return@onFreeCloudContent
+            mutableStateFlow.update {
+                it.copy(
+                    viewState = freeState.copy(
+                        isPremiumUpgradePending = action.isPending,
+                    ),
+                )
             }
         }
     }
@@ -561,14 +603,19 @@ class PlanViewModel @Inject constructor(
         onFreeCloudContent { freeState ->
             if (!freeState.isAwaitingPremiumStatus) return@onFreeCloudContent
 
-            val isPremium = authRepository
+            val activeAccount = authRepository
                 .userStateFlow
                 .value
                 ?.activeAccount
-                ?.isPremium == true
+            val isPremium = activeAccount?.isPremium == true
             if (isPremium) {
                 onPremiumUpgradeSuccess()
             } else {
+                // Persist the pending-upgrade signal so the Vault banner and the Plan-screen
+                // Upgrade Now CTA can suppress themselves while the server catches up.
+                activeAccount?.userId?.let { userId ->
+                    premiumStateManager.markPremiumUpgradePending(userId = userId)
+                }
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = PlanState.DialogState.PendingUpgrade,
@@ -788,6 +835,7 @@ data class PlanState(
                 val rate: String,
                 val checkoutUrl: String?,
                 val isAwaitingPremiumStatus: Boolean,
+                val isPremiumUpgradePending: Boolean,
             ) : Free()
 
             /**
@@ -1094,6 +1142,13 @@ sealed class PlanAction {
          */
         data class SubscriptionStatusUpdateReceive(
             val state: SubscriptionStatusState,
+        ) : Internal()
+
+        /**
+         * The shared "Premium upgrade pending" flag for the active user has updated.
+         */
+        data class PremiumUpgradePendingUpdateReceive(
+            val isPending: Boolean,
         ) : Internal()
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -25,6 +25,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStat
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionInfo
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
+import com.x8bit.bitwarden.data.billing.repository.model.UpgradeLifecycleState
 import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
@@ -92,8 +93,8 @@ class PlanViewModel @Inject constructor(
                     checkoutUrl = null,
                     isAwaitingPremiumStatus = false,
                     isPremiumUpgradePending = premiumStateManager
-                        .isPremiumUpgradePendingFlow
-                        .value,
+                        .lifecycleStateFlow
+                        .value is UpgradeLifecycleState.UpgradePending,
                 )
             },
             dialogState = null,
@@ -128,8 +129,8 @@ class PlanViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         premiumStateManager
-            .isPremiumUpgradePendingFlow
-            .map { PlanAction.Internal.PremiumUpgradePendingUpdateReceive(it) }
+            .lifecycleStateFlow
+            .map { PlanAction.Internal.LifecycleStateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -197,8 +198,8 @@ class PlanViewModel @Inject constructor(
                 handleSubscriptionStatusUpdateReceive(action)
             }
 
-            is PlanAction.Internal.PremiumUpgradePendingUpdateReceive -> {
-                handlePremiumUpgradePendingUpdateReceive(action)
+            is PlanAction.Internal.LifecycleStateReceive -> {
+                handleLifecycleStateReceive(action)
             }
         }
     }
@@ -417,8 +418,8 @@ class PlanViewModel @Inject constructor(
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
                             isPremiumUpgradePending = premiumStateManager
-                                .isPremiumUpgradePendingFlow
-                                .value,
+                                .lifecycleStateFlow
+                                .value is UpgradeLifecycleState.UpgradePending,
                         ),
                         dialogState = PlanState.DialogState.Loading(
                             message = BitwardenString.loading.asText(),
@@ -449,15 +450,16 @@ class PlanViewModel @Inject constructor(
         }
     }
 
-    private fun handlePremiumUpgradePendingUpdateReceive(
-        action: PlanAction.Internal.PremiumUpgradePendingUpdateReceive,
+    private fun handleLifecycleStateReceive(
+        action: PlanAction.Internal.LifecycleStateReceive,
     ) {
+        val isPending = action.state is UpgradeLifecycleState.UpgradePending
         onFreeCloudContent { freeState ->
-            if (freeState.isPremiumUpgradePending == action.isPending) return@onFreeCloudContent
+            if (freeState.isPremiumUpgradePending == isPending) return@onFreeCloudContent
             mutableStateFlow.update {
                 it.copy(
                     viewState = freeState.copy(
-                        isPremiumUpgradePending = action.isPending,
+                        isPremiumUpgradePending = isPending,
                     ),
                 )
             }
@@ -1134,10 +1136,10 @@ sealed class PlanAction {
         ) : Internal()
 
         /**
-         * The shared "Premium upgrade pending" flag for the active user has updated.
+         * The shared [UpgradeLifecycleState] for the active user has updated.
          */
-        data class PremiumUpgradePendingUpdateReceive(
-            val isPending: Boolean,
+        data class LifecycleStateReceive(
+            val state: UpgradeLifecycleState,
         ) : Internal()
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -726,55 +726,57 @@ class PremiumStateManagerTest {
     }
 
     @Test
-    fun `lifecycleStateFlow emits Free when nothing has been observed`() = runTest {
+    fun `upgradeLifecycleStateFlow emits Free when nothing has been observed`() = runTest {
         val manager = createManager()
-        manager.lifecycleStateFlow.test {
+        manager.upgradeLifecycleStateFlow.test {
             assertEquals(UpgradeLifecycleState.Free, awaitItem())
         }
     }
 
     @Test
-    fun `lifecycleStateFlow emits Free when there is no active user`() = runTest {
+    fun `upgradeLifecycleStateFlow emits Free when there is no active user`() = runTest {
         fakeAuthDiskSource.userState = null
         val manager = createManager()
-        manager.lifecycleStateFlow.test {
+        manager.upgradeLifecycleStateFlow.test {
             assertEquals(UpgradeLifecycleState.Free, awaitItem())
         }
     }
 
     @Test
-    fun `markPremiumUpgradePending transitions lifecycleStateFlow to UpgradePending`() = runTest {
-        val manager = createManager()
-        manager.lifecycleStateFlow.test {
-            assertEquals(UpgradeLifecycleState.Free, awaitItem())
-            manager.markPremiumUpgradePending(userId = ACTIVE_USER_ID)
-            assertEquals(UpgradeLifecycleState.UpgradePending, awaitItem())
-            fakeSettingsDiskSource.assertPremiumUpgradePending(
-                userId = ACTIVE_USER_ID,
-                expected = true,
-            )
+    fun `markPremiumUpgradePending transitions upgradeLifecycleStateFlow to UpgradePending`() =
+        runTest {
+            val manager = createManager()
+            manager.upgradeLifecycleStateFlow.test {
+                assertEquals(UpgradeLifecycleState.Free, awaitItem())
+                manager.markPremiumUpgradePending(userId = ACTIVE_USER_ID)
+                assertEquals(UpgradeLifecycleState.UpgradePending, awaitItem())
+                fakeSettingsDiskSource.assertPremiumUpgradePending(
+                    userId = ACTIVE_USER_ID,
+                    expected = true,
+                )
+            }
         }
-    }
 
     @Test
-    fun `lifecycleStateFlow emits Premium when the active user holds personal Premium`() = runTest {
-        fakeAuthDiskSource.userState = userStateJsonWith(
-            account = createAccountJson(hasPremiumPersonally = true),
-        )
-        val manager = createManager()
-        manager.lifecycleStateFlow.test {
-            assertEquals(
-                UpgradeLifecycleState.Premium(
-                    subscriptionStatus = SubscriptionStatusState.NoSubscription,
-                ),
-                awaitItem(),
+    fun `upgradeLifecycleStateFlow emits Premium when the active user holds personal Premium`() =
+        runTest {
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(hasPremiumPersonally = true),
             )
+            val manager = createManager()
+            manager.upgradeLifecycleStateFlow.test {
+                assertEquals(
+                    UpgradeLifecycleState.Premium(
+                        subscriptionStatus = SubscriptionStatusState.NoSubscription,
+                    ),
+                    awaitItem(),
+                )
+            }
         }
-    }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `lifecycleStateFlow re-keys on active user change and only reflects the active user's flag`() =
+    fun `upgradeLifecycleStateFlow re-keys on active user change and only reflects the active user's flag`() =
         runTest {
             val otherUserId = "otherUserId"
             fakeSettingsDiskSource.storePremiumUpgradePending(
@@ -782,7 +784,7 @@ class PremiumStateManagerTest {
                 isPending = true,
             )
             val manager = createManager()
-            manager.lifecycleStateFlow.test {
+            manager.upgradeLifecycleStateFlow.test {
                 assertEquals(UpgradeLifecycleState.UpgradePending, awaitItem())
                 // Switching active user — the other user has no pending flag set.
                 fakeAuthDiskSource.userState = userStateJsonWith(
@@ -794,7 +796,7 @@ class PremiumStateManagerTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `userState transition from non-Premium to personal Premium transitions lifecycleStateFlow to Premium and clears the pending flag`() =
+    fun `userState transition from non-Premium to personal Premium transitions upgradeLifecycleStateFlow to Premium and clears the pending flag`() =
         runTest {
             // Free user with a pending upgrade in flight.
             fakeAuthDiskSource.userState = userStateJsonWith(account = createAccountJson())
@@ -803,7 +805,7 @@ class PremiumStateManagerTest {
                 isPending = true,
             )
             val manager = createManager()
-            manager.lifecycleStateFlow.test {
+            manager.upgradeLifecycleStateFlow.test {
                 assertEquals(UpgradeLifecycleState.UpgradePending, awaitItem())
                 // Server flips personal Premium on — lifecycle transitions to Premium, the
                 // disk-backed pending flag auto-clears via the manager's init block.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -725,6 +725,121 @@ class PremiumStateManagerTest {
     }
 
     @Test
+    fun `isPremiumUpgradePendingFlow emits false when nothing has been observed`() = runTest {
+        val manager = createManager()
+        manager.isPremiumUpgradePendingFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `isPremiumUpgradePendingFlow emits false when there is no active user`() = runTest {
+        fakeAuthDiskSource.userState = null
+        val manager = createManager()
+        manager.isPremiumUpgradePendingFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `markPremiumUpgradePending stores true and isPremiumUpgradePendingFlow emits true`() =
+        runTest {
+            val manager = createManager()
+            manager.isPremiumUpgradePendingFlow.test {
+                assertFalse(awaitItem())
+                manager.markPremiumUpgradePending(userId = ACTIVE_USER_ID)
+                assertTrue(awaitItem())
+                fakeSettingsDiskSource.assertPremiumUpgradePending(
+                    userId = ACTIVE_USER_ID,
+                    expected = true,
+                )
+            }
+        }
+
+    @Test
+    fun `clearPremiumUpgradePending writes false and isPremiumUpgradePendingFlow emits false`() =
+        runTest {
+            fakeSettingsDiskSource.storePremiumUpgradePending(
+                userId = ACTIVE_USER_ID,
+                isPending = true,
+            )
+            val manager = createManager()
+            manager.isPremiumUpgradePendingFlow.test {
+                assertTrue(awaitItem())
+                manager.clearPremiumUpgradePending(userId = ACTIVE_USER_ID)
+                assertFalse(awaitItem())
+                fakeSettingsDiskSource.assertPremiumUpgradePending(
+                    userId = ACTIVE_USER_ID,
+                    expected = false,
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `isPremiumUpgradePendingFlow re-keys on active user change and only reflects the active user's flag`() =
+        runTest {
+            val otherUserId = "otherUserId"
+            fakeSettingsDiskSource.storePremiumUpgradePending(
+                userId = ACTIVE_USER_ID,
+                isPending = true,
+            )
+            val manager = createManager()
+            manager.isPremiumUpgradePendingFlow.test {
+                assertTrue(awaitItem())
+                // Switching active user — the other user has no pending flag set.
+                fakeAuthDiskSource.userState = userStateJsonWith(
+                    account = createAccountJson(userId = otherUserId),
+                )
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `userState transition from non-Premium to personal Premium clears the pending upgrade flag`() =
+        runTest {
+            // Free user with a pending upgrade in flight.
+            fakeAuthDiskSource.userState = userStateJsonWith(account = createAccountJson())
+            fakeSettingsDiskSource.storePremiumUpgradePending(
+                userId = ACTIVE_USER_ID,
+                isPending = true,
+            )
+            val manager = createManager()
+            manager.isPremiumUpgradePendingFlow.test {
+                assertTrue(awaitItem())
+                // Server flips personal Premium on — pending should auto-clear.
+                fakeAuthDiskSource.userState = userStateJsonWith(
+                    account = createAccountJson(hasPremiumPersonally = true),
+                )
+                assertFalse(awaitItem())
+                fakeSettingsDiskSource.assertPremiumUpgradePending(
+                    userId = ACTIVE_USER_ID,
+                    expected = false,
+                )
+            }
+        }
+
+    @Test
+    fun `banner is ineligible while the active user has a pending Premium upgrade`() = runTest {
+        // Baseline: banner is eligible (the default DEFAULT_USER_STATE_JSON satisfies all gates).
+        fakeSettingsDiskSource.storePremiumUpgradePending(
+            userId = ACTIVE_USER_ID,
+            isPending = true,
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+            // Clearing pending re-enables the banner.
+            fakeSettingsDiskSource.storePremiumUpgradePending(
+                userId = ACTIVE_USER_ID,
+                isPending = false,
+            )
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
     fun `subscriptionStatusStateFlow emits NoSubscription when there is no active user`() =
         runTest {
             fakeAuthDiskSource.userState = null

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -818,7 +818,7 @@ class PremiumStateManagerTest {
                 )
                 fakeSettingsDiskSource.assertPremiumUpgradePending(
                     userId = ACTIVE_USER_ID,
-                    expected = false,
+                    expected = null,
                 )
             }
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -16,6 +16,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStat
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionInfo
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
+import com.x8bit.bitwarden.data.billing.repository.model.UpgradeLifecycleState
 import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
@@ -725,59 +726,55 @@ class PremiumStateManagerTest {
     }
 
     @Test
-    fun `isPremiumUpgradePendingFlow emits false when nothing has been observed`() = runTest {
+    fun `lifecycleStateFlow emits Free when nothing has been observed`() = runTest {
         val manager = createManager()
-        manager.isPremiumUpgradePendingFlow.test {
-            assertFalse(awaitItem())
+        manager.lifecycleStateFlow.test {
+            assertEquals(UpgradeLifecycleState.Free, awaitItem())
         }
     }
 
     @Test
-    fun `isPremiumUpgradePendingFlow emits false when there is no active user`() = runTest {
+    fun `lifecycleStateFlow emits Free when there is no active user`() = runTest {
         fakeAuthDiskSource.userState = null
         val manager = createManager()
-        manager.isPremiumUpgradePendingFlow.test {
-            assertFalse(awaitItem())
+        manager.lifecycleStateFlow.test {
+            assertEquals(UpgradeLifecycleState.Free, awaitItem())
         }
     }
 
     @Test
-    fun `markPremiumUpgradePending stores true and isPremiumUpgradePendingFlow emits true`() =
-        runTest {
-            val manager = createManager()
-            manager.isPremiumUpgradePendingFlow.test {
-                assertFalse(awaitItem())
-                manager.markPremiumUpgradePending(userId = ACTIVE_USER_ID)
-                assertTrue(awaitItem())
-                fakeSettingsDiskSource.assertPremiumUpgradePending(
-                    userId = ACTIVE_USER_ID,
-                    expected = true,
-                )
-            }
+    fun `markPremiumUpgradePending transitions lifecycleStateFlow to UpgradePending`() = runTest {
+        val manager = createManager()
+        manager.lifecycleStateFlow.test {
+            assertEquals(UpgradeLifecycleState.Free, awaitItem())
+            manager.markPremiumUpgradePending(userId = ACTIVE_USER_ID)
+            assertEquals(UpgradeLifecycleState.UpgradePending, awaitItem())
+            fakeSettingsDiskSource.assertPremiumUpgradePending(
+                userId = ACTIVE_USER_ID,
+                expected = true,
+            )
         }
+    }
 
     @Test
-    fun `clearPremiumUpgradePending writes false and isPremiumUpgradePendingFlow emits false`() =
-        runTest {
-            fakeSettingsDiskSource.storePremiumUpgradePending(
-                userId = ACTIVE_USER_ID,
-                isPending = true,
+    fun `lifecycleStateFlow emits Premium when the active user holds personal Premium`() = runTest {
+        fakeAuthDiskSource.userState = userStateJsonWith(
+            account = createAccountJson(hasPremiumPersonally = true),
+        )
+        val manager = createManager()
+        manager.lifecycleStateFlow.test {
+            assertEquals(
+                UpgradeLifecycleState.Premium(
+                    subscriptionStatus = SubscriptionStatusState.NoSubscription,
+                ),
+                awaitItem(),
             )
-            val manager = createManager()
-            manager.isPremiumUpgradePendingFlow.test {
-                assertTrue(awaitItem())
-                manager.clearPremiumUpgradePending(userId = ACTIVE_USER_ID)
-                assertFalse(awaitItem())
-                fakeSettingsDiskSource.assertPremiumUpgradePending(
-                    userId = ACTIVE_USER_ID,
-                    expected = false,
-                )
-            }
         }
+    }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `isPremiumUpgradePendingFlow re-keys on active user change and only reflects the active user's flag`() =
+    fun `lifecycleStateFlow re-keys on active user change and only reflects the active user's flag`() =
         runTest {
             val otherUserId = "otherUserId"
             fakeSettingsDiskSource.storePremiumUpgradePending(
@@ -785,19 +782,19 @@ class PremiumStateManagerTest {
                 isPending = true,
             )
             val manager = createManager()
-            manager.isPremiumUpgradePendingFlow.test {
-                assertTrue(awaitItem())
+            manager.lifecycleStateFlow.test {
+                assertEquals(UpgradeLifecycleState.UpgradePending, awaitItem())
                 // Switching active user — the other user has no pending flag set.
                 fakeAuthDiskSource.userState = userStateJsonWith(
                     account = createAccountJson(userId = otherUserId),
                 )
-                assertFalse(awaitItem())
+                assertEquals(UpgradeLifecycleState.Free, awaitItem())
             }
         }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `userState transition from non-Premium to personal Premium clears the pending upgrade flag`() =
+    fun `userState transition from non-Premium to personal Premium transitions lifecycleStateFlow to Premium and clears the pending flag`() =
         runTest {
             // Free user with a pending upgrade in flight.
             fakeAuthDiskSource.userState = userStateJsonWith(account = createAccountJson())
@@ -806,13 +803,19 @@ class PremiumStateManagerTest {
                 isPending = true,
             )
             val manager = createManager()
-            manager.isPremiumUpgradePendingFlow.test {
-                assertTrue(awaitItem())
-                // Server flips personal Premium on — pending should auto-clear.
+            manager.lifecycleStateFlow.test {
+                assertEquals(UpgradeLifecycleState.UpgradePending, awaitItem())
+                // Server flips personal Premium on — lifecycle transitions to Premium, the
+                // disk-backed pending flag auto-clears via the manager's init block.
                 fakeAuthDiskSource.userState = userStateJsonWith(
                     account = createAccountJson(hasPremiumPersonally = true),
                 )
-                assertFalse(awaitItem())
+                assertEquals(
+                    UpgradeLifecycleState.Premium(
+                        subscriptionStatus = SubscriptionStatusState.NoSubscription,
+                    ),
+                    awaitItem(),
+                )
                 fakeSettingsDiskSource.assertPremiumUpgradePending(
                     userId = ACTIVE_USER_ID,
                     expected = false,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -154,6 +154,10 @@ class SettingsDiskSourceTest {
             userId = userId,
             isPending = true,
         )
+        settingsDiskSource.storePremiumUpgradePending(
+            userId = userId,
+            isPending = true,
+        )
         settingsDiskSource.storeInlineAutofillEnabled(
             userId = userId,
             isInlineAutofillEnabled = true,
@@ -195,6 +199,9 @@ class SettingsDiskSourceTest {
         )
         assertTrue(
             settingsDiskSource.getUpgradedToPremiumCardPending(userId = userId) ?: false,
+        )
+        assertTrue(
+            settingsDiskSource.getPremiumUpgradePending(userId = userId) ?: false,
         )
 
         // These should be cleared
@@ -952,6 +959,72 @@ class SettingsDiskSourceTest {
                         isPending = true,
                     )
                     assertEquals(true, awaitItem())
+                }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getPremiumUpgradePending when values are present should pull from SharedPreferences`() {
+        val baseKey = "bwPreferencesStorage:premiumUpgradePending"
+        val mockUserId = "mockUserId"
+        val key = "${baseKey}_$mockUserId"
+        assertNull(settingsDiskSource.getPremiumUpgradePending(userId = mockUserId))
+        fakeSharedPreferences.edit { putBoolean(key, true) }
+        assertEquals(
+            true,
+            settingsDiskSource.getPremiumUpgradePending(userId = mockUserId),
+        )
+    }
+
+    @Test
+    fun `storePremiumUpgradePending for non-null values should update SharedPreferences`() {
+        val baseKey = "bwPreferencesStorage:premiumUpgradePending"
+        val mockUserId = "mockUserId"
+        val key = "${baseKey}_$mockUserId"
+        settingsDiskSource.storePremiumUpgradePending(
+            userId = mockUserId,
+            isPending = true,
+        )
+        assertTrue(fakeSharedPreferences.getBoolean(key, false))
+    }
+
+    @Test
+    fun `storePremiumUpgradePending for null values should clear SharedPreferences`() {
+        val baseKey = "bwPreferencesStorage:premiumUpgradePending"
+        val mockUserId = "mockUserId"
+        val key = "${baseKey}_$mockUserId"
+        fakeSharedPreferences.edit { putBoolean(key, true) }
+        settingsDiskSource.storePremiumUpgradePending(
+            userId = mockUserId,
+            isPending = null,
+        )
+        assertFalse(fakeSharedPreferences.contains(key))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getPremiumUpgradePendingFlow should react to changes in storePremiumUpgradePending`() =
+        runTest {
+            val mockUserId = "mockUserId"
+            settingsDiskSource
+                .getPremiumUpgradePendingFlow(userId = mockUserId)
+                .test {
+                    assertNull(
+                        settingsDiskSource.getPremiumUpgradePending(userId = mockUserId),
+                    )
+                    assertNull(awaitItem())
+
+                    settingsDiskSource.storePremiumUpgradePending(
+                        userId = mockUserId,
+                        isPending = true,
+                    )
+                    assertEquals(true, awaitItem())
+
+                    settingsDiskSource.storePremiumUpgradePending(
+                        userId = mockUserId,
+                        isPending = false,
+                    )
+                    assertEquals(false, awaitItem())
                 }
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -962,7 +962,6 @@ class SettingsDiskSourceTest {
                 }
         }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `getPremiumUpgradePending when values are present should pull from SharedPreferences`() {
         val baseKey = "bwPreferencesStorage:premiumUpgradePending"
@@ -1001,7 +1000,6 @@ class SettingsDiskSourceTest {
         assertFalse(fakeSharedPreferences.contains(key))
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `getPremiumUpgradePendingFlow should react to changes in storePremiumUpgradePending`() =
         runTest {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -70,6 +70,7 @@ class FakeSettingsDiskSource(
     private var storedPremiumUpgradeBannerDismissed = mutableMapOf<String, Boolean?>()
     private val storedUpgradedToPremiumCardConsumed = mutableMapOf<String, Boolean?>()
     private val storedUpgradedToPremiumCardPending = mutableMapOf<String, Boolean?>()
+    private val storedPremiumUpgradePending = mutableMapOf<String, Boolean?>()
     private val storedInlineAutofillEnabled = mutableMapOf<String, Boolean?>()
     private val storedBlockedAutofillUris = mutableMapOf<String, List<String>?>()
     private var storedIsIconLoadingDisabled: Boolean? = null
@@ -122,6 +123,9 @@ class FakeSettingsDiskSource(
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     private val mutableUpgradedToPremiumCardPendingFlow =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutablePremiumUpgradePendingFlow =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     override var appLanguage: AppLanguage?
@@ -389,6 +393,18 @@ class FakeSettingsDiskSource(
         getMutableUpgradedToPremiumCardPendingFlow(userId = userId)
             .onSubscription { emit(getUpgradedToPremiumCardPending(userId = userId)) }
 
+    override fun getPremiumUpgradePending(userId: String): Boolean? =
+        storedPremiumUpgradePending[userId]
+
+    override fun storePremiumUpgradePending(userId: String, isPending: Boolean?) {
+        storedPremiumUpgradePending[userId] = isPending
+        getMutablePremiumUpgradePendingFlow(userId = userId).tryEmit(isPending)
+    }
+
+    override fun getPremiumUpgradePendingFlow(userId: String): Flow<Boolean?> =
+        getMutablePremiumUpgradePendingFlow(userId = userId)
+            .onSubscription { emit(getPremiumUpgradePending(userId = userId)) }
+
     override fun getInlineAutofillEnabled(userId: String): Boolean? =
         storedInlineAutofillEnabled[userId]
 
@@ -568,6 +584,13 @@ class FakeSettingsDiskSource(
     }
 
     /**
+     * Asserts that the stored "Premium upgrade pending" value matches the [expected] one.
+     */
+    fun assertPremiumUpgradePending(userId: String, expected: Boolean?) {
+        assertEquals(expected, storedPremiumUpgradePending[userId])
+    }
+
+    /**
      * Asserts that the stored last sync time matches the [expected] one.
      */
     fun assertLastSyncTime(userId: String, expected: Instant?) {
@@ -649,6 +672,13 @@ class FakeSettingsDiskSource(
         userId: String,
     ): MutableSharedFlow<Boolean?> =
         mutableUpgradedToPremiumCardPendingFlow.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutablePremiumUpgradePendingFlow(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> =
+        mutablePremiumUpgradePendingFlow.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -1263,6 +1263,7 @@ private val DEFAULT_FREE_STATE = PlanState(
         rate = "$1.65",
         checkoutUrl = null,
         isAwaitingPremiumStatus = false,
+        isPremiumUpgradePending = false,
     ),
     dialogState = null,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -20,6 +20,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStat
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionInfo
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
+import com.x8bit.bitwarden.data.billing.repository.model.UpgradeLifecycleState
 import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
@@ -67,11 +68,12 @@ class PlanViewModelTest : BaseViewModelTest() {
     }
     private val mutableSubscriptionStatusStateFlow =
         MutableStateFlow<SubscriptionStatusState>(SubscriptionStatusState.NoSubscription)
-    private val mutableIsPremiumUpgradePendingFlow = MutableStateFlow(false)
+    private val mutableLifecycleStateFlow =
+        MutableStateFlow<UpgradeLifecycleState>(UpgradeLifecycleState.Free)
     private var mockIsSelfHosted = false
     private val mockPremiumStateManager: PremiumStateManager = mockk(relaxed = true) {
         every { subscriptionStatusStateFlow } returns mutableSubscriptionStatusStateFlow
-        every { isPremiumUpgradePendingFlow } returns mutableIsPremiumUpgradePendingFlow
+        every { lifecycleStateFlow } returns mutableLifecycleStateFlow
         every { isSelfHosted } answers { mockIsSelfHosted }
     }
     private val mutableEnvironmentFlow = MutableStateFlow<Environment>(Environment.Us)
@@ -557,40 +559,34 @@ class PlanViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `ContinueClick dismisses dialog and navigates back without clearing pending flag`() =
-        runTest {
-            val viewModel = createViewModel(
-                initialState = DEFAULT_FREE_STATE.copy(
-                    viewState = PlanState.ViewState.Free.Cloud(
-                        rate = "$1.67",
-                        checkoutUrl = null,
-                        isAwaitingPremiumStatus = true,
-                        isPremiumUpgradePending = true,
-                    ),
-                    dialogState = PlanState.DialogState.PendingUpgrade,
+    fun `ContinueClick dismisses the PendingUpgrade dialog and navigates back`() = runTest {
+        val viewModel = createViewModel(
+            initialState = DEFAULT_FREE_STATE.copy(
+                viewState = PlanState.ViewState.Free.Cloud(
+                    rate = "$1.67",
+                    checkoutUrl = null,
+                    isAwaitingPremiumStatus = true,
+                    isPremiumUpgradePending = true,
                 ),
-                pricingResult = null,
-            )
+                dialogState = PlanState.DialogState.PendingUpgrade,
+            ),
+            pricingResult = null,
+        )
 
-            viewModel.eventFlow.test {
-                viewModel.trySendAction(PlanAction.ContinueClick)
-                assertEquals(PlanEvent.NavigateBack, awaitItem())
-            }
-
-            verify(exactly = 0) {
-                mockPremiumStateManager.clearPremiumUpgradePending(any())
-            }
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(PlanAction.ContinueClick)
+            assertEquals(PlanEvent.NavigateBack, awaitItem())
         }
+    }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `isPremiumUpgradePendingFlow updates propagate onto Free Cloud view state`() = runTest {
+    fun `lifecycleStateFlow updates propagate onto Free Cloud view state`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.stateFlow.test {
             assertEquals(DEFAULT_FREE_STATE, awaitItem())
 
-            mutableIsPremiumUpgradePendingFlow.value = true
+            mutableLifecycleStateFlow.value = UpgradeLifecycleState.UpgradePending
 
             assertEquals(
                 DEFAULT_FREE_STATE.copy(
@@ -604,7 +600,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 awaitItem(),
             )
 
-            mutableIsPremiumUpgradePendingFlow.value = false
+            mutableLifecycleStateFlow.value = UpgradeLifecycleState.Free
 
             assertEquals(DEFAULT_FREE_STATE, awaitItem())
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -557,29 +557,30 @@ class PlanViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `ContinueClick should clear the pending upgrade flag and navigate back`() = runTest {
-        val viewModel = createViewModel(
-            initialState = DEFAULT_FREE_STATE.copy(
-                viewState = PlanState.ViewState.Free.Cloud(
-                    rate = "$1.67",
-                    checkoutUrl = null,
-                    isAwaitingPremiumStatus = true,
-                    isPremiumUpgradePending = true,
+    fun `ContinueClick dismisses dialog and navigates back without clearing pending flag`() =
+        runTest {
+            val viewModel = createViewModel(
+                initialState = DEFAULT_FREE_STATE.copy(
+                    viewState = PlanState.ViewState.Free.Cloud(
+                        rate = "$1.67",
+                        checkoutUrl = null,
+                        isAwaitingPremiumStatus = true,
+                        isPremiumUpgradePending = true,
+                    ),
+                    dialogState = PlanState.DialogState.PendingUpgrade,
                 ),
-                dialogState = PlanState.DialogState.PendingUpgrade,
-            ),
-            pricingResult = null,
-        )
+                pricingResult = null,
+            )
 
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(PlanAction.ContinueClick)
-            assertEquals(PlanEvent.NavigateBack, awaitItem())
-        }
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(PlanAction.ContinueClick)
+                assertEquals(PlanEvent.NavigateBack, awaitItem())
+            }
 
-        verify {
-            mockPremiumStateManager.clearPremiumUpgradePending(userId = DEFAULT_ACCOUNT.userId)
+            verify(exactly = 0) {
+                mockPremiumStateManager.clearPremiumUpgradePending(any())
+            }
         }
-    }
 
     @Suppress("MaxLineLength")
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -73,7 +73,7 @@ class PlanViewModelTest : BaseViewModelTest() {
     private var mockIsSelfHosted = false
     private val mockPremiumStateManager: PremiumStateManager = mockk(relaxed = true) {
         every { subscriptionStatusStateFlow } returns mutableSubscriptionStatusStateFlow
-        every { lifecycleStateFlow } returns mutableLifecycleStateFlow
+        every { upgradeLifecycleStateFlow } returns mutableLifecycleStateFlow
         every { isSelfHosted } answers { mockIsSelfHosted }
     }
     private val mutableEnvironmentFlow = MutableStateFlow<Environment>(Environment.Us)
@@ -580,7 +580,7 @@ class PlanViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `lifecycleStateFlow updates propagate onto Free Cloud view state`() = runTest {
+    fun `upgradeLifecycleStateFlow updates propagate onto Free Cloud view state`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.stateFlow.test {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -67,9 +67,11 @@ class PlanViewModelTest : BaseViewModelTest() {
     }
     private val mutableSubscriptionStatusStateFlow =
         MutableStateFlow<SubscriptionStatusState>(SubscriptionStatusState.NoSubscription)
+    private val mutableIsPremiumUpgradePendingFlow = MutableStateFlow(false)
     private var mockIsSelfHosted = false
-    private val mockPremiumStateManager: PremiumStateManager = mockk {
+    private val mockPremiumStateManager: PremiumStateManager = mockk(relaxed = true) {
         every { subscriptionStatusStateFlow } returns mutableSubscriptionStatusStateFlow
+        every { isPremiumUpgradePendingFlow } returns mutableIsPremiumUpgradePendingFlow
         every { isSelfHosted } answers { mockIsSelfHosted }
     }
     private val mutableEnvironmentFlow = MutableStateFlow<Environment>(Environment.Us)
@@ -144,6 +146,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "$1.67",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = true,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = PlanState.DialogState.WaitingForPayment,
                     ),
@@ -224,6 +227,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "$1.67",
                             checkoutUrl = checkoutUrl,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = null,
                     ),
@@ -314,6 +318,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "$1.67",
                             checkoutUrl = checkoutUrl,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = null,
                     ),
@@ -386,6 +391,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 rate = "$1.67",
                 checkoutUrl = checkoutUrl,
                 isAwaitingPremiumStatus = false,
+                isPremiumUpgradePending = false,
             )
             val viewModel = createViewModel(
                 initialState = DEFAULT_FREE_STATE.copy(
@@ -434,6 +440,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                         rate = "$1.67",
                         checkoutUrl = null,
                         isAwaitingPremiumStatus = true,
+                        isPremiumUpgradePending = false,
                     ),
                     dialogState = PlanState.DialogState.WaitingForPayment,
                 ),
@@ -476,6 +483,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "$1.67",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = true,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = PlanState.DialogState.WaitingForPayment,
                     ),
@@ -531,6 +539,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "$1.67",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = true,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = PlanState.DialogState.PendingUpgrade,
                     ),
@@ -540,11 +549,65 @@ class PlanViewModelTest : BaseViewModelTest() {
 
             verify {
                 mockSpecialCircumstanceManager.specialCircumstance = null
+                mockPremiumStateManager.markPremiumUpgradePending(userId = DEFAULT_ACCOUNT.userId)
             }
             coVerify {
                 mockVaultRepository.syncForResult(forced = true)
             }
         }
+
+    @Test
+    fun `ContinueClick should clear the pending upgrade flag and navigate back`() = runTest {
+        val viewModel = createViewModel(
+            initialState = DEFAULT_FREE_STATE.copy(
+                viewState = PlanState.ViewState.Free.Cloud(
+                    rate = "$1.67",
+                    checkoutUrl = null,
+                    isAwaitingPremiumStatus = true,
+                    isPremiumUpgradePending = true,
+                ),
+                dialogState = PlanState.DialogState.PendingUpgrade,
+            ),
+            pricingResult = null,
+        )
+
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(PlanAction.ContinueClick)
+            assertEquals(PlanEvent.NavigateBack, awaitItem())
+        }
+
+        verify {
+            mockPremiumStateManager.clearPremiumUpgradePending(userId = DEFAULT_ACCOUNT.userId)
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `isPremiumUpgradePendingFlow updates propagate onto Free Cloud view state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(DEFAULT_FREE_STATE, awaitItem())
+
+            mutableIsPremiumUpgradePendingFlow.value = true
+
+            assertEquals(
+                DEFAULT_FREE_STATE.copy(
+                    viewState = PlanState.ViewState.Free.Cloud(
+                        rate = "$1.67",
+                        checkoutUrl = null,
+                        isAwaitingPremiumStatus = false,
+                        isPremiumUpgradePending = true,
+                    ),
+                ),
+                awaitItem(),
+            )
+
+            mutableIsPremiumUpgradePendingFlow.value = false
+
+            assertEquals(DEFAULT_FREE_STATE, awaitItem())
+        }
+    }
 
     @Test
     fun `UserStateUpdateReceive premium during Loading should navigate to UpgradedToPremium`() =
@@ -555,6 +618,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                         rate = "$1.67",
                         checkoutUrl = null,
                         isAwaitingPremiumStatus = true,
+                        isPremiumUpgradePending = false,
                     ),
                     dialogState = PlanState.DialogState.Loading(
                         message = BitwardenString.confirming_your_upgrade.asText(),
@@ -666,6 +730,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "$1.67",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = null,
                     ),
@@ -694,6 +759,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = null,
                     ),
@@ -719,6 +785,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = PlanState.DialogState.GetPricingError(
                             title = BitwardenString.pricing_unavailable.asText(),
@@ -747,6 +814,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = PlanState.DialogState.GetPricingError(
                             title = BitwardenString.pricing_unavailable.asText(),
@@ -770,6 +838,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = PlanState.DialogState.Loading(
                             message = BitwardenString.loading.asText(),
@@ -801,6 +870,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = PlanState.DialogState.GetPricingError(
                             title = BitwardenString.pricing_unavailable.asText(),
@@ -819,6 +889,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = null,
                     ),
@@ -990,6 +1061,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
+                            isPremiumUpgradePending = false,
                         ),
                         dialogState = PlanState.DialogState.Loading(
                             message = BitwardenString.loading.asText(),
@@ -1705,6 +1777,7 @@ private val DEFAULT_FREE_STATE = PlanState(
         rate = "$1.67",
         checkoutUrl = null,
         isAwaitingPremiumStatus = false,
+        isPremiumUpgradePending = false,
     ),
     dialogState = null,
 )


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37232

## 📔 Objective

When a user completes Stripe checkout and returns to the app, the server-side subscription confirmation can lag the client. During that window the Vault home upgrade banner and the Plan screen Upgrade Now button kept advertising the upgrade we were already processing, which nudged users to start the checkout flow a second time.

Promote the "PendingUpgrade" signal from transient `PlanViewModel` state to a per-user disk-backed flag exposed via `PremiumStateManager`. The banner-eligibility flow now gates on it, the Plan screen hides its Upgrade Now CTA while it is set, and the flag clears when the server flips the active user to Premium. Dismissing the PendingUpgrade dialog is a UI-only action and leaves the pending state intact, so CTAs stay suppressed until the upgrade actually resolves.