### PR TITLE
[PM-38263] fix: Reference invoices in past due subscription description

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -685,7 +685,7 @@ class PlanScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(
                 "You have a grace period of 7 days from your subscription expiration date. " +
-                    "Please resolve the past due amount by April 21, 2026.",
+                    "Please resolve the past due invoices by April 21, 2026.",
             )
             .assertTextRangeHasBoldSpan(boldSubstring = "April 21, 2026")
     }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1313,8 +1313,8 @@ Do you want to switch to this account?</string>
     <string name="subscription_canceled_description">Your subscription was canceled on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. Resubscribe to continue using Premium features.</string>
     <string name="subscription_update_payment_description">We couldn’t process your payment. Update your payment method before your subscription ends on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>.</string>
     <plurals name="subscription_past_due_description">
-        <item quantity="one">You have a grace period of <annotation arg="0">%1$d</annotation> day from your subscription expiration date. Please resolve the past due amount by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>
-        <item quantity="other">You have a grace period of <annotation arg="0">%1$d</annotation> days from your subscription expiration date. Please resolve the past due amount by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>
+        <item quantity="one">You have a grace period of <annotation arg="0">%1$d</annotation> day from your subscription expiration date. Please resolve the past due invoices by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>
+        <item quantity="other">You have a grace period of <annotation arg="0">%1$d</annotation> days from your subscription expiration date. Please resolve the past due invoices by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>
     </plurals>
     <string name="subscription_paused_description">Your subscription is paused. Resume to continue using premium features.</string>
     <string name="subscription_expired_description">Your subscription expired on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. Resubscribe to continue using Premium features.</string>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38263

## 📔 Objective

The past due grace-period description instructed users to resolve the past due "amount," but a subscription can carry multiple outstanding invoices. Both iOS and the Figma design reference "invoices," so this corrects the Android copy to match the intended, accurate wording.

Affects the `subscription_past_due_description` plurals resource (both `one` and `other` forms); the coupled `PlanScreenTest` assertion is updated in lockstep.

## 📸 Screenshots

### Figma

<img width="365" src="https://github.com/user-attachments/assets/8469ba70-051d-454f-8104-966f7d720ac4" /> 

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/e3a4891a-8c6f-43d1-9307-a30b3469e8e8" /> | <img width="365" src="https://github.com/user-attachments/assets/dcec81eb-023f-48c2-86e7-fc0453e90311" /> |