### PR TITLE
[PM-38279] fix: Hide Cancel Premium action for Update payment status

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -1170,18 +1170,19 @@ sealed class PlanAction {
 
 /**
  * Returns `true` when this status corresponds to a subscription that the user can still
- * cancel through the Stripe portal — i.e., a live or recoverable subscription. Terminal
- * states (canceled) do not present a cancel action.
+ * cancel through the Stripe portal — i.e., a live subscription. Terminal states (canceled,
+ * expired, pending cancellation) and states whose primary action is recovering payment
+ * (update payment) do not present a cancel action.
  */
 private fun PremiumSubscriptionStatus.canBeCanceled(): Boolean = when (this) {
     PremiumSubscriptionStatus.CANCELED,
     PremiumSubscriptionStatus.PENDING_CANCELLATION,
+    PremiumSubscriptionStatus.UPDATE_PAYMENT,
         -> false
 
     PremiumSubscriptionStatus.ACTIVE,
     PremiumSubscriptionStatus.PAST_DUE,
     PremiumSubscriptionStatus.PAUSED,
-    PremiumSubscriptionStatus.UPDATE_PAYMENT,
         -> true
 }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -1131,6 +1131,35 @@ class PlanViewModelTest : BaseViewModelTest() {
                         viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
                             status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
                             suspensionDateText = "April 21, 2026",
+                            showCancelButton = false,
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `SubscriptionResultReceive Success with UpdatePayment status should hide cancel button`() =
+        runTest {
+            markUserPremium()
+
+            val viewModel = createViewModel(
+                subscriptionResult = SubscriptionResult.Success(
+                    subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
+                        status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
+                        suspensionDate = Instant.parse("2026-04-21T00:00:00Z"),
+                    ),
+                ),
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_PREMIUM_LOADED_STATE.copy(
+                        viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
+                            status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
+                            suspensionDateText = "April 21, 2026",
+                            showCancelButton = false,
                         ),
                     ),
                     awaitItem(),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -1140,34 +1140,6 @@ class PlanViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `SubscriptionResultReceive Success with UpdatePayment status should hide cancel button`() =
-        runTest {
-            markUserPremium()
-
-            val viewModel = createViewModel(
-                subscriptionResult = SubscriptionResult.Success(
-                    subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
-                        status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
-                        suspensionDate = Instant.parse("2026-04-21T00:00:00Z"),
-                    ),
-                ),
-            )
-
-            viewModel.stateFlow.test {
-                assertEquals(
-                    DEFAULT_PREMIUM_LOADED_STATE.copy(
-                        viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
-                            status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
-                            suspensionDateText = "April 21, 2026",
-                            showCancelButton = false,
-                        ),
-                    ),
-                    awaitItem(),
-                )
-            }
-        }
-
-    @Test
     fun `SubscriptionResultReceive Success with PastDue status should describe grace period`() =
         runTest {
             markUserPremium()


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38279

## 📔 Objective

When a subscription is in the **Update payment** state (mapped from the `INCOMPLETE`/`UNPAID` Stripe substates), the member's path back to a healthy subscription is updating their payment method — not canceling. Offering a "Cancel Premium" action in that state is misleading and works against recovery.

This moves `UPDATE_PAYMENT` into the non-cancelable arm of `canBeCanceled()`, so the Plan screen no longer renders the "Cancel Premium" button for that status. It now sits alongside the other non-cancelable states (`CANCELED`, `PENDING_CANCELLATION`). All other live states (`ACTIVE`, `PAST_DUE`, `PAUSED`) are unchanged.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/809eacef-b7d8-4f3b-8f37-07b4bace4193" /> | <img width="365" src="https://github.com/user-attachments/assets/abfb5436-607d-4d4e-bddb-f785d3f699d2" /> | 