### PR TITLE
[PM-37804] fix: Drop redundant Stripe checkout confirmation on Upgrade Now

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -280,7 +280,6 @@ private fun FreeCloudContent(
     handlers: PlanHandlers,
     modifier: Modifier = Modifier,
 ) {
-    var shouldShowUpgradeDialog by rememberSaveable { mutableStateOf(false) }
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -300,28 +299,10 @@ private fun FreeCloudContent(
         // user to Premium.
         if (!viewState.isPremiumUpgradePending) {
             UpgradeNowCallToAction(
-                onUpgradeNowClick = { shouldShowUpgradeDialog = true },
+                onUpgradeNowClick = handlers.onUpgradeNowClick,
             )
         }
         Spacer(modifier = Modifier.navigationBarsPadding())
-    }
-
-    if (shouldShowUpgradeDialog) {
-        BitwardenTwoButtonDialog(
-            title = stringResource(id = BitwardenString.continue_to_stripe),
-            message = stringResource(
-                id = BitwardenString
-                    .youll_go_to_stripes_secure_checkout_to_complete_your_purchase,
-            ),
-            confirmButtonText = stringResource(id = BitwardenString.continue_text),
-            dismissButtonText = stringResource(id = BitwardenString.cancel),
-            onConfirmClick = {
-                shouldShowUpgradeDialog = false
-                handlers.onUpgradeNowClick()
-            },
-            onDismissClick = { shouldShowUpgradeDialog = false },
-            onDismissRequest = { shouldShowUpgradeDialog = false },
-        )
     }
 }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -137,66 +137,14 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `upgrade now button click should show continue to Stripe confirmation dialog`() {
-        composeTestRule
-            .onAllNodesWithText("Continue to Stripe?")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .assertDoesNotExist()
-
+    fun `upgrade now button click should send UpgradeNowClick action`() {
         composeTestRule
             .onNodeWithTag("UpgradeNowButton")
             .performScrollTo()
             .performClick()
-
-        composeTestRule
-            .onAllNodesWithText("Continue to Stripe?")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .assertExists()
-        composeTestRule
-            .onAllNodesWithText(
-                "You’ll go to Stripe’s secure checkout to complete your purchase.",
-            )
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .assertExists()
-        verify(exactly = 0) { viewModel.trySendAction(PlanAction.UpgradeNowClick) }
-    }
-
-    @Test
-    fun `upgrade now dialog continue click should send UpgradeNowClick action and dismiss`() {
-        composeTestRule
-            .onNodeWithTag("UpgradeNowButton")
-            .performScrollTo()
-            .performClick()
-
-        composeTestRule
-            .onAllNodesWithText("Continue")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .performClick()
-
-        verify { viewModel.trySendAction(PlanAction.UpgradeNowClick) }
-        composeTestRule
-            .onAllNodesWithText("Continue to Stripe?")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .assertDoesNotExist()
-    }
-
-    @Test
-    fun `upgrade now dialog cancel click should dismiss without sending action`() {
-        composeTestRule
-            .onNodeWithTag("UpgradeNowButton")
-            .performScrollTo()
-            .performClick()
-
-        composeTestRule
-            .onAllNodesWithText("Cancel")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .performClick()
-
-        verify(exactly = 0) { viewModel.trySendAction(PlanAction.UpgradeNowClick) }
-        composeTestRule
-            .onAllNodesWithText("Continue to Stripe?")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .assertDoesNotExist()
+        verify {
+            viewModel.trySendAction(PlanAction.UpgradeNowClick)
+        }
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

PM-37804
Follow-up to #6958.

## 📔 Objective

The Upgrade Now CTA on the free Premium plan screen already shows the Stripe checkout disclosure directly beneath the button. The confirmation dialog added in #6958 repeated that exact copy verbatim, costing an extra tap without conveying any new information.

This change removes the dialog so the footer is the single, in-context disclosure for that CTA. The Cancel Premium and Manage Plan confirmation dialogs are unaffected; neither has accompanying footer copy, so their dialogs still earn their place.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/495f4f64-3b22-405c-94b5-4c3e073a1df0" />| <video src="https://github.com/user-attachments/assets/7fab56ad-2048-41cc-90bf-adfecd83ce58" /> |



