### PR TITLE
Chore: Remove the Manager type from OrganizationType

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkOrganizationExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkOrganizationExtensions.kt
@@ -43,6 +43,5 @@ private val OrganizationType.toSdkOrganizationUserType: OrganizationUserType
         OrganizationType.OWNER -> OrganizationUserType.OWNER
         OrganizationType.ADMIN -> OrganizationUserType.ADMIN
         OrganizationType.USER -> OrganizationUserType.USER
-        OrganizationType.MANAGER -> OrganizationUserType.ADMIN
         OrganizationType.CUSTOM -> OrganizationUserType.CUSTOM
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkOrganizationExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkOrganizationExtensionsTest.kt
@@ -70,6 +70,5 @@ private val ORGANIZATION_TYPE_MAP: Map<OrganizationType, OrganizationUserType> =
     OrganizationType.OWNER to OrganizationUserType.OWNER,
     OrganizationType.ADMIN to OrganizationUserType.ADMIN,
     OrganizationType.USER to OrganizationUserType.USER,
-    OrganizationType.MANAGER to OrganizationUserType.ADMIN,
     OrganizationType.CUSTOM to OrganizationUserType.CUSTOM,
 )

--- a/network/src/main/kotlin/com/bitwarden/network/model/OrganizationType.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/OrganizationType.kt
@@ -29,12 +29,6 @@ enum class OrganizationType {
     USER,
 
     /**
-     * The user is a manager in the organization.
-     */
-    @SerialName("3")
-    MANAGER,
-
-    /**
      * The user has a custom role in the organization.
      */
     @SerialName("4")


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the `MANAGER` type from the `OrganizationType` enum. The value is never used and the server side migrated all accounts several years ago.
