### PR TITLE
[PM-38411] tech-debt: Update deprecated argument in actions/create-github-app-token

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          client-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
           permission-contents: write      # for creating and pushing a new branch
           permission-pull-requests: write # for creating pull request

--- a/.github/workflows/sdlc-sdk-update.yml
+++ b/.github/workflows/sdlc-sdk-update.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          client-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
           permission-pull-requests: write
           permission-actions: read


### PR DESCRIPTION
## 🎟️ Tracking

PM-38411

## 📔 Objective

Replacing deprecated argument of `actions/create-github-app-token`, `app-id` deprecated in favour of `client-id` in 3.1.0. 

https://github.com/actions/create-github-app-token/releases/tag/v3.1.0
