### PR TITLE
BWA-252: bug: Empty string totp codes should not be counted as a totp code

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
@@ -4,6 +4,7 @@ import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.decodeFromStringWithErrorCallback
 import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.ui.platform.base.util.orNullIfBlank
 import com.x8bit.bitwarden.data.vault.datasource.disk.dao.CiphersDao
 import com.x8bit.bitwarden.data.vault.datasource.disk.dao.CollectionsDao
 import com.x8bit.bitwarden.data.vault.datasource.disk.dao.DomainsDao
@@ -134,7 +135,7 @@ class VaultDiskSourceImpl(
                 .filter {
                     // A safety-check since after the DB migration, we will temporarily think
                     // all ciphers contain a totp code
-                    it.login?.totp != null
+                    it.login?.totp.orNullIfBlank() != null
                 }
         }
     }
@@ -166,7 +167,7 @@ class VaultDiskSourceImpl(
                 CipherEntity(
                     id = cipher.id,
                     userId = userId,
-                    hasTotp = cipher.login?.totp != null,
+                    hasTotp = cipher.login?.totp.orNullIfBlank() != null,
                     cipherType = json.encodeToString(cipher.type),
                     cipherJson = json.encodeToString(cipher),
                     organizationId = cipher.organizationId,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
@@ -294,7 +294,7 @@ private fun VaultAddEditState.ViewState.Content.ItemType.toLoginView(
                 clock = clock,
             ),
             uris = it.uriList.toLoginUriView(),
-            totp = it.totp,
+            totp = it.totp.orNullIfBlank(),
             autofillOnPageLoad = common.originalCipher?.login?.autofillOnPageLoad,
             fido2Credentials = common.originalCipher?.login?.fido2Credentials
                 .takeIf { _ -> it.fido2CredentialCreationDateTime != null },


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-252](https://bitwarden.atlassian.net/browse/BWA-252)

## 📔 Objective

This PR filter out ciphers that have nonnull totp values but the values are blank.


[BWA-252]: https://bitwarden.atlassian.net/browse/BWA-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ