### PR TITLE
PM-38534: bug: Update LoginResult to use friendly error message

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -612,15 +612,12 @@ class AuthRepositoryImpl(
         asymmetricalKey: String,
     ): LoginResult {
         val profile = authDiskSource.userState?.activeAccount?.profile
-            ?: return LoginResult.Error(errorMessage = null, error = NoActiveUserException())
+            ?: return LoginResult.Error(error = NoActiveUserException())
         val userId = profile.userId
         val accountKeys = authDiskSource.getAccountKeys(userId = userId)
         val privateKey = accountKeys?.publicKeyEncryptionKeyPair?.wrappedPrivateKey
             ?: authDiskSource.getPrivateKey(userId = userId)
-            ?: return LoginResult.Error(
-                errorMessage = null,
-                error = MissingPropertyException("Private Key"),
-            )
+            ?: return LoginResult.Error(error = MissingPropertyException("Private Key"))
 
         checkForVaultUnlockError(
             onVaultUnlockError = { error ->
@@ -670,7 +667,7 @@ class AuthRepositoryImpl(
             onFailure = { throwable ->
                 when {
                     throwable.isSslHandShakeError() -> LoginResult.CertificateError
-                    else -> LoginResult.Error(errorMessage = null, error = throwable)
+                    else -> LoginResult.Error(error = throwable)
                 }
             },
             onSuccess = { it },
@@ -715,10 +712,7 @@ class AuthRepositoryImpl(
                 orgIdentifier = orgIdentifier,
             )
         }
-        ?: LoginResult.Error(
-            errorMessage = null,
-            error = MissingPropertyException("Identity Token Auth Model"),
-        )
+        ?: LoginResult.Error(error = MissingPropertyException("Identity Token Auth Model"))
 
     override suspend fun login(
         email: String,
@@ -736,17 +730,13 @@ class AuthRepositoryImpl(
                 orgIdentifier = orgIdentifier,
             )
         }
-        ?: LoginResult.Error(
-            errorMessage = null,
-            error = MissingPropertyException("Identity Token Auth Model"),
-        )
+        ?: LoginResult.Error(error = MissingPropertyException("Identity Token Auth Model"))
 
     override suspend fun continueKeyConnectorLogin(
         orgIdentifier: String,
         email: String,
     ): LoginResult {
         val response = keyConnectorResponse ?: return LoginResult.Error(
-            errorMessage = null,
             error = MissingPropertyException("Key Connector Response"),
         )
         return handleLoginCommonSuccess(
@@ -1815,10 +1805,7 @@ class AuthRepositoryImpl(
                         LoginResult.UnofficialServerError
                     }
 
-                    else -> LoginResult.Error(
-                        errorMessage = null,
-                        error = throwable,
-                    )
+                    else -> LoginResult.Error(error = throwable)
                 }
             },
             onSuccess = { loginResponse ->

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LoginResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LoginResult.kt
@@ -1,5 +1,7 @@
 package com.x8bit.bitwarden.data.auth.repository.model
 
+import com.x8bit.bitwarden.data.platform.util.userFriendlyMessage
+
 /**
  * Models result of logging in.
  */
@@ -30,8 +32,8 @@ sealed class LoginResult {
      * There was an error logging in.
      */
     data class Error(
-        val errorMessage: String?,
         val error: Throwable?,
+        val errorMessage: String? = error?.userFriendlyMessage,
     ) : LoginResult()
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensions.kt
@@ -15,5 +15,5 @@ fun VaultUnlockError.toLoginErrorResult(): LoginResult.Error = when (this) {
     is VaultUnlockResult.BiometricDecodingError,
     is VaultUnlockResult.GenericError,
     is VaultUnlockResult.InvalidStateError,
-        -> LoginResult.Error(errorMessage = null, error = this.error)
+        -> LoginResult.Error(error = this.error)
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -207,11 +207,7 @@ class AuthRepositoryTest {
         every { storeUserHasLoggedInValue(any()) } just runs
     }
     private val authSdkSource = mockk<AuthSdkSource> {
-        coEvery {
-            getNewAuthRequest(
-                email = EMAIL,
-            )
-        } returns AUTH_REQUEST_RESPONSE.asSuccess()
+        coEvery { getNewAuthRequest(email = EMAIL) } returns AUTH_REQUEST_RESPONSE.asSuccess()
         coEvery {
             hashPassword(
                 email = EMAIL,
@@ -247,10 +243,7 @@ class AuthRepositoryTest {
     private val configDiskSource = FakeConfigDiskSource()
     private val vaultSdkSource = mockk<VaultSdkSource> {
         coEvery {
-            getAuthRequestKey(
-                publicKey = PUBLIC_KEY,
-                userId = USER_ID_1,
-            )
+            getAuthRequestKey(publicKey = PUBLIC_KEY, userId = USER_ID_1)
         } returns "AsymmetricEncString".asSuccess()
     }
     private val authRequestManager: AuthRequestManager = mockk()
@@ -282,7 +275,9 @@ class AuthRepositoryTest {
             hasPendingAccountAdditionStateFlow
         } returns mutableHasPendingAccountAdditionStateFlow
         every { hasPendingAccountAddition = any() } just runs
-        every { hasPendingAccountAddition } returns mutableHasPendingAccountAdditionStateFlow.value
+        every {
+            hasPendingAccountAddition
+        } answers { mutableHasPendingAccountAdditionStateFlow.value }
         every { hasPendingAccountDeletion = any() } just runs
         val blockSlot = slot<suspend () -> LoginResult>()
         coEvery { userStateTransaction(capture(blockSlot)) } coAnswers { blockSlot.captured() }
@@ -1561,7 +1556,7 @@ class AuthRepositoryTest {
             asymmetricalKey = asymmetricalKey,
         )
         assertEquals(
-            LoginResult.Error(errorMessage = null, error = NoActiveUserException()),
+            LoginResult.Error(error = NoActiveUserException()),
             result,
         )
     }
@@ -1577,10 +1572,7 @@ class AuthRepositoryTest {
                 asymmetricalKey = asymmetricalKey,
             )
             assertEquals(
-                LoginResult.Error(
-                    errorMessage = null,
-                    error = MissingPropertyException("Private Key"),
-                ),
+                LoginResult.Error(error = MissingPropertyException("Private Key")),
                 result,
             )
         }
@@ -1597,10 +1589,7 @@ class AuthRepositoryTest {
                 asymmetricalKey = asymmetricalKey,
             )
             assertEquals(
-                LoginResult.Error(
-                    errorMessage = null,
-                    error = MissingPropertyException("Private Key"),
-                ),
+                LoginResult.Error(error = MissingPropertyException("Private Key")),
                 result,
             )
         }
@@ -1841,7 +1830,7 @@ class AuthRepositoryTest {
             vaultRepository.syncIfNecessary()
             settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
         }
-        assertEquals(LoginResult.Error(errorMessage = null, error = error), result)
+        assertEquals(LoginResult.Error(error = error), result)
     }
 
     @Suppress("MaxLineLength")
@@ -1910,7 +1899,7 @@ class AuthRepositoryTest {
             identityService.preLogin(email = EMAIL)
         } returns error.asFailure()
         val result = repository.login(email = EMAIL, password = PASSWORD)
-        assertEquals(LoginResult.Error(errorMessage = null, error = error), result)
+        assertEquals(LoginResult.Error(error = error), result)
         assertEquals(AuthState.Unauthenticated, repository.authStateFlow.value)
         coVerify { identityService.preLogin(email = EMAIL) }
     }
@@ -1935,7 +1924,7 @@ class AuthRepositoryTest {
                 )
             } returns error.asFailure()
             val result = repository.login(email = EMAIL, password = PASSWORD)
-            assertEquals(LoginResult.Error(errorMessage = null, error = error), result)
+            assertEquals(LoginResult.Error(error = error), result)
             assertEquals(AuthState.Unauthenticated, repository.authStateFlow.value)
             coVerify { identityService.preLogin(email = EMAIL) }
             coVerify {
@@ -2900,7 +2889,7 @@ class AuthRepositoryTest {
                 twoFactorData = TWO_FACTOR_DATA,
                 orgIdentifier = null,
             )
-            assertEquals(LoginResult.Error(errorMessage = null, error = error), finalResult)
+            assertEquals(LoginResult.Error(error = error), finalResult)
             assertEquals(twoFactorResponse, repository.twoFactorResponse)
             fakeAuthDiskSource.assertTwoFactorToken(
                 email = EMAIL,
@@ -3039,10 +3028,7 @@ class AuthRepositoryTest {
             orgIdentifier = null,
         )
         assertEquals(
-            LoginResult.Error(
-                errorMessage = null,
-                error = MissingPropertyException("Identity Token Auth Model"),
-            ),
+            LoginResult.Error(error = MissingPropertyException("Identity Token Auth Model")),
             result,
         )
     }
@@ -3111,7 +3097,7 @@ class AuthRepositoryTest {
             requestPrivateKey = DEVICE_REQUEST_PRIVATE_KEY,
             masterPasswordHash = PASSWORD_HASH,
         )
-        assertEquals(LoginResult.Error(errorMessage = null, error = error), result)
+        assertEquals(LoginResult.Error(error = error), result)
         assertEquals(AuthState.Unauthenticated, repository.authStateFlow.value)
         coVerify {
             identityService.getToken(
@@ -3608,7 +3594,7 @@ class AuthRepositoryTest {
             ssoRedirectUri = SSO_REDIRECT_URI,
             organizationIdentifier = ORGANIZATION_IDENTIFIER,
         )
-        assertEquals(LoginResult.Error(errorMessage = null, error = error), result)
+        assertEquals(LoginResult.Error(error = error), result)
         assertEquals(AuthState.Unauthenticated, repository.authStateFlow.value)
         coVerify {
             identityService.getToken(
@@ -3856,7 +3842,7 @@ class AuthRepositoryTest {
                 organizationIdentifier = ORGANIZATION_IDENTIFIER,
             )
 
-            assertEquals(LoginResult.Error(errorMessage = null, error = error), result)
+            assertEquals(LoginResult.Error(error = error), result)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = null)
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = null)
             fakeAuthDiskSource.assertAccountTokens(userId = USER_ID_1, accountTokens = null)
@@ -4148,7 +4134,7 @@ class AuthRepositoryTest {
                 orgIdentifier = ORGANIZATION_IDENTIFIER,
                 email = EMAIL,
             )
-            assertEquals(LoginResult.Error(errorMessage = null, error = error), continueResult)
+            assertEquals(LoginResult.Error(error = error), continueResult)
             fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = null)
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = null)
             coVerify(exactly = 1) {
@@ -7717,10 +7703,7 @@ class AuthRepositoryTest {
                 email = EMAIL,
             )
             assertEquals(
-                LoginResult.Error(
-                    errorMessage = null,
-                    error = MissingPropertyException("Key Connector Response"),
-                ),
+                LoginResult.Error(error = MissingPropertyException("Key Connector Response")),
                 continueResult,
             )
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensionsTest.kt
@@ -24,7 +24,7 @@ class LoginResultExtensionsTest {
     fun `VaultUnlockResult with null error message as default maps to LoginResult Error with null message`() {
         val error = Throwable("Fail")
         val result = VaultUnlockResult.AuthenticationError(error = error).toLoginErrorResult()
-        assertEquals(LoginResult.Error(errorMessage = null, error = error), result)
+        assertEquals(LoginResult.Error(error = error), result)
     }
 
     @Test
@@ -36,7 +36,7 @@ class LoginResultExtensionsTest {
         val genericErrorResult = VaultUnlockResult.GenericError(error = error).toLoginErrorResult()
         val biometricErrorResult =
             VaultUnlockResult.BiometricDecodingError(error = error).toLoginErrorResult()
-        val expectedResult = LoginResult.Error(errorMessage = null, error = error)
+        val expectedResult = LoginResult.Error(error = error)
 
         assertEquals(expectedResult, invalidStateResult)
         assertEquals(expectedResult, genericErrorResult)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
@@ -338,7 +338,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
             val error = Throwable("Fail!")
             coEvery {
                 authRepository.login(any(), any(), any(), any(), any())
-            } returns LoginResult.Error(errorMessage = null, error = error)
+            } returns LoginResult.Error(error = error)
 
             val viewModel = createViewModel(
                 ssoData = DEFAULT_SSO_DATA,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
@@ -350,7 +350,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     requestPrivateKey = DEFAULT_LOGIN_DATA.privateKey,
                     masterPasswordHash = DEFAULT_LOGIN_DATA.masterPasswordHash,
                 )
-            } returns LoginResult.Error(errorMessage = null, error = error)
+            } returns LoginResult.Error(error = error)
             val viewModel = createViewModel()
             viewModel.eventFlow.test {
                 viewModel.stateFlow.test {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -569,7 +569,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                 ),
                 orgIdentifier = DEFAULT_ORG_IDENTIFIER,
             )
-        } returns LoginResult.Error(errorMessage = null, error = error)
+        } returns LoginResult.Error(error = error)
 
         val viewModel = createViewModel()
         viewModel.stateFlow.test {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38534](https://bitwarden.atlassian.net/browse/PM-38534)

## 📔 Objective

This PR updates the `LoginResult` to use the `userFriendlyMessage` for default construction. This will help improve the error messages displayed in the UI when a login fails.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/c6f9dd25-77b2-4621-a49d-af71931a6ba3" /> | <img width="350" src="https://github.com/user-attachments/assets/9a29a6a1-d445-4506-bfac-b5fce2c1deb3" /> |



[PM-38534]: https://bitwarden.atlassian.net/browse/PM-38534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ