### PR TITLE
[PM-37571] chore: Remove unused isSdkSupported guard

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -451,14 +451,6 @@ class VaultAddEditViewModel @Inject constructor(
 
     @Suppress("LongMethod")
     private fun handleSaveClick() = onContent { content ->
-        if (!content.type.isSdkSupported) {
-            sendEvent(
-                VaultAddEditEvent.ShowSnackbar(
-                    message = BitwardenString.an_error_has_occurred.asText(),
-                ),
-            )
-            return@onContent
-        }
         if (hasValidationErrors(content)) return@onContent
 
         mutableStateFlow.update {
@@ -2982,11 +2974,6 @@ data class VaultAddEditState(
                  * A list of all the linked field types supported by this [ItemType].
                  */
                 abstract val vaultLinkedFieldTypes: ImmutableList<VaultLinkedFieldType>
-
-                /**
-                 * Whether this item type has SDK support for save operations.
-                 */
-                open val isSdkSupported: Boolean get() = true
 
                 /**
                  * Represents the login item information.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -2409,35 +2409,32 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `ItemType BankAccount should expose BANK_ACCOUNT itemTypeOption and be SDK supported`() {
+    fun `ItemType BankAccount should expose BANK_ACCOUNT itemTypeOption`() {
         val itemType = VaultAddEditState.ViewState.Content.ItemType.BankAccount()
         assertEquals(
             VaultAddEditState.ItemTypeOption.BANK_ACCOUNT,
             itemType.itemTypeOption,
         )
-        assertTrue(itemType.isSdkSupported)
         assertTrue(itemType.vaultLinkedFieldTypes.isEmpty())
     }
 
     @Test
-    fun `ItemType License should expose DRIVERS_LICENSE itemTypeOption and be SDK supported`() {
+    fun `ItemType License should expose DRIVERS_LICENSE itemTypeOption`() {
         val itemType = VaultAddEditState.ViewState.Content.ItemType.License()
         assertEquals(
             VaultAddEditState.ItemTypeOption.LICENSE,
             itemType.itemTypeOption,
         )
-        assertTrue(itemType.isSdkSupported)
         assertTrue(itemType.vaultLinkedFieldTypes.isEmpty())
     }
 
     @Test
-    fun `ItemType Passport should expose PASSPORT itemTypeOption and be SDK supported`() {
+    fun `ItemType Passport should expose PASSPORT itemTypeOption`() {
         val itemType = VaultAddEditState.ViewState.Content.ItemType.Passport()
         assertEquals(
             VaultAddEditState.ItemTypeOption.PASSPORT,
             itemType.itemTypeOption,
         )
-        assertTrue(itemType.isSdkSupported)
         assertTrue(itemType.vaultLinkedFieldTypes.isEmpty())
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37571

## 📔 Objective

Remove the `isSdkSupported` property and the save-path guard it fed. Now that every item type has SDK support, the property is always `true`, so the guard that blocked saving unsupported types is unreachable dead code.