### PR TITLE
🍒 [PM-38364] fix: Multiply subscription line-item cost by quantity

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.billing.repository.util
 import com.bitwarden.network.model.BitwardenDiscountJson
 import com.bitwarden.network.model.BitwardenSubscriptionResponseJson
 import com.bitwarden.network.model.CadenceTypeJson
+import com.bitwarden.network.model.CartItemJson
 import com.bitwarden.network.model.DiscountTypeJson
 import com.bitwarden.network.model.SubscriptionStatusJson
 import com.x8bit.bitwarden.data.billing.repository.model.PlanCadence
@@ -11,28 +12,35 @@ import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionInfo
 import java.math.BigDecimal
 import java.math.RoundingMode
 
-private val PERCENT_DIVISOR: BigDecimal = BigDecimal("100")
 private const val MONEY_SCALE: Int = 2
 
 /**
  * Maps a [BitwardenSubscriptionResponseJson] into a [SubscriptionInfo] domain
  * model.
  *
- * `discountAmount` is resolved at mapping time: fixed-amount discounts pass
- * through as-is; percent-off discounts apply to the password manager subtotal
- * (`seatsCost + storageCost`). `nextChargeTotal` is computed client-side as
- * `seatsCost + storageCost - discountAmount + estimatedTax` because the server
+ * Each line item's `cost` is a per-unit price, so its contribution is
+ * `cost * quantity`. Two discount channels are combined into `discountAmount`:
+ * the cart-level discount applies to the password manager subtotal
+ * (`seatsCost + storageCost`), and the Password Manager seats item-level
+ * discount applies to the seats line total. Item-level discounts on other line
+ * items are intentionally ignored, mirroring the web client. Fixed-amount
+ * discounts pass through as-is; percent-off discounts treat a value below 1 as
+ * an already-decimal fraction and round half-up. `nextChargeTotal` is computed
+ * client-side as `subtotal - discountAmount + estimatedTax` because the server
  * does not expose a precomputed total.
  */
 fun BitwardenSubscriptionResponseJson.toSubscriptionInfo(): SubscriptionInfo {
-    val seatsCost = cart.passwordManager.seats.cost
-    val storageCost = cart.passwordManager.additionalStorage?.cost
-    val discountAmount = cart.discount?.toMoneyAmount(
-        subtotal = seatsCost + (storageCost ?: BigDecimal.ZERO),
-    )
+    val seatsCost = cart.passwordManager.seats.lineTotal()
+    val storageCost = cart.passwordManager.additionalStorage?.lineTotal()
+    val subtotal = seatsCost + (storageCost ?: BigDecimal.ZERO)
+    val cartDiscount = cart.discount?.toDiscountAmount(baseAmount = subtotal)
+    val seatsDiscount = cart.passwordManager.seats.discount
+        ?.toDiscountAmount(baseAmount = seatsCost)
+    val discountAmount = listOfNotNull(cartDiscount, seatsDiscount)
+        .takeIf { it.isNotEmpty() }
+        ?.reduce(BigDecimal::add)
     val estimatedTax = cart.estimatedTax
-    val nextChargeTotal = seatsCost +
-        (storageCost ?: BigDecimal.ZERO) -
+    val nextChargeTotal = subtotal -
         (discountAmount ?: BigDecimal.ZERO) +
         estimatedTax
 
@@ -76,16 +84,18 @@ private fun BitwardenSubscriptionResponseJson.toPremiumSubscriptionStatus():
     SubscriptionStatusJson.PAUSED -> PremiumSubscriptionStatus.PAUSED
 }
 
+private fun CartItemJson.lineTotal(): BigDecimal = cost.multiply(quantity.toBigDecimal())
+
 private fun CadenceTypeJson.toPlanCadence(): PlanCadence = when (this) {
     CadenceTypeJson.ANNUALLY -> PlanCadence.ANNUALLY
     CadenceTypeJson.MONTHLY -> PlanCadence.MONTHLY
 }
 
-private fun BitwardenDiscountJson.toMoneyAmount(subtotal: BigDecimal): BigDecimal =
+private fun BitwardenDiscountJson.toDiscountAmount(baseAmount: BigDecimal): BigDecimal =
     when (type) {
         DiscountTypeJson.AMOUNT_OFF -> value
-        DiscountTypeJson.PERCENT_OFF ->
-            subtotal
-                .multiply(value)
-                .divide(PERCENT_DIVISOR, MONEY_SCALE, RoundingMode.HALF_EVEN)
+        DiscountTypeJson.PERCENT_OFF -> {
+            val percentage = if (value < BigDecimal.ONE) value else value.movePointLeft(2)
+            baseAmount.multiply(percentage).setScale(MONEY_SCALE, RoundingMode.HALF_UP)
+        }
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
@@ -127,6 +127,24 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
     }
 
     @Test
+    fun `toSubscriptionInfo storageCost multiplies unit cost by quantity`() {
+        val info = buildResponse(
+            storageCost = BigDecimal("4"),
+            storageQuantity = 3,
+        ).toSubscriptionInfo()
+        assertEquals(BigDecimal("12"), info.storageCost)
+    }
+
+    @Test
+    fun `toSubscriptionInfo seatsCost multiplies unit cost by quantity`() {
+        val info = buildResponse(
+            seatsCost = BigDecimal("19.80"),
+            seatsQuantity = 2,
+        ).toSubscriptionInfo()
+        assertEquals(BigDecimal("39.60"), info.seatsCost)
+    }
+
+    @Test
     fun `toSubscriptionInfo discountAmount is null when no discount`() {
         val info = buildResponse(discount = null).toSubscriptionInfo()
         assertNull(info.discountAmount)
@@ -158,6 +176,77 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
     }
 
     @Test
+    fun `toSubscriptionInfo PERCENT_OFF discount treats value below one as a decimal fraction`() {
+        val info = buildResponse(
+            seatsCost = BigDecimal("20.00"),
+            discount = BitwardenDiscountJson(
+                type = DiscountTypeJson.PERCENT_OFF,
+                value = BigDecimal("0.5"),
+            ),
+        ).toSubscriptionInfo()
+        assertEquals(BigDecimal("10.00"), info.discountAmount)
+    }
+
+    @Test
+    fun `toSubscriptionInfo applies PM seats item-level discount`() {
+        val info = buildResponse(
+            seatsCost = BigDecimal("19.80"),
+            seatsDiscount = BitwardenDiscountJson(
+                type = DiscountTypeJson.AMOUNT_OFF,
+                value = BigDecimal("5.00"),
+            ),
+        ).toSubscriptionInfo()
+        assertEquals(BigDecimal("5.00"), info.discountAmount)
+        assertEquals(BigDecimal("14.80"), info.nextChargeTotal)
+    }
+
+    @Test
+    fun `toSubscriptionInfo PERCENT_OFF seats item discount applies to seats line total`() {
+        val info = buildResponse(
+            seatsCost = BigDecimal("19.80"),
+            seatsQuantity = 2,
+            seatsDiscount = BitwardenDiscountJson(
+                type = DiscountTypeJson.PERCENT_OFF,
+                value = BigDecimal("10.00"),
+            ),
+        ).toSubscriptionInfo()
+        assertEquals(BigDecimal("3.96"), info.discountAmount)
+    }
+
+    @Test
+    fun `toSubscriptionInfo combines cart-level and PM seats item discounts`() {
+        val info = buildResponse(
+            seatsCost = BigDecimal("19.80"),
+            seatsDiscount = BitwardenDiscountJson(
+                type = DiscountTypeJson.AMOUNT_OFF,
+                value = BigDecimal("3.00"),
+            ),
+            discount = BitwardenDiscountJson(
+                type = DiscountTypeJson.AMOUNT_OFF,
+                value = BigDecimal("2.00"),
+            ),
+            estimatedTax = BigDecimal("1.00"),
+        ).toSubscriptionInfo()
+        assertEquals(BigDecimal("5.00"), info.discountAmount)
+        assertEquals(BigDecimal("15.80"), info.nextChargeTotal)
+    }
+
+    @Test
+    fun `toSubscriptionInfo ignores additionalStorage item-level discount`() {
+        val info = buildResponse(
+            seatsCost = BigDecimal("19.80"),
+            storageCost = BigDecimal("4"),
+            storageQuantity = 3,
+            storageDiscount = BitwardenDiscountJson(
+                type = DiscountTypeJson.AMOUNT_OFF,
+                value = BigDecimal("5.00"),
+            ),
+        ).toSubscriptionInfo()
+        assertNull(info.discountAmount)
+        assertEquals(BigDecimal("31.80"), info.nextChargeTotal)
+    }
+
+    @Test
     fun `toSubscriptionInfo passes estimatedTax through`() {
         val info = buildResponse(estimatedTax = BigDecimal("3.85")).toSubscriptionInfo()
         assertEquals(BigDecimal("3.85"), info.estimatedTax)
@@ -176,6 +265,31 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
             estimatedTax = BigDecimal("3.85"),
         ).toSubscriptionInfo()
         assertEquals(BigDecimal("45.55"), info.nextChargeTotal)
+    }
+
+    @Test
+    fun `toSubscriptionInfo nextChargeTotal multiplies storage line by quantity`() {
+        val info = buildResponse(
+            seatsCost = BigDecimal("19.80"),
+            storageCost = BigDecimal("4"),
+            storageQuantity = 3,
+            estimatedTax = BigDecimal("2.04"),
+        ).toSubscriptionInfo()
+        assertEquals(BigDecimal("33.84"), info.nextChargeTotal)
+    }
+
+    @Test
+    fun `toSubscriptionInfo PERCENT_OFF discount applies to quantity-multiplied subtotal`() {
+        val info = buildResponse(
+            seatsCost = BigDecimal("19.80"),
+            storageCost = BigDecimal("4"),
+            storageQuantity = 3,
+            discount = BitwardenDiscountJson(
+                type = DiscountTypeJson.PERCENT_OFF,
+                value = BigDecimal("10.00"),
+            ),
+        ).toSubscriptionInfo()
+        assertEquals(BigDecimal("3.18"), info.discountAmount)
     }
 
     @Test
@@ -217,7 +331,11 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
         status: SubscriptionStatusJson = SubscriptionStatusJson.ACTIVE,
         cadence: CadenceTypeJson = CadenceTypeJson.ANNUALLY,
         seatsCost: BigDecimal = BigDecimal("19.80"),
+        seatsQuantity: Long = 1,
+        seatsDiscount: BitwardenDiscountJson? = null,
         storageCost: BigDecimal? = null,
+        storageQuantity: Long = 1,
+        storageDiscount: BitwardenDiscountJson? = null,
         discount: BitwardenDiscountJson? = null,
         estimatedTax: BigDecimal = BigDecimal.ZERO,
         storage: StorageJson? = null,
@@ -232,16 +350,16 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
             passwordManager = PasswordManagerCartItemsJson(
                 seats = CartItemJson(
                     translationKey = "premiumMembership",
-                    quantity = 1,
+                    quantity = seatsQuantity,
                     cost = seatsCost,
-                    discount = null,
+                    discount = seatsDiscount,
                 ),
                 additionalStorage = storageCost?.let {
                     CartItemJson(
                         translationKey = "additionalStorage",
-                        quantity = 1,
+                        quantity = storageQuantity,
                         cost = it,
-                        discount = null,
+                        discount = storageDiscount,
                     )
                 },
             ),


### PR DESCRIPTION
## 🎟️ Tracking

Cherry-pick of #7012 onto `release/2026.5-rc55`.

https://bitwarden.atlassian.net/browse/PM-38364

## 📔 Objective

Subscription cart totals were computed from each line item's per-unit `cost` without applying its `quantity`, so multi-unit additional storage (e.g. 3 GB at $4/GB) was presented as a single unit — undercharging the displayed storage cost and next-charge total.

This corrects the mapping so each line item contributes `cost × quantity`. It also brings two discount behaviors into parity with the web client's `cart-summary` component, verified against the `server` contract:

- The Password Manager seats item-level discount is now applied (against the seats line total) in addition to the cart-level discount; both are combined into the surfaced discount amount.
- Percent-off discounts treat a value below 1 as an already-decimal fraction and round half-up, matching the web client's arithmetic.

Item-level discounts on other line items remain intentionally unapplied, mirroring the web client's current scope. The single-object discount model was verified against the server source and required no change.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/d23437bf-dba9-499d-a82e-e9fe6be6933e" /> | <img width="365" src="https://github.com/user-attachments/assets/0a3f38cf-892d-45d1-abb9-92a6e17127b4" /> |