### PR TITLE
[PM-37181] feat: Surface Expired subscription substate

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -336,8 +336,10 @@ private fun SubscriptionStatusState.isInTroubleState(): Boolean =
     this is SubscriptionStatusState.Available &&
         when (this.status) {
             PremiumSubscriptionStatus.CANCELED,
+            PremiumSubscriptionStatus.EXPIRED,
             PremiumSubscriptionStatus.PAST_DUE,
             PremiumSubscriptionStatus.PAUSED,
+            PremiumSubscriptionStatus.UNPAID,
             PremiumSubscriptionStatus.UPDATE_PAYMENT,
                 -> true
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -339,7 +339,6 @@ private fun SubscriptionStatusState.isInTroubleState(): Boolean =
             PremiumSubscriptionStatus.EXPIRED,
             PremiumSubscriptionStatus.PAST_DUE,
             PremiumSubscriptionStatus.PAUSED,
-            PremiumSubscriptionStatus.UNPAID,
             PremiumSubscriptionStatus.UPDATE_PAYMENT,
                 -> true
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumSubscriptionStatus.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumSubscriptionStatus.kt
@@ -20,11 +20,5 @@ enum class PremiumSubscriptionStatus {
     PENDING_CANCELLATION,
     PAST_DUE,
     PAUSED,
-
-    /**
-     * The subscription is delinquent past the grace period and Stripe has stopped attempting
-     * to collect payment. Recoverable only by resolving the outstanding invoices.
-     */
-    UNPAID,
     UPDATE_PAYMENT,
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumSubscriptionStatus.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumSubscriptionStatus.kt
@@ -8,10 +8,23 @@ enum class PremiumSubscriptionStatus {
     CANCELED,
 
     /**
+     * The subscription's initial payment never succeeded and Stripe voided the invoice, so
+     * the subscription never became active. Distinct from [CANCELED], which describes a
+     * subscription that was previously active.
+     */
+    EXPIRED,
+
+    /**
      * The subscription is scheduled to cancel at a future date but is still active until then.
      */
     PENDING_CANCELLATION,
     PAST_DUE,
     PAUSED,
+
+    /**
+     * The subscription is delinquent past the grace period and Stripe has stopped attempting
+     * to collect payment. Recoverable only by resolving the outstanding invoices.
+     */
+    UNPAID,
     UPDATE_PAYMENT,
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
@@ -64,13 +64,13 @@ private fun BitwardenSubscriptionResponseJson.toPremiumSubscriptionStatus():
         }
     }
 
-    SubscriptionStatusJson.CANCELED,
-    SubscriptionStatusJson.UNPAID,
-        -> PremiumSubscriptionStatus.CANCELED
+    SubscriptionStatusJson.CANCELED -> PremiumSubscriptionStatus.CANCELED
 
     SubscriptionStatusJson.INCOMPLETE_EXPIRED -> PremiumSubscriptionStatus.EXPIRED
 
-    SubscriptionStatusJson.INCOMPLETE -> PremiumSubscriptionStatus.UPDATE_PAYMENT
+    SubscriptionStatusJson.INCOMPLETE,
+    SubscriptionStatusJson.UNPAID,
+        -> PremiumSubscriptionStatus.UPDATE_PAYMENT
 
     SubscriptionStatusJson.PAST_DUE -> PremiumSubscriptionStatus.PAST_DUE
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
@@ -67,7 +67,6 @@ private fun BitwardenSubscriptionResponseJson.toPremiumSubscriptionStatus():
     SubscriptionStatusJson.CANCELED -> PremiumSubscriptionStatus.CANCELED
 
     SubscriptionStatusJson.INCOMPLETE_EXPIRED -> PremiumSubscriptionStatus.EXPIRED
-
     SubscriptionStatusJson.INCOMPLETE,
     SubscriptionStatusJson.UNPAID,
         -> PremiumSubscriptionStatus.UPDATE_PAYMENT

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
@@ -64,13 +64,13 @@ private fun BitwardenSubscriptionResponseJson.toPremiumSubscriptionStatus():
         }
     }
 
-    SubscriptionStatusJson.CANCELED,
-    SubscriptionStatusJson.INCOMPLETE_EXPIRED,
-        -> PremiumSubscriptionStatus.CANCELED
+    SubscriptionStatusJson.CANCELED -> PremiumSubscriptionStatus.CANCELED
 
-    SubscriptionStatusJson.INCOMPLETE,
-    SubscriptionStatusJson.UNPAID,
-        -> PremiumSubscriptionStatus.UPDATE_PAYMENT
+    SubscriptionStatusJson.INCOMPLETE_EXPIRED -> PremiumSubscriptionStatus.EXPIRED
+
+    SubscriptionStatusJson.INCOMPLETE -> PremiumSubscriptionStatus.UPDATE_PAYMENT
+
+    SubscriptionStatusJson.UNPAID -> PremiumSubscriptionStatus.UNPAID
 
     SubscriptionStatusJson.PAST_DUE -> PremiumSubscriptionStatus.PAST_DUE
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
@@ -64,13 +64,13 @@ private fun BitwardenSubscriptionResponseJson.toPremiumSubscriptionStatus():
         }
     }
 
-    SubscriptionStatusJson.CANCELED -> PremiumSubscriptionStatus.CANCELED
+    SubscriptionStatusJson.CANCELED,
+    SubscriptionStatusJson.UNPAID,
+        -> PremiumSubscriptionStatus.CANCELED
 
     SubscriptionStatusJson.INCOMPLETE_EXPIRED -> PremiumSubscriptionStatus.EXPIRED
 
     SubscriptionStatusJson.INCOMPLETE -> PremiumSubscriptionStatus.UPDATE_PAYMENT
-
-    SubscriptionStatusJson.UNPAID -> PremiumSubscriptionStatus.UNPAID
 
     SubscriptionStatusJson.PAST_DUE -> PremiumSubscriptionStatus.PAST_DUE
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -790,10 +790,6 @@ private fun subscriptionDescriptionText(
             emphasisHighlightStyle = emphasisStyle,
         )
 
-        PremiumSubscriptionStatus.UNPAID -> AnnotatedString(
-            stringResource(id = BitwardenString.subscription_unpaid_description),
-        )
-
         null -> null
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -4,6 +4,7 @@ package com.x8bit.bitwarden.ui.platform.feature.premium.plan
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -405,7 +406,7 @@ private fun PremiumFeaturesCard(
 }
 
 @Composable
-private fun PremiumFeatureRows() {
+private fun ColumnScope.PremiumFeatureRows() {
     BitwardenHorizontalDivider()
 
     val features = listOf(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -72,6 +72,7 @@ import com.x8bit.bitwarden.ui.platform.composition.LocalAuthTabLaunchers
 import com.x8bit.bitwarden.ui.platform.feature.premium.plan.handlers.PlanHandlers
 import com.x8bit.bitwarden.ui.platform.feature.premium.plan.util.badgeColors
 import com.x8bit.bitwarden.ui.platform.feature.premium.plan.util.labelRes
+import com.x8bit.bitwarden.ui.platform.feature.premium.plan.util.showsFeatureList
 import com.x8bit.bitwarden.ui.platform.model.AuthTabLaunchers
 
 private const val PLACEHOLDER_TEXT: String = "--"
@@ -399,25 +400,30 @@ private fun PremiumFeaturesCard(
                 .standardHorizontalMargin(),
         )
 
-        BitwardenHorizontalDivider()
+        PremiumFeatureRows()
+    }
+}
 
-        val features = listOf(
-            BitwardenString.built_in_authenticator,
-            BitwardenString.emergency_access,
-            BitwardenString.secure_file_storage,
-            BitwardenString.breach_monitoring,
+@Composable
+private fun PremiumFeatureRows() {
+    BitwardenHorizontalDivider()
+
+    val features = listOf(
+        BitwardenString.built_in_authenticator,
+        BitwardenString.emergency_access,
+        BitwardenString.secure_file_storage,
+        BitwardenString.breach_monitoring,
+    )
+    features.forEachIndexed { index, featureStringRes ->
+        BitwardenContentBlock(
+            data = ContentBlockData(
+                headerText = stringResource(id = featureStringRes),
+                iconVectorResource = BitwardenDrawable.ic_check_mark,
+            ),
+            headerTextStyle = BitwardenTheme.typography.titleMedium,
+            showDivider = index != features.lastIndex,
+            modifier = Modifier.padding(vertical = 8.dp),
         )
-        features.forEachIndexed { index, featureStringRes ->
-            BitwardenContentBlock(
-                data = ContentBlockData(
-                    headerText = stringResource(id = featureStringRes),
-                    iconVectorResource = BitwardenDrawable.ic_check_mark,
-                ),
-                headerTextStyle = BitwardenTheme.typography.titleMedium,
-                showDivider = index != features.lastIndex,
-                modifier = Modifier.padding(vertical = 8.dp),
-            )
-        }
     }
 }
 
@@ -568,21 +574,18 @@ private fun PremiumContent(
     }
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun SubscriptionCard(
     viewState: PlanState.ViewState.Premium,
     modifier: Modifier = Modifier,
 ) {
-    val rowModifier = Modifier
-        .fillMaxWidth()
-        .standardHorizontalMargin()
     Column(
         modifier = modifier
             .fillMaxWidth()
             .cardStyle(
                 cardStyle = CardStyle.Full,
-                // Override bottom padding; the final row owns its own spacing.
+                // Override bottom padding; the final row (line item or feature) owns its
+                // own spacing.
                 paddingBottom = 0.dp,
             ),
     ) {
@@ -599,55 +602,70 @@ private fun SubscriptionCard(
                 .standardHorizontalMargin(),
         )
 
-        BitwardenHorizontalDivider()
-
-        SubscriptionLineItem(
-            label = stringResource(id = BitwardenString.billing_amount),
-            value = viewState.billingAmountText(),
-            testTag = "BillingAmountRow",
-            modifier = rowModifier,
-        )
-
-        viewState.storageCostText?.let { storageCostText ->
-            BitwardenHorizontalDivider(modifier = Modifier.padding(start = 16.dp))
-            SubscriptionLineItem(
-                label = stringResource(id = BitwardenString.storage_cost),
-                value = storageCostText,
-                testTag = "StorageCostRow",
-                modifier = rowModifier,
-            )
+        if (viewState.status?.showsFeatureList() == true) {
+            PremiumFeatureRows()
+        } else {
+            SubscriptionLineItems(viewState = viewState)
         }
+    }
+}
 
-        viewState.discountAmountText?.let { discountAmountText ->
-            BitwardenHorizontalDivider(modifier = Modifier.padding(start = 16.dp))
-            SubscriptionLineItem(
-                label = stringResource(id = BitwardenString.discount),
-                value = discountAmountText,
-                testTag = "DiscountRow",
-                modifier = rowModifier,
-                valueColor = BitwardenTheme.colorScheme.statusBadge.success.text,
-            )
-        }
+@Composable
+private fun SubscriptionLineItems(
+    viewState: PlanState.ViewState.Premium,
+) {
+    val rowModifier = Modifier
+        .fillMaxWidth()
+        .standardHorizontalMargin()
 
+    BitwardenHorizontalDivider()
+
+    SubscriptionLineItem(
+        label = stringResource(id = BitwardenString.billing_amount),
+        value = viewState.billingAmountText(),
+        testTag = "BillingAmountRow",
+        modifier = rowModifier,
+    )
+
+    viewState.storageCostText?.let { storageCostText ->
         BitwardenHorizontalDivider(modifier = Modifier.padding(start = 16.dp))
-
         SubscriptionLineItem(
-            label = stringResource(id = BitwardenString.estimated_tax),
-            value = viewState.estimatedTaxText,
-            testTag = "EstimatedTaxRow",
+            label = stringResource(id = BitwardenString.storage_cost),
+            value = storageCostText,
+            testTag = "StorageCostRow",
             modifier = rowModifier,
-        )
-
-        BitwardenHorizontalDivider(modifier = Modifier.padding(start = 16.dp))
-
-        SubscriptionLineItem(
-            label = stringResource(id = BitwardenString.total),
-            value = viewState.totalText(),
-            testTag = "TotalRow",
-            modifier = rowModifier,
-            labelStyle = BitwardenTheme.typography.bodyLargeEmphasis,
         )
     }
+
+    viewState.discountAmountText?.let { discountAmountText ->
+        BitwardenHorizontalDivider(modifier = Modifier.padding(start = 16.dp))
+        SubscriptionLineItem(
+            label = stringResource(id = BitwardenString.discount),
+            value = discountAmountText,
+            testTag = "DiscountRow",
+            modifier = rowModifier,
+            valueColor = BitwardenTheme.colorScheme.statusBadge.success.text,
+        )
+    }
+
+    BitwardenHorizontalDivider(modifier = Modifier.padding(start = 16.dp))
+
+    SubscriptionLineItem(
+        label = stringResource(id = BitwardenString.estimated_tax),
+        value = viewState.estimatedTaxText,
+        testTag = "EstimatedTaxRow",
+        modifier = rowModifier,
+    )
+
+    BitwardenHorizontalDivider(modifier = Modifier.padding(start = 16.dp))
+
+    SubscriptionLineItem(
+        label = stringResource(id = BitwardenString.total),
+        value = viewState.totalText(),
+        testTag = "TotalRow",
+        modifier = rowModifier,
+        labelStyle = BitwardenTheme.typography.bodyLargeEmphasis,
+    )
 }
 
 @Composable
@@ -698,7 +716,7 @@ private fun SubscriptionHeader(
     }
 }
 
-@Suppress("CyclomaticComplexMethod")
+@Suppress("CyclomaticComplexMethod", "LongMethod")
 @Composable
 private fun subscriptionDescriptionText(
     status: PremiumSubscriptionStatus?,
@@ -763,6 +781,17 @@ private fun subscriptionDescriptionText(
 
         PremiumSubscriptionStatus.PAUSED -> AnnotatedString(
             stringResource(id = BitwardenString.subscription_paused_description),
+        )
+
+        PremiumSubscriptionStatus.EXPIRED -> annotatedStringResource(
+            id = BitwardenString.subscription_expired_description,
+            args = arrayOf(suspensionDateText ?: PLACEHOLDER_TEXT),
+            style = baseStyle,
+            emphasisHighlightStyle = emphasisStyle,
+        )
+
+        PremiumSubscriptionStatus.UNPAID -> AnnotatedString(
+            stringResource(id = BitwardenString.subscription_unpaid_description),
         )
 
         null -> null

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -1129,7 +1129,9 @@ sealed class PlanAction {
  */
 private fun PremiumSubscriptionStatus.canBeCanceled(): Boolean = when (this) {
     PremiumSubscriptionStatus.CANCELED,
+    PremiumSubscriptionStatus.EXPIRED,
     PremiumSubscriptionStatus.PENDING_CANCELLATION,
+    PremiumSubscriptionStatus.UNPAID,
         -> false
 
     PremiumSubscriptionStatus.ACTIVE,
@@ -1147,9 +1149,11 @@ private fun PremiumSubscriptionStatus.canBeCanceled(): Boolean = when (this) {
  */
 private fun PremiumSubscriptionStatus.isPremiumViewEligible(): Boolean = when (this) {
     PremiumSubscriptionStatus.CANCELED,
+    PremiumSubscriptionStatus.EXPIRED,
     PremiumSubscriptionStatus.PAST_DUE,
     PremiumSubscriptionStatus.PAUSED,
     PremiumSubscriptionStatus.PENDING_CANCELLATION,
+    PremiumSubscriptionStatus.UNPAID,
     PremiumSubscriptionStatus.UPDATE_PAYMENT,
         -> true
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -1131,7 +1131,6 @@ private fun PremiumSubscriptionStatus.canBeCanceled(): Boolean = when (this) {
     PremiumSubscriptionStatus.CANCELED,
     PremiumSubscriptionStatus.EXPIRED,
     PremiumSubscriptionStatus.PENDING_CANCELLATION,
-    PremiumSubscriptionStatus.UNPAID,
         -> false
 
     PremiumSubscriptionStatus.ACTIVE,
@@ -1153,7 +1152,6 @@ private fun PremiumSubscriptionStatus.isPremiumViewEligible(): Boolean = when (t
     PremiumSubscriptionStatus.PAST_DUE,
     PremiumSubscriptionStatus.PAUSED,
     PremiumSubscriptionStatus.PENDING_CANCELLATION,
-    PremiumSubscriptionStatus.UNPAID,
     PremiumSubscriptionStatus.UPDATE_PAYMENT,
         -> true
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/util/PremiumSubscriptionStatusExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/util/PremiumSubscriptionStatusExtensions.kt
@@ -14,13 +14,34 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStat
 fun PremiumSubscriptionStatus.labelRes(): Int = when (this) {
     PremiumSubscriptionStatus.ACTIVE -> BitwardenString.subscription_status_active
     PremiumSubscriptionStatus.CANCELED -> BitwardenString.subscription_status_canceled
+    PremiumSubscriptionStatus.EXPIRED -> BitwardenString.subscription_status_expired
     PremiumSubscriptionStatus.PENDING_CANCELLATION -> {
         BitwardenString.subscription_status_pending_cancellation
     }
 
     PremiumSubscriptionStatus.PAST_DUE -> BitwardenString.subscription_status_past_due
     PremiumSubscriptionStatus.PAUSED -> BitwardenString.subscription_status_paused
+    PremiumSubscriptionStatus.UNPAID -> BitwardenString.subscription_status_unpaid
     PremiumSubscriptionStatus.UPDATE_PAYMENT -> BitwardenString.subscription_status_update_payment
+}
+
+/**
+ * Returns `true` when the Premium plan card should replace its billing line items with the
+ * premium feature list. Reserved for terminal states where line items carry no actionable
+ * information and the user's path forward is to resubscribe.
+ */
+fun PremiumSubscriptionStatus.showsFeatureList(): Boolean = when (this) {
+    PremiumSubscriptionStatus.CANCELED,
+    PremiumSubscriptionStatus.EXPIRED,
+        -> true
+
+    PremiumSubscriptionStatus.ACTIVE,
+    PremiumSubscriptionStatus.PAST_DUE,
+    PremiumSubscriptionStatus.PAUSED,
+    PremiumSubscriptionStatus.PENDING_CANCELLATION,
+    PremiumSubscriptionStatus.UNPAID,
+    PremiumSubscriptionStatus.UPDATE_PAYMENT,
+        -> false
 }
 
 /**
@@ -31,7 +52,11 @@ fun PremiumSubscriptionStatus.labelRes(): Int = when (this) {
 fun PremiumSubscriptionStatus.badgeColors(): BitwardenColorScheme.StatusBadgeVariantColors =
     when (this) {
         PremiumSubscriptionStatus.ACTIVE -> BitwardenTheme.colorScheme.statusBadge.success
-        PremiumSubscriptionStatus.CANCELED -> BitwardenTheme.colorScheme.statusBadge.error
+        PremiumSubscriptionStatus.CANCELED,
+        PremiumSubscriptionStatus.EXPIRED,
+        PremiumSubscriptionStatus.UNPAID,
+            -> BitwardenTheme.colorScheme.statusBadge.error
+
         PremiumSubscriptionStatus.PAST_DUE,
         PremiumSubscriptionStatus.PAUSED,
         PremiumSubscriptionStatus.PENDING_CANCELLATION,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/util/PremiumSubscriptionStatusExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/util/PremiumSubscriptionStatusExtensions.kt
@@ -21,7 +21,6 @@ fun PremiumSubscriptionStatus.labelRes(): Int = when (this) {
 
     PremiumSubscriptionStatus.PAST_DUE -> BitwardenString.subscription_status_past_due
     PremiumSubscriptionStatus.PAUSED -> BitwardenString.subscription_status_paused
-    PremiumSubscriptionStatus.UNPAID -> BitwardenString.subscription_status_unpaid
     PremiumSubscriptionStatus.UPDATE_PAYMENT -> BitwardenString.subscription_status_update_payment
 }
 
@@ -39,7 +38,6 @@ fun PremiumSubscriptionStatus.showsFeatureList(): Boolean = when (this) {
     PremiumSubscriptionStatus.PAST_DUE,
     PremiumSubscriptionStatus.PAUSED,
     PremiumSubscriptionStatus.PENDING_CANCELLATION,
-    PremiumSubscriptionStatus.UNPAID,
     PremiumSubscriptionStatus.UPDATE_PAYMENT,
         -> false
 }
@@ -54,7 +52,6 @@ fun PremiumSubscriptionStatus.badgeColors(): BitwardenColorScheme.StatusBadgeVar
         PremiumSubscriptionStatus.ACTIVE -> BitwardenTheme.colorScheme.statusBadge.success
         PremiumSubscriptionStatus.CANCELED,
         PremiumSubscriptionStatus.EXPIRED,
-        PremiumSubscriptionStatus.UNPAID,
             -> BitwardenTheme.colorScheme.statusBadge.error
 
         PremiumSubscriptionStatus.PAST_DUE,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -918,7 +918,6 @@ class PremiumStateManagerTest {
             PremiumSubscriptionStatus.EXPIRED,
             PremiumSubscriptionStatus.PAST_DUE,
             PremiumSubscriptionStatus.PAUSED,
-            PremiumSubscriptionStatus.UNPAID,
             PremiumSubscriptionStatus.UPDATE_PAYMENT,
         ).forEach { status ->
             fakeAuthDiskSource.userState = userStateJsonWith(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -915,8 +915,10 @@ class PremiumStateManagerTest {
     fun `banner eligible when account is premium but status is in a trouble state`() = runTest {
         listOf(
             PremiumSubscriptionStatus.CANCELED,
+            PremiumSubscriptionStatus.EXPIRED,
             PremiumSubscriptionStatus.PAST_DUE,
             PremiumSubscriptionStatus.PAUSED,
+            PremiumSubscriptionStatus.UNPAID,
             PremiumSubscriptionStatus.UPDATE_PAYMENT,
         ).forEach { status ->
             fakeAuthDiskSource.userState = userStateJsonWith(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
@@ -28,11 +28,11 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
     }
 
     @Test
-    fun `toSubscriptionInfo maps CANCELED and UNPAID to CANCELED`() {
-        listOf(SubscriptionStatusJson.CANCELED, SubscriptionStatusJson.UNPAID).forEach {
-            val info = buildResponse(status = it).toSubscriptionInfo()
-            assertEquals(PremiumSubscriptionStatus.CANCELED, info.status)
-        }
+    fun `toSubscriptionInfo maps CANCELED to CANCELED`() {
+        val info = buildResponse(
+            status = SubscriptionStatusJson.CANCELED,
+        ).toSubscriptionInfo()
+        assertEquals(PremiumSubscriptionStatus.CANCELED, info.status)
     }
 
     @Test
@@ -44,11 +44,11 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
     }
 
     @Test
-    fun `toSubscriptionInfo maps INCOMPLETE to UPDATE_PAYMENT`() {
-        val info = buildResponse(
-            status = SubscriptionStatusJson.INCOMPLETE,
-        ).toSubscriptionInfo()
-        assertEquals(PremiumSubscriptionStatus.UPDATE_PAYMENT, info.status)
+    fun `toSubscriptionInfo maps INCOMPLETE and UNPAID to UPDATE_PAYMENT`() {
+        listOf(SubscriptionStatusJson.INCOMPLETE, SubscriptionStatusJson.UNPAID).forEach {
+            val info = buildResponse(status = it).toSubscriptionInfo()
+            assertEquals(PremiumSubscriptionStatus.UPDATE_PAYMENT, info.status)
+        }
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
@@ -34,19 +34,27 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
     }
 
     @Test
-    fun `toSubscriptionInfo maps INCOMPLETE_EXPIRED to CANCELED`() {
+    fun `toSubscriptionInfo maps INCOMPLETE_EXPIRED to EXPIRED`() {
         val info = buildResponse(
             status = SubscriptionStatusJson.INCOMPLETE_EXPIRED,
         ).toSubscriptionInfo()
-        assertEquals(PremiumSubscriptionStatus.CANCELED, info.status)
+        assertEquals(PremiumSubscriptionStatus.EXPIRED, info.status)
     }
 
     @Test
-    fun `toSubscriptionInfo maps INCOMPLETE and UNPAID to UPDATE_PAYMENT`() {
-        listOf(SubscriptionStatusJson.INCOMPLETE, SubscriptionStatusJson.UNPAID).forEach {
-            val info = buildResponse(status = it).toSubscriptionInfo()
-            assertEquals(PremiumSubscriptionStatus.UPDATE_PAYMENT, info.status)
-        }
+    fun `toSubscriptionInfo maps INCOMPLETE to UPDATE_PAYMENT`() {
+        val info = buildResponse(
+            status = SubscriptionStatusJson.INCOMPLETE,
+        ).toSubscriptionInfo()
+        assertEquals(PremiumSubscriptionStatus.UPDATE_PAYMENT, info.status)
+    }
+
+    @Test
+    fun `toSubscriptionInfo maps UNPAID to UNPAID`() {
+        val info = buildResponse(
+            status = SubscriptionStatusJson.UNPAID,
+        ).toSubscriptionInfo()
+        assertEquals(PremiumSubscriptionStatus.UNPAID, info.status)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
@@ -28,9 +28,11 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
     }
 
     @Test
-    fun `toSubscriptionInfo maps CANCELED to CANCELED`() {
-        val info = buildResponse(status = SubscriptionStatusJson.CANCELED).toSubscriptionInfo()
-        assertEquals(PremiumSubscriptionStatus.CANCELED, info.status)
+    fun `toSubscriptionInfo maps CANCELED and UNPAID to CANCELED`() {
+        listOf(SubscriptionStatusJson.CANCELED, SubscriptionStatusJson.UNPAID).forEach {
+            val info = buildResponse(status = it).toSubscriptionInfo()
+            assertEquals(PremiumSubscriptionStatus.CANCELED, info.status)
+        }
     }
 
     @Test
@@ -47,14 +49,6 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
             status = SubscriptionStatusJson.INCOMPLETE,
         ).toSubscriptionInfo()
         assertEquals(PremiumSubscriptionStatus.UPDATE_PAYMENT, info.status)
-    }
-
-    @Test
-    fun `toSubscriptionInfo maps UNPAID to UNPAID`() {
-        val info = buildResponse(
-            status = SubscriptionStatusJson.UNPAID,
-        ).toSubscriptionInfo()
-        assertEquals(PremiumSubscriptionStatus.UNPAID, info.status)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -681,7 +681,7 @@ class PlanScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(
                 "Your subscription was canceled on April 21, 2026. " +
-                    "Resubscribe to continue using premium features.",
+                    "Resubscribe to continue using Premium features.",
             )
             .assertTextRangeHasBoldSpan(boldSubstring = "April 21, 2026")
     }
@@ -700,7 +700,7 @@ class PlanScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(
                 "Your subscription was canceled on May 15, 2026. " +
-                    "Resubscribe to continue using premium features.",
+                    "Resubscribe to continue using Premium features.",
             )
             .assertTextRangeHasBoldSpan(boldSubstring = "May 15, 2026")
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -556,6 +556,34 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `status badge should render with Expired label for EXPIRED status`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.EXPIRED,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText("Expired")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `status badge should render with Unpaid label for UNPAID status`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.UNPAID,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText("Unpaid")
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun `status badge should render with Update payment label for UPDATE_PAYMENT status`() {
         mutableStateFlow.update {
             it.copy(
@@ -620,9 +648,11 @@ class PlanScreenTest : BitwardenComposeTest() {
         }
         composeTestRule.onNodeWithText("Active").assertDoesNotExist()
         composeTestRule.onNodeWithText("Canceled").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Expired").assertDoesNotExist()
         composeTestRule.onNodeWithText("Past due").assertDoesNotExist()
         composeTestRule.onNodeWithText("Paused").assertDoesNotExist()
         composeTestRule.onNodeWithText("Pending cancellation").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Unpaid").assertDoesNotExist()
         composeTestRule.onNodeWithText("Update payment").assertDoesNotExist()
     }
 
@@ -761,6 +791,40 @@ class PlanScreenTest : BitwardenComposeTest() {
             .assertTextRangeHasBoldSpan(boldSubstring = "May 1, 2026")
     }
 
+    @Test
+    fun `EXPIRED description should bold the suspension date`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.EXPIRED,
+                    suspensionDateText = "April 21, 2026",
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(
+                "Your subscription expired on April 21, 2026. " +
+                    "Resubscribe to continue using Premium features.",
+            )
+            .assertTextRangeHasBoldSpan(boldSubstring = "April 21, 2026")
+    }
+
+    @Test
+    fun `UNPAID description should render plain text`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.UNPAID,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(
+                "To reactivate your subscription, please resolve the past due invoices.",
+            )
+            .assertIsDisplayed()
+    }
+
     // endregion Premium content rendering
 
     // region Line items
@@ -893,6 +957,82 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     // endregion Line items
+
+    // region Terminal-state feature list
+
+    @Test
+    fun `CANCELED status should render feature list instead of line items`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.CANCELED,
+                ),
+            )
+        }
+        composeTestRule.onNodeWithText("Built-in authenticator").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Emergency access").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Secure file storage").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Breach monitoring").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("BillingAmountRow").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("StorageCostRow").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("DiscountRow").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("EstimatedTaxRow").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("TotalRow").assertDoesNotExist()
+    }
+
+    @Test
+    fun `EXPIRED status should render feature list instead of line items`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.EXPIRED,
+                ),
+            )
+        }
+        composeTestRule.onNodeWithText("Built-in authenticator").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Emergency access").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Secure file storage").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Breach monitoring").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("BillingAmountRow").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("StorageCostRow").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("DiscountRow").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("EstimatedTaxRow").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("TotalRow").assertDoesNotExist()
+    }
+
+    @Test
+    fun `UNPAID status should keep line items and not render feature list`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.UNPAID,
+                ),
+            )
+        }
+        composeTestRule.onNodeWithTag("BillingAmountRow").assertExists()
+        composeTestRule.onNodeWithTag("EstimatedTaxRow").assertExists()
+        composeTestRule.onNodeWithTag("TotalRow").assertExists()
+        composeTestRule.onNodeWithText("Built-in authenticator").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Breach monitoring").assertDoesNotExist()
+    }
+
+    @Test
+    fun `UPDATE_PAYMENT status should keep line items and not render feature list`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
+                ),
+            )
+        }
+        composeTestRule.onNodeWithTag("BillingAmountRow").assertExists()
+        composeTestRule.onNodeWithTag("EstimatedTaxRow").assertExists()
+        composeTestRule.onNodeWithTag("TotalRow").assertExists()
+        composeTestRule.onNodeWithText("Built-in authenticator").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Breach monitoring").assertDoesNotExist()
+    }
+
+    // endregion Terminal-state feature list
 
     // region Action buttons
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -570,20 +570,6 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `status badge should render with Unpaid label for UNPAID status`() {
-        mutableStateFlow.update {
-            it.copy(
-                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
-                    status = PremiumSubscriptionStatus.UNPAID,
-                ),
-            )
-        }
-        composeTestRule
-            .onNodeWithText("Unpaid")
-            .assertIsDisplayed()
-    }
-
-    @Test
     fun `status badge should render with Update payment label for UPDATE_PAYMENT status`() {
         mutableStateFlow.update {
             it.copy(
@@ -652,7 +638,6 @@ class PlanScreenTest : BitwardenComposeTest() {
         composeTestRule.onNodeWithText("Past due").assertDoesNotExist()
         composeTestRule.onNodeWithText("Paused").assertDoesNotExist()
         composeTestRule.onNodeWithText("Pending cancellation").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Unpaid").assertDoesNotExist()
         composeTestRule.onNodeWithText("Update payment").assertDoesNotExist()
     }
 
@@ -807,22 +792,6 @@ class PlanScreenTest : BitwardenComposeTest() {
                     "Resubscribe to continue using Premium features.",
             )
             .assertTextRangeHasBoldSpan(boldSubstring = "April 21, 2026")
-    }
-
-    @Test
-    fun `UNPAID description should render plain text`() {
-        mutableStateFlow.update {
-            it.copy(
-                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
-                    status = PremiumSubscriptionStatus.UNPAID,
-                ),
-            )
-        }
-        composeTestRule
-            .onNodeWithText(
-                "To reactivate your subscription, please resolve the past due invoices.",
-            )
-            .assertIsDisplayed()
     }
 
     // endregion Premium content rendering
@@ -998,22 +967,6 @@ class PlanScreenTest : BitwardenComposeTest() {
         composeTestRule.onNodeWithTag("DiscountRow").assertDoesNotExist()
         composeTestRule.onNodeWithTag("EstimatedTaxRow").assertDoesNotExist()
         composeTestRule.onNodeWithTag("TotalRow").assertDoesNotExist()
-    }
-
-    @Test
-    fun `UNPAID status should keep line items and not render feature list`() {
-        mutableStateFlow.update {
-            it.copy(
-                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
-                    status = PremiumSubscriptionStatus.UNPAID,
-                ),
-            )
-        }
-        composeTestRule.onNodeWithTag("BillingAmountRow").assertExists()
-        composeTestRule.onNodeWithTag("EstimatedTaxRow").assertExists()
-        composeTestRule.onNodeWithTag("TotalRow").assertExists()
-        composeTestRule.onNodeWithText("Built-in authenticator").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Breach monitoring").assertDoesNotExist()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -1179,32 +1179,6 @@ class PlanViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `SubscriptionResultReceive Success with Unpaid status should hide cancel button`() =
-        runTest {
-            markUserPremium()
-
-            val viewModel = createViewModel(
-                subscriptionResult = SubscriptionResult.Success(
-                    subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
-                        status = PremiumSubscriptionStatus.UNPAID,
-                    ),
-                ),
-            )
-
-            viewModel.stateFlow.test {
-                assertEquals(
-                    DEFAULT_PREMIUM_LOADED_STATE.copy(
-                        viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
-                            status = PremiumSubscriptionStatus.UNPAID,
-                            showCancelButton = false,
-                        ),
-                    ),
-                    awaitItem(),
-                )
-            }
-        }
-
-    @Test
     fun `SubscriptionResultReceive Success with Monthly cadence formats per-month rate`() =
         runTest {
             markUserPremium()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -1153,6 +1153,58 @@ class PlanViewModelTest : BaseViewModelTest() {
         }
 
     @Test
+    fun `SubscriptionResultReceive Success with Expired status should hide cancel button`() =
+        runTest {
+            markUserPremium()
+
+            val viewModel = createViewModel(
+                subscriptionResult = SubscriptionResult.Success(
+                    subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
+                        status = PremiumSubscriptionStatus.EXPIRED,
+                    ),
+                ),
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_PREMIUM_LOADED_STATE.copy(
+                        viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
+                            status = PremiumSubscriptionStatus.EXPIRED,
+                            showCancelButton = false,
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `SubscriptionResultReceive Success with Unpaid status should hide cancel button`() =
+        runTest {
+            markUserPremium()
+
+            val viewModel = createViewModel(
+                subscriptionResult = SubscriptionResult.Success(
+                    subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
+                        status = PremiumSubscriptionStatus.UNPAID,
+                    ),
+                ),
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_PREMIUM_LOADED_STATE.copy(
+                        viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
+                            status = PremiumSubscriptionStatus.UNPAID,
+                            showCancelButton = false,
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
     fun `SubscriptionResultReceive Success with Monthly cadence formats per-month rate`() =
         runTest {
             markUserPremium()

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1303,8 +1303,10 @@ Do you want to switch to this account?</string>
     <string name="cancel_premium">Cancel Premium</string>
     <string name="subscription_status_active">Active</string>
     <string name="subscription_status_canceled">Canceled</string>
+    <string name="subscription_status_expired">Expired</string>
     <string name="subscription_status_past_due">Past due</string>
     <string name="subscription_status_paused">Paused</string>
+    <string name="subscription_status_unpaid">Unpaid</string>
     <string name="subscription_status_update_payment">Update payment</string>
     <string name="subscription_status_pending_cancellation">Pending cancellation</string>
     <string name="subscription_pending_cancellation_description">Your subscription is scheduled to cancel on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. You can reinstate it anytime before then.</string>
@@ -1316,6 +1318,8 @@ Do you want to switch to this account?</string>
         <item quantity="other">You have a grace period of <annotation arg="0">%1$d</annotation> days from your subscription expiration date. Please resolve the past due amount by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>
     </plurals>
     <string name="subscription_paused_description">Your subscription is paused. Resume to continue using premium features.</string>
+    <string name="subscription_expired_description">Your subscription expired on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. Resubscribe to continue using Premium features.</string>
+    <string name="subscription_unpaid_description">To reactivate your subscription, please resolve the past due invoices.</string>
     <string name="loading_subscription">Loading subscription…</string>
     <string name="loading_portal">Loading portal…</string>
     <string name="portal_error">Something went wrong</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1310,7 +1310,7 @@ Do you want to switch to this account?</string>
     <string name="subscription_status_pending_cancellation">Pending cancellation</string>
     <string name="subscription_pending_cancellation_description">Your subscription is scheduled to cancel on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. You can reinstate it anytime before then.</string>
     <string name="premium_next_charge_summary">Your next charge is for <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation> USD due on <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</string>
-    <string name="subscription_canceled_description">Your subscription was canceled on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. Resubscribe to continue using premium features.</string>
+    <string name="subscription_canceled_description">Your subscription was canceled on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. Resubscribe to continue using Premium features.</string>
     <string name="subscription_update_payment_description">We couldn’t process your payment. Update your payment before your subscription ends on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>.</string>
     <plurals name="subscription_past_due_description">
         <item quantity="one">You have a grace period of <annotation arg="0">%1$d</annotation> day from your subscription expiration date. Please resolve the past due amount by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1306,7 +1306,6 @@ Do you want to switch to this account?</string>
     <string name="subscription_status_expired">Expired</string>
     <string name="subscription_status_past_due">Past due</string>
     <string name="subscription_status_paused">Paused</string>
-    <string name="subscription_status_unpaid">Unpaid</string>
     <string name="subscription_status_update_payment">Update payment</string>
     <string name="subscription_status_pending_cancellation">Pending cancellation</string>
     <string name="subscription_pending_cancellation_description">Your subscription is scheduled to cancel on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. You can reinstate it anytime before then.</string>
@@ -1319,7 +1318,6 @@ Do you want to switch to this account?</string>
     </plurals>
     <string name="subscription_paused_description">Your subscription is paused. Resume to continue using premium features.</string>
     <string name="subscription_expired_description">Your subscription expired on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. Resubscribe to continue using Premium features.</string>
-    <string name="subscription_unpaid_description">To reactivate your subscription, please resolve the past due invoices.</string>
     <string name="loading_subscription">Loading subscription…</string>
     <string name="loading_portal">Loading portal…</string>
     <string name="portal_error">Something went wrong</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37181](https://bitwarden.atlassian.net/browse/PM-37181)

## 📔 Objective

`INCOMPLETE_EXPIRED` was previously folded onto `CANCELED` at the JSON boundary, hiding the distinction between an expired subscription and one the user canceled. It now maps to a dedicated `EXPIRED` UI state with its own label, badge color, and description copy — matching the web client's `subscription-card` treatment.

For terminal states (`CANCELED` and `EXPIRED`), the Premium card swaps the billing line items for the premium feature list so users see a resubscribe-oriented layout rather than charges that no longer apply. Other trouble states (`PAST_DUE`, `PENDING_CANCELLATION`, `UPDATE_PAYMENT`) retain the billing line items.

## 📸 Screenshots

| Figma | Actual |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/56ca42cd-e04e-4abb-8bf7-026a1a2f253a" /> | <img width="365" src="https://github.com/user-attachments/assets/81e0cd05-31fa-4e1d-847a-8c220cf060da" /> |


| Figma | Actual |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/b731f39b-d058-4e33-b911-b8a53b37ba8c" /> | <img width="365" src="https://github.com/user-attachments/assets/6c92de9a-b383-4707-a66a-a30aaea621c2" /> |

[PM-37181]: https://bitwarden.atlassian.net/browse/PM-37181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ