### PR TITLE
PM-38358: Chore: Remove user key

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
@@ -115,16 +115,6 @@ interface AuthDiskSource : AppIdProvider {
     )
 
     /**
-     * Retrieves a user key using a [userId].
-     */
-    fun getUserKey(userId: String): String?
-
-    /**
-     * Stores a user key using a [userId].
-     */
-    fun storeUserKey(userId: String, userKey: String?)
-
-    /**
      * Retrieves the local user data key for the given [userId].
      */
     fun getLocalUserDataKey(userId: String): String?

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
@@ -109,6 +109,10 @@ class AuthDiskSourceImpl(
         // We must migrate the tokens from being stored in the UserState(shared preferences) to
         // being stored separately in encrypted shared preferences.
         migrateAccountTokens()
+
+        // We want to make sure that any left over encrypted user keys are scrubbed from storage
+        // Since it is no longer supported.
+        removeLegacyUserKeys()
     }
 
     override var authenticatorSyncSymmetricKey: ByteArray?
@@ -146,7 +150,6 @@ class AuthDiskSourceImpl(
 
     override fun clearData(userId: String) {
         storeInvalidUnlockAttempts(userId = userId, invalidUnlockAttempts = null)
-        storeUserKey(userId = userId, userKey = null)
         storeLocalUserDataKey(userId = userId, wrappedKey = null)
         storeUserAutoUnlockKey(userId = userId, userAutoUnlockKey = null)
         storePrivateKey(userId = userId, privateKey = null)
@@ -228,16 +231,6 @@ class AuthDiskSourceImpl(
         putInt(
             key = INVALID_UNLOCK_ATTEMPTS_KEY.appendIdentifier(userId),
             value = invalidUnlockAttempts,
-        )
-    }
-
-    override fun getUserKey(userId: String): String? =
-        getString(key = MASTER_KEY_ENCRYPTION_USER_KEY.appendIdentifier(userId))
-
-    override fun storeUserKey(userId: String, userKey: String?) {
-        putString(
-            key = MASTER_KEY_ENCRYPTION_USER_KEY.appendIdentifier(userId),
-            value = userKey,
         )
     }
 
@@ -661,5 +654,9 @@ class AuthDiskSourceImpl(
                 ?.mapValues { (_, accountJson) -> accountJson.copy(tokens = null) }
                 .orEmpty(),
         )
+    }
+
+    private fun removeLegacyUserKeys() {
+        removeWithPrefix(prefix = MASTER_KEY_ENCRYPTION_USER_KEY)
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1046,14 +1046,16 @@ class AuthRepositoryImpl(
     }
 
     override suspend fun removePassword(masterPassword: String): RemovePasswordResult {
-        val activeAccount = authDiskSource
+        val profile = authDiskSource
             .userState
             ?.activeAccount
+            ?.profile
             ?: return RemovePasswordResult.Error(error = NoActiveUserException())
-        val profile = activeAccount.profile
         val userId = profile.userId
-        val userKey = authDiskSource
-            .getUserKey(userId = userId)
+        val userKey = profile
+            .userDecryptionOptions
+            ?.masterPasswordUnlock
+            ?.masterKeyWrappedUserKey
             ?: return RemovePasswordResult.Error(error = MissingPropertyException("User Key"))
         val keyConnectorUrl = organizations
             .find {
@@ -1513,7 +1515,12 @@ class AuthRepositoryImpl(
             )
 
     override suspend fun validatePassword(password: String): ValidatePasswordResult {
-        val userId = activeUserId ?: return ValidatePasswordResult.Error(NoActiveUserException())
+        val profile = authDiskSource
+            .userState
+            ?.activeAccount
+            ?.profile
+            ?: return ValidatePasswordResult.Error(error = NoActiveUserException())
+        val userId = profile.userId
         return authDiskSource
             .getMasterPasswordHash(userId = userId)
             ?.let { masterPasswordHash ->
@@ -1529,8 +1536,10 @@ class AuthRepositoryImpl(
                     )
             }
             ?: run {
-                val encryptedKey = authDiskSource
-                    .getUserKey(userId)
+                val encryptedKey = profile
+                    .userDecryptionOptions
+                    ?.masterPasswordUnlock
+                    ?.masterKeyWrappedUserKey
                     ?: return ValidatePasswordResult.Error(MissingPropertyException("UserKey"))
                 vaultSdkSource
                     .validatePasswordUserKey(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1224,9 +1224,6 @@ class AuthRepositoryImpl(
                             keys = null,
                         ),
                     )
-                    .onSuccess {
-                        authDiskSource.storeUserKey(userId = userId, userKey = response.newKey)
-                    }
                     .map { response.passwordHash }
             }
             .flatMap { masterPasswordHash ->
@@ -1365,10 +1362,6 @@ class AuthRepositoryImpl(
                         authDiskSource.storePrivateKey(
                             userId = userId,
                             privateKey = response.keys.private,
-                        )
-                        authDiskSource.storeUserKey(
-                            userId = userId,
-                            userKey = response.encryptedUserKey,
                         )
                     }
                     .map { response.masterPasswordHash }
@@ -1983,11 +1976,6 @@ class AuthRepositoryImpl(
                     }
                 }
         }
-        loginResponse.key?.let {
-            // Only set the value if it's present, since we may have set it already
-            // when we completed the pending admin auth request.
-            authDiskSource.storeUserKey(userId = userId, userKey = it)
-        }
         // We continue to store the private key for backwards compatibility. Key connector
         // conversion still relies on the private key.
         loginResponse.privateKeyOrNull()?.let {
@@ -2136,13 +2124,6 @@ class AuthRepositoryImpl(
                         )
                         .also { result ->
                             if (result is VaultUnlockResult.Success) {
-                                // We now know that login/unlock was successful, so we store the
-                                // userKey and privateKey we now have since it didn't exist on the
-                                // loginResponse.
-                                authDiskSource.storeUserKey(
-                                    userId = userId,
-                                    userKey = keyConnector.encryptedUserKey,
-                                )
                                 // We continue to store the private key for backwards compatibility
                                 // since key connector conversion still relies on the private key.
                                 authDiskSource.storePrivateKey(
@@ -2283,7 +2264,6 @@ class AuthRepositoryImpl(
                             method = AuthRequestMethod.UserKey(protectedUserKey = userKey),
                         ),
                     )
-                    authDiskSource.storeUserKey(userId = userId, userKey = userKey)
                 }
             authDiskSource.storePendingAuthRequest(
                 userId = userId,
@@ -2313,10 +2293,6 @@ class AuthRepositoryImpl(
                 deviceProtectedUserKey = encryptedUserKey,
             ),
         )
-
-        if (vaultUnlockResult is VaultUnlockResult.Success) {
-            authDiskSource.storeUserKey(userId = userId, userKey = encryptedUserKey)
-        }
         return vaultUnlockResult
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
@@ -34,7 +34,10 @@ fun UserStateJson.toRemovedPasswordUserStateJson(
     val profile = account.profile
     val updatedUserDecryptionOptions = profile
         .userDecryptionOptions
-        ?.copy(hasMasterPassword = false)
+        ?.copy(
+            hasMasterPassword = false,
+            masterPasswordUnlock = null,
+        )
         ?: UserDecryptionOptionsJson(
             hasMasterPassword = false,
             trustedDeviceUserDecryptionOptions = null,
@@ -68,7 +71,10 @@ fun UserStateJson.toUpdatedUserStateJson(
         ?.let { syncUserDecryption ->
             profile
                 .userDecryptionOptions
-                ?.copy(masterPasswordUnlock = syncUserDecryption.masterPasswordUnlock)
+                ?.copy(
+                    hasMasterPassword = syncUserDecryption.masterPasswordUnlock != null,
+                    masterPasswordUnlock = syncUserDecryption.masterPasswordUnlock,
+                )
                 ?: UserDecryptionOptionsJson(
                     hasMasterPassword = syncUserDecryption.masterPasswordUnlock != null,
                     trustedDeviceUserDecryptionOptions = null,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
@@ -377,7 +377,6 @@ class VaultSyncManagerImpl(
         val profile = syncResponse.profile
         val userId = profile.id
         authDiskSource.apply {
-            storeUserKey(userId = userId, userKey = profile.key)
             storePrivateKey(userId = userId, privateKey = profile.privateKey)
             storeAccountKeys(userId = userId, accountKeys = profile.accountKeys)
             storeOrganizationKeys(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -37,7 +37,11 @@ import java.time.Instant
 @Suppress("LargeClass")
 class AuthDiskSourceTest {
     private val fakeEncryptedSharedPreferences = FakeSharedPreferences()
-    private val fakeSharedPreferences = FakeSharedPreferences()
+    private val fakeSharedPreferences = FakeSharedPreferences().apply {
+        edit(commit = true) {
+            putString("bwPreferencesStorage:masterKeyEncryptedUserKey", "testUserKey")
+        }
+    }
     private val legacySecureStorageMigrator = mockk<LegacySecureStorageMigrator> {
         every { migrateIfNecessary() } just runs
     }
@@ -54,6 +58,13 @@ class AuthDiskSourceTest {
     @Test
     fun `initialization should kick off a legacy migration if necessary`() {
         verify(exactly = 1) { legacySecureStorageMigrator.migrateIfNecessary() }
+    }
+
+    @Test
+    fun `initialization should trigger a legacy user key removal`() {
+        assertNull(
+            fakeSharedPreferences.getString("bwPreferencesStorage:masterKeyEncryptedUserKey", null),
+        )
     }
 
     @Test
@@ -279,7 +290,6 @@ class AuthDiskSourceTest {
             userId = userId,
             invalidUnlockAttempts = 1,
         )
-        authDiskSource.storeUserKey(userId = userId, userKey = "userKey")
         authDiskSource.storeUserAutoUnlockKey(
             userId = userId,
             userAutoUnlockKey = "userAutoUnlockKey",
@@ -334,7 +344,6 @@ class AuthDiskSourceTest {
         assertNull(authDiskSource.getUserBiometricInitVector(userId = userId))
         assertNull(authDiskSource.getUserBiometricUnlockKey(userId = userId))
         assertNull(authDiskSource.getInvalidUnlockAttempts(userId = userId))
-        assertNull(authDiskSource.getUserKey(userId = userId))
         assertNull(authDiskSource.getUserAutoUnlockKey(userId = userId))
         assertNull(authDiskSource.getPrivateKey(userId = userId))
         assertNull(authDiskSource.getAccountKeys(userId = userId))
@@ -407,45 +416,6 @@ class AuthDiskSourceTest {
             invalidUnlockAttempts = null,
         )
         assertFalse(fakeSharedPreferences.contains(invalidUnlockAttemptsKey))
-    }
-
-    @Test
-    fun `getUserKey should pull from SharedPreferences`() {
-        val userKeyBaseKey = "bwPreferencesStorage:masterKeyEncryptedUserKey"
-        val mockUserId = "mockUserId"
-        val mockUserKey = "mockUserKey"
-        fakeSharedPreferences
-            .edit {
-                putString(
-                    "${userKeyBaseKey}_$mockUserId",
-                    mockUserKey,
-                )
-            }
-        val actual = authDiskSource.getUserKey(userId = mockUserId)
-        assertEquals(
-            mockUserKey,
-            actual,
-        )
-    }
-
-    @Test
-    fun `storeUserKey should update SharedPreferences`() {
-        val userKeyBaseKey = "bwPreferencesStorage:masterKeyEncryptedUserKey"
-        val mockUserId = "mockUserId"
-        val mockUserKey = "mockUserKey"
-        authDiskSource.storeUserKey(
-            userId = mockUserId,
-            userKey = mockUserKey,
-        )
-        val actual = fakeSharedPreferences
-            .getString(
-                "${userKeyBaseKey}_$mockUserId",
-                null,
-            )
-        assertEquals(
-            mockUserKey,
-            actual,
-        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
@@ -44,7 +44,6 @@ class FakeAuthDiskSource : AuthDiskSource {
     private val storedIsTdeLoginComplete = mutableMapOf<String, Boolean?>()
     private val storedShouldTrustDevice = mutableMapOf<String, Boolean?>()
     private val storedInvalidUnlockAttempts = mutableMapOf<String, Int?>()
-    private val storedUserKeys = mutableMapOf<String, String?>()
     private val storedLocalUserDataKeys = mutableMapOf<String, String?>()
     private val storedPrivateKeys = mutableMapOf<String, String?>()
     private val storedTwoFactorTokens = mutableMapOf<String, String?>()
@@ -81,7 +80,6 @@ class FakeAuthDiskSource : AuthDiskSource {
 
     override fun clearData(userId: String) {
         storedInvalidUnlockAttempts.remove(userId)
-        storedUserKeys.remove(userId)
         storedLocalUserDataKeys.remove(userId)
         storedPrivateKeys.remove(userId)
         storedTwoFactorTokens.clear()
@@ -144,12 +142,6 @@ class FakeAuthDiskSource : AuthDiskSource {
         invalidUnlockAttempts: Int?,
     ) {
         storedInvalidUnlockAttempts[userId] = invalidUnlockAttempts
-    }
-
-    override fun getUserKey(userId: String): String? = storedUserKeys[userId]
-
-    override fun storeUserKey(userId: String, userKey: String?) {
-        storedUserKeys[userId] = userKey
     }
 
     override fun getLocalUserDataKey(userId: String): String? = storedLocalUserDataKeys[userId]
@@ -420,13 +412,6 @@ class FakeAuthDiskSource : AuthDiskSource {
      */
     fun assertInvalidUnlockAttempts(userId: String, invalidUnlockAttempts: Int?) {
         assertEquals(invalidUnlockAttempts, storedInvalidUnlockAttempts[userId])
-    }
-
-    /**
-     * Assert that the [userKey] was stored successfully using the [userId].
-     */
-    fun assertUserKey(userId: String, userKey: String?) {
-        assertEquals(userKey, storedUserKeys[userId])
     }
 
     /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -5364,9 +5364,14 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `removePassword with no userKey should return error`() = runTest {
-        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
-        fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = null)
+    fun `removePassword with no masterKeyWrappedUserKey should return error`() = runTest {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1.copy(
+            accounts = mapOf(
+                USER_ID_1 to ACCOUNT_1.copy(
+                    profile = PROFILE_1.copy(userDecryptionOptions = null),
+                ),
+            ),
+        )
 
         val result = repository.removePassword(masterPassword = PASSWORD)
 
@@ -5379,7 +5384,6 @@ class AuthRepositoryTest {
     @Test
     fun `removePassword with no keyConnectorUrl should return error`() = runTest {
         fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
-        fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = ENCRYPTED_USER_KEY)
         val organizations = listOf(
             createMockOrganizationNetwork(
                 number = 1,
@@ -5402,7 +5406,6 @@ class AuthRepositoryTest {
     fun `removePassword with migrateExistingUserToKeyConnector exception should return error`() =
         runTest {
             fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
-            fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = ENCRYPTED_USER_KEY)
             val url = "www.example.com"
             val error = Throwable("Fail!")
             val organizations = listOf(
@@ -5434,7 +5437,6 @@ class AuthRepositoryTest {
     fun `removePassword with migrateExistingUserToKeyConnector error should return error`() =
         runTest {
             fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
-            fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = ENCRYPTED_USER_KEY)
             val url = "www.example.com"
             val error = Throwable("Fail!")
             val expectedResult = MigrateExistingUserToKeyConnectorResult.Error(error)
@@ -5471,7 +5473,6 @@ class AuthRepositoryTest {
     fun `removePassword with migrateExistingUserToKeyConnector wrong password error should return WrongPasswordError error`() =
         runTest {
             fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
-            fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = ENCRYPTED_USER_KEY)
             val url = "www.example.com"
             val expectedResult = MigrateExistingUserToKeyConnectorResult.WrongPasswordError
             val organizations = listOf(
@@ -5507,7 +5508,6 @@ class AuthRepositoryTest {
     fun `removePassword with migrateExistingUserToKeyConnector success should sync and return success`() =
         runTest {
             fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
-            fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = ENCRYPTED_USER_KEY)
             val url = "www.example.com"
             val organizations = listOf(
                 createMockOrganizationNetwork(
@@ -7027,12 +7027,18 @@ class AuthRepositoryTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `validatePassword with no stored password hash and no stored user key returns ValidatePasswordResult Error`() =
+    fun `validatePassword with no stored password hash and no stored masterKeyWrappedUserKey returns ValidatePasswordResult Error`() =
         runTest {
             val userId = USER_ID_1
             val password = "password"
             val passwordHash = "passwordHash"
-            fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE_1.copy(
+                accounts = mapOf(
+                    USER_ID_1 to ACCOUNT_1.copy(
+                        profile = PROFILE_1.copy(userDecryptionOptions = null),
+                    ),
+                ),
+            )
             coEvery {
                 vaultSdkSource.validatePassword(
                     userId = userId,
@@ -7098,18 +7104,16 @@ class AuthRepositoryTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `validatePassword with no stored password hash and a stored user key with sdk failure returns ValidatePasswordResult Success invalid`() =
+    fun `validatePassword with no stored password hash and a stored masterKeyWrappedUserKey with sdk failure returns ValidatePasswordResult Success invalid`() =
         runTest {
             val userId = USER_ID_1
             val password = "password"
-            val userKey = "userKey"
             fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
-            fakeAuthDiskSource.storeUserKey(userId = userId, userKey = userKey)
             coEvery {
                 vaultSdkSource.validatePasswordUserKey(
                     userId = userId,
                     password = password,
-                    encryptedUserKey = userKey,
+                    encryptedUserKey = ENCRYPTED_USER_KEY,
                 )
             } returns Throwable("Fail").asFailure()
 
@@ -7120,19 +7124,17 @@ class AuthRepositoryTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `validatePassword with no stored password hash and a stored user key with sdk success returns ValidatePasswordResult Success valid`() =
+    fun `validatePassword with no stored password hash and a stored masterKeyWrappedUserKey with sdk success returns ValidatePasswordResult Success valid`() =
         runTest {
             val userId = USER_ID_1
             val password = "password"
-            val userKey = "userKey"
             val passwordHash = "passwordHash"
             fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
-            fakeAuthDiskSource.storeUserKey(userId = userId, userKey = userKey)
             coEvery {
                 vaultSdkSource.validatePasswordUserKey(
                     userId = userId,
                     password = password,
-                    encryptedUserKey = userKey,
+                    encryptedUserKey = ENCRYPTED_USER_KEY,
                 )
             } returns passwordHash.asSuccess()
 
@@ -7997,7 +7999,7 @@ class AuthRepositoryTest {
                 keyConnectorUserDecryptionOptions = null,
                 masterPasswordUnlock = MasterPasswordUnlockDataJson(
                     kdf = BASE_PROFILE_1.toSdkParams().toKdfRequestModel(),
-                    masterKeyWrappedUserKey = "key",
+                    masterKeyWrappedUserKey = ENCRYPTED_USER_KEY,
                     salt = "mockSalt",
                 ),
             ),
@@ -8049,7 +8051,7 @@ class AuthRepositoryTest {
                             trustedDeviceUserDecryptionOptions = null,
                             masterPasswordUnlock = MasterPasswordUnlockDataJson(
                                 kdf = BASE_PROFILE_1.toSdkParams().toKdfRequestModel(),
-                                masterKeyWrappedUserKey = "key",
+                                masterKeyWrappedUserKey = ENCRYPTED_USER_KEY,
                                 salt = "mockSalt",
                             ),
                         ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -494,10 +494,6 @@ class AuthRepositoryTest {
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
             )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
-            )
             fakeAuthDiskSource.assertMasterPasswordHash(
                 userId = USER_ID_1,
                 passwordHash = PASSWORD_HASH,
@@ -2154,10 +2150,6 @@ class AuthRepositoryTest {
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
             )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
-            )
             fakeAuthDiskSource.assertMasterPasswordHash(
                 userId = USER_ID_1,
                 passwordHash = PASSWORD_HASH,
@@ -2268,10 +2260,6 @@ class AuthRepositoryTest {
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS_WITH_NULL_FIELDS,
-            )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
             )
             fakeAuthDiskSource.assertMasterPasswordHash(
                 userId = USER_ID_1,
@@ -2389,10 +2377,6 @@ class AuthRepositoryTest {
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
                 accountKeys = null,
-            )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = null,
             )
             fakeAuthDiskSource.assertMasterPasswordHash(
                 userId = USER_ID_1,
@@ -2621,10 +2605,6 @@ class AuthRepositoryTest {
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
-            )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
             )
             coVerify {
                 identityService.getToken(
@@ -3003,10 +2983,6 @@ class AuthRepositoryTest {
             userId = USER_ID_1,
             accountKeys = ACCOUNT_KEYS,
         )
-        fakeAuthDiskSource.assertUserKey(
-            userId = USER_ID_1,
-            userKey = "key",
-        )
         coVerify {
             identityService.getToken(
                 email = EMAIL,
@@ -3272,10 +3248,6 @@ class AuthRepositoryTest {
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
             )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
-            )
             coVerify {
                 identityService.getToken(
                     email = EMAIL,
@@ -3397,10 +3369,6 @@ class AuthRepositoryTest {
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
-            )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
             )
             coVerify {
                 identityService.getToken(
@@ -3742,10 +3710,6 @@ class AuthRepositoryTest {
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
             )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
-            )
             coVerify {
                 identityService.getToken(
                     email = EMAIL,
@@ -3815,7 +3779,6 @@ class AuthRepositoryTest {
                 privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = ACCOUNT_KEYS)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = "key")
             coVerify(exactly = 1) {
                 identityService.getToken(
                     email = EMAIL,
@@ -3885,7 +3848,6 @@ class AuthRepositoryTest {
             assertEquals(LoginResult.Error(errorMessage = null, error = error), result)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = null)
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = null)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = null)
             coVerify(exactly = 1) {
                 identityService.getToken(
                     email = EMAIL,
@@ -3974,7 +3936,6 @@ class AuthRepositoryTest {
             assertEquals(LoginResult.Success, result)
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = "privateKey")
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = "key")
             coVerify(exactly = 1) {
                 identityService.getToken(
                     email = EMAIL,
@@ -4089,7 +4050,6 @@ class AuthRepositoryTest {
                 userId = USER_ID_1,
                 privateKey = "mockWrappedPrivateKey-1",
             )
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = "key")
             coVerify(exactly = 1) {
                 identityService.getToken(
                     email = EMAIL,
@@ -4195,7 +4155,6 @@ class AuthRepositoryTest {
             assertEquals(LoginResult.Error(errorMessage = null, error = error), continueResult)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = null)
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = null)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = null)
             coVerify(exactly = 1) {
                 identityService.getToken(
                     email = EMAIL,
@@ -4306,7 +4265,6 @@ class AuthRepositoryTest {
             assertEquals(LoginResult.Success, continueResult)
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = PRIVATE_KEY)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = ENCRYPTED_USER_KEY)
             coVerify(exactly = 1) {
                 identityService.getToken(
                     email = EMAIL,
@@ -4481,7 +4439,6 @@ class AuthRepositoryTest {
             assertEquals(LoginResult.Success, result)
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = "privateKey")
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = "encryptedUserKey")
             coVerify(exactly = 1) {
                 identityService.getToken(
                     email = EMAIL,
@@ -4571,10 +4528,6 @@ class AuthRepositoryTest {
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
-            )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
             )
             coVerify {
                 identityService.getToken(
@@ -4670,7 +4623,6 @@ class AuthRepositoryTest {
                 privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = ACCOUNT_KEYS)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = null)
             fakeAuthDiskSource.assertDeviceKey(userId = USER_ID_1, deviceKey = null)
             assertEquals(SINGLE_USER_STATE_1, fakeAuthDiskSource.userState)
             coVerify(exactly = 1) {
@@ -4771,7 +4723,6 @@ class AuthRepositoryTest {
                 privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = ACCOUNT_KEYS)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = encryptedUserKey)
             fakeAuthDiskSource.assertDeviceKey(userId = USER_ID_1, deviceKey = deviceKey)
             assertEquals(SINGLE_USER_STATE_1, fakeAuthDiskSource.userState)
             coVerify {
@@ -4901,7 +4852,6 @@ class AuthRepositoryTest {
                 privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = ACCOUNT_KEYS)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = authRequestKey)
             assertEquals(SINGLE_USER_STATE_1, fakeAuthDiskSource.userState)
             coVerify(exactly = 1) {
                 identityService.getToken(
@@ -4993,10 +4943,6 @@ class AuthRepositoryTest {
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
-            )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
             )
             coVerify {
                 identityService.getToken(
@@ -5205,10 +5151,6 @@ class AuthRepositoryTest {
         fakeAuthDiskSource.assertAccountKeys(
             userId = USER_ID_1,
             accountKeys = ACCOUNT_KEYS,
-        )
-        fakeAuthDiskSource.assertUserKey(
-            userId = USER_ID_1,
-            userKey = "key",
         )
         coVerify {
             identityService.getToken(
@@ -5692,7 +5634,6 @@ class AuthRepositoryTest {
         fakeAuthDiskSource.assertMasterPasswordHash(userId = USER_ID_1, passwordHash = null)
         fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = null)
         fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = null)
-        fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = null)
     }
 
     @Test
@@ -5722,7 +5663,6 @@ class AuthRepositoryTest {
             assertEquals(SetPasswordResult.Error(error = error), result)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = null)
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = null)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = null)
         }
 
     @Test
@@ -6044,7 +5984,6 @@ class AuthRepositoryTest {
         assertEquals(SetPasswordResult.Error(error = error), result)
         fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = null)
         fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = null)
-        fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = null)
     }
 
     @Test
@@ -6099,7 +6038,6 @@ class AuthRepositoryTest {
             assertEquals(SetPasswordResult.Error(error = error), result)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = null)
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = null)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = null)
         }
 
     @Test
@@ -6186,7 +6124,6 @@ class AuthRepositoryTest {
 
             assertEquals(SetPasswordResult.Success, result)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = privateRsaKey)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = encryptedUserKey)
             fakeAuthDiskSource.assertUserState(SINGLE_USER_STATE_1_WITH_PASS)
             coVerify(exactly = 1) {
                 authSdkSource.makeRegisterKeys(email = EMAIL, password = password, kdf = kdf)
@@ -6291,7 +6228,6 @@ class AuthRepositoryTest {
         assertEquals(SetPasswordResult.Success, result)
         fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = null)
         fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = null)
-        fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = encryptedUserKey)
         fakeAuthDiskSource.assertUserState(SINGLE_USER_STATE_1_WITH_PASS)
         coVerify(exactly = 1) {
             vaultSdkSource.updatePassword(userId = USER_ID_1, newPassword = password)
@@ -6369,7 +6305,6 @@ class AuthRepositoryTest {
 
             assertEquals(SetPasswordResult.Error(error = error), result)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = privateRsaKey)
-            fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = encryptedUserKey)
             fakeAuthDiskSource.assertUserState(SINGLE_USER_STATE_1)
             coVerify(exactly = 1) {
                 authSdkSource.makeRegisterKeys(email = EMAIL, password = password, kdf = kdf)
@@ -7686,10 +7621,6 @@ class AuthRepositoryTest {
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
             )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
-            )
             fakeAuthDiskSource.assertMasterPasswordHash(
                 userId = USER_ID_1,
                 passwordHash = PASSWORD_HASH,
@@ -7764,10 +7695,6 @@ class AuthRepositoryTest {
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
                 accountKeys = ACCOUNT_KEYS,
-            )
-            fakeAuthDiskSource.assertUserKey(
-                userId = USER_ID_1,
-                userKey = "key",
             )
             fakeAuthDiskSource.assertMasterPasswordHash(
                 userId = USER_ID_1,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
@@ -55,9 +55,8 @@ class UserStateJsonExtensionsTest {
         unmockkStatic(Kdf::toKdfRequestModel)
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `toUpdatedUserStateJson should do nothing for a non-matching account using toRemovedPasswordUserStateJson`() {
+    fun `toRemovedPasswordUserStateJson should do nothing for a non-matching account`() {
         val originalUserState = UserStateJson(
             activeUserId = "activeUserId",
             accounts = mapOf("activeUserId" to mockk()),
@@ -70,7 +69,7 @@ class UserStateJsonExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `toUpdatedUserStateJson should create user decryption options without a password if not present`() {
+    fun `toRemovedPasswordUserStateJson should create user decryption options without a password if not present`() {
         val originalProfile = AccountJson.Profile(
             userId = "activeUserId",
             email = "email",
@@ -120,8 +119,9 @@ class UserStateJsonExtensionsTest {
         )
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `toUpdatedUserStateJson should update user decryption options to not have a password`() {
+    fun `toRemovedPasswordUserStateJson should update user decryption options to not have a password`() {
         val originalProfile = AccountJson.Profile(
             userId = "activeUserId",
             email = "email",
@@ -141,7 +141,11 @@ class UserStateJsonExtensionsTest {
                 hasMasterPassword = true,
                 trustedDeviceUserDecryptionOptions = null,
                 keyConnectorUserDecryptionOptions = null,
-                masterPasswordUnlock = null,
+                masterPasswordUnlock = MasterPasswordUnlockDataJson(
+                    salt = "salt",
+                    kdf = mockk(),
+                    masterKeyWrappedUserKey = "masterKeyWrappedUserKey",
+                ),
             ),
             isTwoFactorEnabled = false,
             creationDate = Instant.parse("2024-09-13T01:00:00.00Z"),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerTest.kt
@@ -747,7 +747,6 @@ class VaultSyncManagerTest {
                 ),
             )
             fakeAuthDiskSource.assertUserState(userState = updatedUserState)
-            fakeAuthDiskSource.assertUserKey(userId = userId, userKey = "mockKey-1")
             fakeAuthDiskSource.assertPrivateKey(userId = userId, privateKey = "mockPrivateKey-1")
             fakeAuthDiskSource.assertOrganizationKeys(
                 userId = userId,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -504,10 +504,6 @@ class VaultRepositoryTest {
     @Test
     fun `unlockVaultWithMasterPassword with missing private key should return InvalidStateError`() =
         runTest {
-            fakeAuthDiskSource.storeUserKey(
-                userId = "mockId-1",
-                userKey = "mockKey-1",
-            )
             fakeAuthDiskSource.storePrivateKey(
                 userId = "mockId-1",
                 privateKey = null,
@@ -588,10 +584,6 @@ class VaultRepositoryTest {
                 ),
             )
 
-            fakeAuthDiskSource.storeUserKey(
-                userId = userId,
-                userKey = "mockKey-1",
-            )
             fakeAuthDiskSource.userState = userState
             fakeAuthDiskSource.storePrivateKey(userId = userId, privateKey = "mockPrivateKey-1")
 
@@ -657,7 +649,6 @@ class VaultRepositoryTest {
             )
             fakeAuthDiskSource.userState = userState
             fakeAuthDiskSource.storePrivateKey(userId = userId, privateKey = "mockPrivateKey-1")
-            fakeAuthDiskSource.storeUserKey(userId = userId, userKey = userKey)
 
             val result = vaultRepository.unlockVaultWithMasterPassword(
                 masterPassword = masterPassword,
@@ -1649,10 +1640,6 @@ class VaultRepositoryTest {
         fakeAuthDiskSource.storePrivateKey(
             userId = userId,
             privateKey = "mockPrivateKey-1",
-        )
-        fakeAuthDiskSource.storeUserKey(
-            userId = userId,
-            userKey = "mockKey-1",
         )
         fakeAuthDiskSource.storePinProtectedUserKey(
             userId = userId,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38358](https://bitwarden.atlassian.net/browse/PM-38358)

## 📔 Objective

This PR removes the stored encrypted user key from shared preferences and updates the remaining location that relied on it.


[PM-38358]: https://bitwarden.atlassian.net/browse/PM-38358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ