### PR TITLE
PM-38285: Feat: Filter unconfirmed organizations from the app

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -25,6 +25,7 @@ import com.bitwarden.network.model.GetTokenResponseJson
 import com.bitwarden.network.model.IdentityTokenAuthModel
 import com.bitwarden.network.model.OrganizationAutoEnrollStatusResponseJson
 import com.bitwarden.network.model.OrganizationKeysResponseJson
+import com.bitwarden.network.model.OrganizationStatusType
 import com.bitwarden.network.model.OrganizationType
 import com.bitwarden.network.model.PasswordHintResponseJson
 import com.bitwarden.network.model.PrevalidateSsoResponseJson
@@ -312,6 +313,7 @@ class AuthRepositoryImpl(
     override val organizations: List<Organization>
         get() = activeUserId
             ?.let { authDiskSource.getOrganizations(it) }
+            ?.filter { it.status == OrganizationStatusType.CONFIRMED }
             .orEmpty()
             .toOrganizations()
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/AuthDiskSourceExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/AuthDiskSourceExtensions.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.auth.repository.util
 
+import com.bitwarden.network.model.OrganizationStatusType
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.model.UserAccountTokens
@@ -27,6 +28,7 @@ val AuthDiskSource.userOrganizationsList: List<UserOrganizations>
                 userId = userId,
                 organizations = this
                     .getOrganizations(userId = userId)
+                    ?.filter { it.status == OrganizationStatusType.CONFIRMED }
                     .orEmpty()
                     .toOrganizations(),
             )
@@ -48,10 +50,15 @@ val AuthDiskSource.userOrganizationsListFlow: Flow<List<UserOrganizations>>
                         .map { (userId, _) ->
                             this
                                 .getOrganizationsFlow(userId = userId)
-                                .map {
+                                .map { organizations ->
                                     UserOrganizations(
                                         userId = userId,
-                                        organizations = it.orEmpty().toOrganizations(),
+                                        organizations = organizations
+                                            ?.filter {
+                                                it.status == OrganizationStatusType.CONFIRMED
+                                            }
+                                            .orEmpty()
+                                            .toOrganizations(),
                                     )
                                 }
                         },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultMigrationManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultMigrationManagerImpl.kt
@@ -8,6 +8,7 @@ import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.core.data.util.flatMap
 import com.bitwarden.network.model.BulkShareCiphersJsonRequest
+import com.bitwarden.network.model.OrganizationStatusType
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.toCipherWithIdJsonRequest
 import com.bitwarden.network.service.CiphersService
@@ -144,6 +145,7 @@ class VaultMigrationManagerImpl(
 
             val orgName = authDiskSource
                 .getOrganizations(userId = userId)
+                ?.filter { it.status == OrganizationStatusType.CONFIRMED }
                 ?.firstOrNull { it.id == orgId }
                 ?.name
                 ?: return@update VaultMigrationData.NoMigrationRequired

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
@@ -7,6 +7,7 @@ import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.combineDataStates
 import com.bitwarden.core.data.repository.util.map
 import com.bitwarden.core.data.repository.util.updateToPendingOrLoading
+import com.bitwarden.network.model.OrganizationStatusType
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.service.SyncService
 import com.bitwarden.network.util.isNoConnectionError
@@ -469,6 +470,9 @@ class VaultSyncManagerImpl(
                                 data = collections.sortAlphabeticallyByTypeAndOrganization(
                                     userOrganizations = authDiskSource
                                         .getOrganizations(userId = userId)
+                                        ?.filter { org ->
+                                            org.status == OrganizationStatusType.CONFIRMED
+                                        }
                                         .orEmpty(),
                                 ),
                             )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/OrganizationUserPolicyContextUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/OrganizationUserPolicyContextUtil.kt
@@ -11,7 +11,7 @@ import com.bitwarden.policies.OrganizationUserPolicyContext
 fun createMockOrganizationUserPolicyContext(
     number: Int = 1,
     id: String = "mockId-$number",
-    status: OrganizationUserStatusType = OrganizationUserStatusType.ACCEPTED,
+    status: OrganizationUserStatusType = OrganizationUserStatusType.CONFIRMED,
     role: OrganizationUserType = OrganizationUserType.ADMIN,
     enabled: Boolean = false,
     usePolicies: Boolean = false,

--- a/network/src/test/kotlin/com/bitwarden/network/service/SyncServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/SyncServiceTest.kt
@@ -118,7 +118,7 @@ private const val SYNC_SUCCESS_JSON = """
         "name": "mockName-1",
         "useApi": false,
         "familySponsorshipValidUntil": "2023-10-27T12:00:00.00Z",
-        "status": 1,
+        "status": 2,
         "userIsClaimedByOrganization": false
       }
     ],
@@ -167,7 +167,7 @@ private const val SYNC_SUCCESS_JSON = """
         "name": "mockName-1",
         "useApi": false,
         "familySponsorshipValidUntil": "2023-10-27T12:00:00.00Z",
-        "status": 1,
+        "status": 2,
         "userIsClaimedByOrganization": false
       }
     ],
@@ -243,7 +243,7 @@ private const val SYNC_SUCCESS_JSON = """
         "name": "mockName-1",
         "useApi": false,
         "familySponsorshipValidUntil": "2023-10-27T12:00:00.00Z",
-        "status": 1,
+        "status": 2,
         "userIsClaimedByOrganization": false
       }
     ]

--- a/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseProfileUtil.kt
+++ b/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseProfileUtil.kt
@@ -94,7 +94,7 @@ fun createMockOrganizationNetwork(
     name: String? = "mockName-$number",
     shouldUseApi: Boolean = false,
     familySponsorshipValidUntil: Instant? = Instant.parse("2023-10-27T12:00:00Z"),
-    status: OrganizationStatusType = OrganizationStatusType.ACCEPTED,
+    status: OrganizationStatusType = OrganizationStatusType.CONFIRMED,
     userIsClaimedByOrganization: Boolean = false,
     limitItemDeletion: Boolean = false,
 ): SyncResponseJson.Profile.Organization =


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38285](https://bitwarden.atlassian.net/browse/PM-38285)

## 📔 Objective

This PR filters out all unconfirmed organizations from being processed in the app. The only exception to this is policies which need to handle accepted organizations as well.


[PM-38285]: https://bitwarden.atlassian.net/browse/PM-38285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ