### PR TITLE
[PM-38537] Add support for Titanium Browser

### DIFF
--- a/app/src/main/assets/fido2_privileged_community.json
+++ b/app/src/main/assets/fido2_privileged_community.json
@@ -115,6 +115,18 @@
           }
         ]
       }
+    },
+    {
+      "type": "android",
+      "info": {
+        "package_name": "io.github.jqssun.helium",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "09:55:40:49:4D:53:F4:8C:A0:51:BC:86:C3:92:C4:6E:DB:29:72:5D:A5:59:2B:D8:AF:3C:3D:02:7B:31:66:BB"
+          }
+        ]
+      }
     }
   ]
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/util/BrowserUtil.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/util/BrowserUtil.kt
@@ -127,6 +127,7 @@ private val ACCESSIBILITY_SUPPORTED_BROWSERS = listOf(
         possibleUrlSemanticIds = listOf("ADDRESSBAR_URL_BOX"),
         urlExtractor = mozillaUrlExtractor,
     ),
+    Browser(packageName = "io.github.jqssun.helium", urlFieldId = "url_bar"),
     Browser(packageName = "mark.via", urlFieldId = "am,an"),
     Browser(packageName = "mark.via.gp", urlFieldId = "as"),
     Browser(packageName = "net.dezor.browser", urlFieldId = "url_bar"),

--- a/app/src/main/res/xml/autofill_service_configuration.xml
+++ b/app/src/main/res/xml/autofill_service_configuration.xml
@@ -197,6 +197,9 @@
         android:name="io.github.forkmaintainers.iceraven"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package
+        android:name="io.github.jqssun.helium"
+        android:maxLongVersionCode="10000000000" />
+    <compatibility-package
         android:name="mark.via"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/jqssun/android-titanium-browser/issues/24
https://github.com/jqssun/android-titanium-browser/issues/48

## 📔 Objective

Required for passkey and autofill support on [Titanium](https://github.com/jqssun/android-titanium-browser), which is based on Chromium. 

This browser is also available on Google Play Store at https://play.google.com/store/apps/details?id=io.github.jqssun.helium

## 📸 Screenshots

https://github.com/user-attachments/assets/9ffa190e-d10a-425e-9f66-0bfb6441a876
