### PR TITLE
PM-38587: Feat: Add accessibility service disclaimer at startup

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.core.app.ActivityCompat
 import androidx.core.os.LocaleListCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -25,6 +26,8 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.ui.platform.base.util.EventsEffect
+import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.platform.util.setHorizonOSAppLayout
 import com.bitwarden.ui.platform.util.setupEdgeToEdge
@@ -110,6 +113,7 @@ class MainActivity : AppCompatActivity() {
         )
     }
 
+    @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         intent = intent.validate()
         var shouldShowSplashScreen = true
@@ -143,6 +147,14 @@ class MainActivity : AppCompatActivity() {
                     theme = state.theme,
                     dynamicColor = state.isDynamicColorsEnabled,
                 ) {
+                    MainActivityDialogs(
+                        dialogState = state.dialogState,
+                        onAccessibilityDisclaimerDismiss = {
+                            mainViewModel.trySendAction(
+                                MainAction.DismissAccessibilityDisclaimerDialog,
+                            )
+                        },
+                    )
                     NavHost(
                         navController = navController,
                         startDestination = RootNavigationRoute,
@@ -235,6 +247,26 @@ class MainActivity : AppCompatActivity() {
             setHorizonOSAppLayout {
                 mainViewModel.trySendAction(MainAction.Internal.ResizeHasBeenRequested)
             }
+        }
+    }
+
+    @Composable
+    private fun MainActivityDialogs(
+        dialogState: MainState.DialogState?,
+        onAccessibilityDisclaimerDismiss: () -> Unit,
+    ) {
+        when (dialogState) {
+            MainState.DialogState.AccessibilityDisclosure -> {
+                BitwardenBasicDialog(
+                    title = stringResource(id = BitwardenString.accessibility_service_disclosure),
+                    message = stringResource(
+                        id = BitwardenString.accessibility_disclosure_start_up_text,
+                    ),
+                    onDismissRequest = onAccessibilityDisclaimerDismiss,
+                )
+            }
+
+            null -> Unit
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -43,6 +43,7 @@ import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.util.isAddTotpLoginItemFromAuthenticator
 import com.x8bit.bitwarden.data.vault.manager.model.VaultStateEvent
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import com.x8bit.bitwarden.ui.platform.feature.rootnav.RootNavViewModel
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.x8bit.bitwarden.ui.platform.model.FeatureFlagsState
 import com.x8bit.bitwarden.ui.platform.util.isAccountSecurityShortcut
@@ -101,6 +102,7 @@ class MainViewModel @Inject constructor(
         isScreenCaptureAllowed = settingsRepository.isScreenCaptureAllowed,
         isDynamicColorsEnabled = settingsRepository.isDynamicColorsEnabled,
         hasResizeBeenRequested = false,
+        dialogState = null,
     ),
 ) {
     private var specialCircumstance: SpecialCircumstance?
@@ -148,6 +150,12 @@ class MainViewModel @Inject constructor(
         settingsRepository
             .isDynamicColorsEnabledFlow
             .map { MainAction.Internal.DynamicColorsUpdate(it) }
+            .onEach(::trySendAction)
+            .launchIn(viewModelScope)
+
+        settingsRepository
+            .hasShownAccessibilityDisclaimerFlow
+            .map { MainAction.Internal.HasShownAccessibilityDisclaimerUpdate(it) }
             .onEach(::trySendAction)
             .launchIn(viewModelScope)
 
@@ -211,6 +219,10 @@ class MainViewModel @Inject constructor(
             is MainAction.CookieAcquisitionResult -> handleCookieAcquisitionResult(action)
             is MainAction.PremiumCheckoutResult -> handlePremiumCheckoutResult(action)
             is MainAction.StripePortalResult -> handleStripePortalResult()
+            is MainAction.DismissAccessibilityDisclaimerDialog -> {
+                handleDismissAccessibilityDisclaimerDialog()
+            }
+
             is MainAction.Internal -> handleInternalAction(action)
         }
     }
@@ -235,6 +247,20 @@ class MainViewModel @Inject constructor(
             is MainAction.Internal.CookieAcquisitionReady -> handleCookieAcquisitionReady()
             is MainAction.Internal.LocalNetworkAccessRequired -> handleLocalNetworkAccessRequired()
             is MainAction.Internal.ResizeHasBeenRequested -> handleResizeHasBeenRequested()
+            is MainAction.Internal.HasShownAccessibilityDisclaimerUpdate -> {
+                handleHasShownAccessibilityDisclaimerUpdate(action)
+            }
+        }
+    }
+
+    private fun handleHasShownAccessibilityDisclaimerUpdate(
+        action: MainAction.Internal.HasShownAccessibilityDisclaimerUpdate,
+    ) {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = MainState.DialogState.AccessibilityDisclosure
+                    .takeUnless { action.hasBeenShown },
+            )
         }
     }
 
@@ -270,6 +296,10 @@ class MainViewModel @Inject constructor(
 
     private fun handleStripePortalResult() {
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.StripePortal
+    }
+
+    private fun handleDismissAccessibilityDisclaimerDialog() {
+        settingsRepository.accessibilityDisclaimerHasBeenShown()
     }
 
     private fun handleAppResumeDataUpdated(action: MainAction.ResumeScreenDataReceived) {
@@ -557,12 +587,25 @@ data class MainState(
     val isScreenCaptureAllowed: Boolean,
     val isDynamicColorsEnabled: Boolean,
     val hasResizeBeenRequested: Boolean,
+    val dialogState: DialogState?,
 ) : Parcelable {
     /**
      * Contains all feature flags that are available to the UI.
      */
     val featureFlagsState: FeatureFlagsState
         get() = FeatureFlagsState
+
+    /**
+     * Representation of all dialogs displayed from the [MainActivity].
+     */
+    @Parcelize
+    sealed class DialogState : Parcelable {
+        /**
+         * Displays an accessibility disclosure to users explaining how we utilize the
+         * AccessibilityService.
+         */
+        data object AccessibilityDisclosure : DialogState()
+    }
 }
 
 /**
@@ -633,6 +676,11 @@ sealed class MainAction {
     data class AppSpecificLanguageUpdate(val appLanguage: AppLanguage) : MainAction()
 
     /**
+     * Received if the user dismisses the accessibility disclaimer dialog.
+     */
+    data object DismissAccessibilityDisclaimerDialog : MainAction()
+
+    /**
      * Actions for internal use by the ViewModel.
      */
     sealed class Internal : MainAction() {
@@ -692,6 +740,11 @@ sealed class MainAction {
          * Indicates that resize has been requested on the Activity
          */
         data object ResizeHasBeenRequested : Internal()
+
+        /**
+         * Indicates that the accessibility disclaimer has been displayed.
+         */
+        data class HasShownAccessibilityDisclaimerUpdate(val hasBeenShown: Boolean) : Internal()
     }
 }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -41,6 +41,17 @@ interface SettingsDiskSource : FlightRecorderDiskSource {
     var initialAutofillDialogShown: Boolean?
 
     /**
+     * Indicates if the accessibility disclaimer has been displayed to the user.
+     */
+    var hasShownAccessibilityDisclaimer: Boolean?
+
+    /**
+     * Emits up-to-date values indicating if the accessibility disclaimer has been displayed to
+     * the user.
+     */
+    val hasShownAccessibilityDisclaimerFlow: Flow<Boolean?>
+
+    /**
      * The currently persisted app theme (or `null` if not set).
      */
     var appTheme: AppTheme

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -35,6 +35,7 @@ private const val ACCOUNT_BIOMETRIC_INTEGRITY_VALID_KEY = "accountBiometricInteg
 private const val CRASH_LOGGING_ENABLED_KEY = "crashLoggingEnabled"
 private const val CLEAR_CLIPBOARD_INTERVAL_KEY = "clearClipboard"
 private const val INITIAL_AUTOFILL_DIALOG_SHOWN = "addSitePromptShown"
+private const val HAS_SHOWN_ACCESSIBILITY_DISCLAIMER_KEY = "hasShownAccessibilityDisclaimer"
 private const val HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY = "hasUserLoggedInOrCreatedAccount"
 private const val SHOW_AUTOFILL_SETTING_BADGE = "showAutofillSettingBadge"
 private const val SHOW_BROWSER_AUTOFILL_SETTING_BADGE = "showBrowserAutofillSettingBadge"
@@ -128,6 +129,8 @@ class SettingsDiskSourceImpl(
 
     private val mutableIsDynamicColorsEnabledFlow = bufferedMutableSharedFlow<Boolean?>()
 
+    private val mutableHasShownAccessibilityDisclaimerFlow = bufferedMutableSharedFlow<Boolean?>()
+
     init {
         migrateScreenCaptureSetting()
     }
@@ -166,6 +169,17 @@ class SettingsDiskSourceImpl(
                 value = value,
             )
         }
+
+    override var hasShownAccessibilityDisclaimer: Boolean?
+        set(value) {
+            putBoolean(HAS_SHOWN_ACCESSIBILITY_DISCLAIMER_KEY, value)
+            mutableHasShownAccessibilityDisclaimerFlow.tryEmit(value)
+        }
+        get() = getBoolean(HAS_SHOWN_ACCESSIBILITY_DISCLAIMER_KEY)
+
+    override val hasShownAccessibilityDisclaimerFlow: Flow<Boolean?>
+        get() = mutableHasShownAccessibilityDisclaimerFlow
+            .onSubscription { emit(hasShownAccessibilityDisclaimer) }
 
     override var systemBiometricIntegritySource: String?
         get() = getString(key = SYSTEM_BIOMETRIC_INTEGRITY_SOURCE_KEY)
@@ -270,6 +284,7 @@ class SettingsDiskSourceImpl(
         // - Upgraded to Premium action card consumed
         // - Upgraded to Premium action card pending
         // - Premium upgrade pending
+        // - Has shown accessibility disclaimer dialog
     }
 
     override fun getIntroducingArchiveActionCardDismissed(userId: String): Boolean? =

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -188,6 +188,16 @@ interface SettingsRepository : FlightRecorderManager {
     val isScreenCaptureAllowedStateFlow: StateFlow<Boolean>
 
     /**
+     * Whether the accessibility disclaimer has been displayed to the user.
+     */
+    val hasShownAccessibilityDisclaimerFlow: StateFlow<Boolean>
+
+    /**
+     * Stores that the accessibility disclaimer has been displayed to the user.
+     */
+    fun accessibilityDisclaimerHasBeenShown()
+
+    /**
      * Disables autofill if it is currently enabled.
      */
     fun disableAutofill()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -372,11 +372,25 @@ class SettingsRepositoryImpl(
                 initialValue = isScreenCaptureAllowed,
             )
 
+    override val hasShownAccessibilityDisclaimerFlow: StateFlow<Boolean>
+        get() = settingsDiskSource
+            .hasShownAccessibilityDisclaimerFlow
+            .map { it ?: false }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Lazily,
+                initialValue = settingsDiskSource.hasShownAccessibilityDisclaimer ?: false,
+            )
+
     init {
         policyManager
             .getActivePoliciesFlow(type = PolicyType.MAXIMUM_VAULT_TIMEOUT)
             .onEach { updateVaultUnlockSettingsIfNecessary(it) }
             .launchIn(unconfinedScope)
+    }
+
+    override fun accessibilityDisclaimerHasBeenShown() {
+        settingsDiskSource.hasShownAccessibilityDisclaimer = true
     }
 
     override fun disableAutofill() {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -114,6 +114,7 @@ class MainViewModelTest : BaseViewModelTest() {
     private val mutableAppLanguageFlow = MutableStateFlow(AppLanguage.DEFAULT)
     private val mutableScreenCaptureAllowedFlow = MutableStateFlow(true)
     private val mutableIsDynamicColorsEnabledFlow = MutableStateFlow(false)
+    private val mutableHasShownAccessibilityDisclaimerFlow = MutableStateFlow(true)
     private val settingsRepository = mockk<SettingsRepository> {
         every { appTheme } returns AppTheme.DEFAULT
         every { appThemeStateFlow } returns mutableAppThemeFlow
@@ -124,6 +125,10 @@ class MainViewModelTest : BaseViewModelTest() {
         every { appLanguage = any() } just runs
         every { isDynamicColorsEnabled } returns false
         every { isDynamicColorsEnabledFlow } returns mutableIsDynamicColorsEnabledFlow
+        every {
+            hasShownAccessibilityDisclaimerFlow
+        } returns mutableHasShownAccessibilityDisclaimerFlow
+        every { accessibilityDisclaimerHasBeenShown() } just runs
     }
     private val authRepository = mockk<AuthRepository> {
         every { activeUserId } returns DEFAULT_USER_STATE.activeUserId
@@ -1369,6 +1374,7 @@ class MainViewModelTest : BaseViewModelTest() {
             isScreenCaptureAllowed = settingsRepository.isScreenCaptureAllowed,
             isDynamicColorsEnabled = settingsRepository.isDynamicColorsEnabled,
             hasResizeBeenRequested = false,
+            dialogState = null,
         )
         viewModel.stateFlow.test {
             assertEquals(
@@ -1382,6 +1388,49 @@ class MainViewModelTest : BaseViewModelTest() {
                 ),
                 awaitItem(),
             )
+        }
+    }
+
+    @Test
+    fun `on HasShownAccessibilityDisclaimerUpdate with false should show accessibility dialog`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_STATE, awaitItem())
+                mutableHasShownAccessibilityDisclaimerFlow.value = false
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        dialogState = MainState.DialogState.AccessibilityDisclosure,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `on HasShownAccessibilityDisclaimerUpdate with true should clear accessibility dialog`() =
+        runTest {
+            mutableHasShownAccessibilityDisclaimerFlow.value = false
+            val viewModel = createViewModel()
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        dialogState = MainState.DialogState.AccessibilityDisclosure,
+                    ),
+                    awaitItem(),
+                )
+                mutableHasShownAccessibilityDisclaimerFlow.value = true
+                assertEquals(DEFAULT_STATE, awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on DismissAccessibilityDisclaimerDialog should store that the accessibility disclaimer has been shown`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(MainAction.DismissAccessibilityDisclaimerDialog)
+        verify(exactly = 1) {
+            settingsRepository.accessibilityDisclaimerHasBeenShown()
         }
     }
 
@@ -1415,6 +1464,7 @@ private val DEFAULT_STATE: MainState = MainState(
     isScreenCaptureAllowed = true,
     isDynamicColorsEnabled = false,
     hasResizeBeenRequested = false,
+    dialogState = null,
 )
 
 private val DEFAULT_FIRST_TIME_STATE = FirstTimeState(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -474,6 +474,42 @@ class SettingsDiskSourceTest {
     }
 
     @Test
+    fun `hasShownAccessibilityDisclaimer should pull from and update SharedPreferences`() {
+        val hasShownAccessibilityDisclaimerKey =
+            "bwPreferencesStorage:hasShownAccessibilityDisclaimer"
+        val expected = true
+
+        assertNull(settingsDiskSource.hasShownAccessibilityDisclaimer)
+
+        fakeSharedPreferences.edit {
+            putBoolean(hasShownAccessibilityDisclaimerKey, expected)
+        }
+
+        assertEquals(
+            expected,
+            settingsDiskSource.hasShownAccessibilityDisclaimer,
+        )
+
+        settingsDiskSource.hasShownAccessibilityDisclaimer = false
+        assertFalse(fakeSharedPreferences.getBoolean(hasShownAccessibilityDisclaimerKey, true))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `hasShownAccessibilityDisclaimerFlow should react to changes in hasShownAccessibilityDisclaimer`() =
+        runTest {
+            settingsDiskSource.hasShownAccessibilityDisclaimerFlow.test {
+                // The initial values of the Flow and the property are in sync
+                assertNull(settingsDiskSource.hasShownAccessibilityDisclaimer)
+                assertNull(awaitItem())
+                settingsDiskSource.hasShownAccessibilityDisclaimer = true
+                assertEquals(true, awaitItem())
+                settingsDiskSource.hasShownAccessibilityDisclaimer = false
+                assertEquals(false, awaitItem())
+            }
+        }
+
+    @Test
     fun `getVaultTimeoutInMinutes when values are present should pull from SharedPreferences`() {
         val vaultTimeoutBaseKey = "bwPreferencesStorage:vaultTimeout"
         val mockUserId = "mockUserId"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -93,6 +93,7 @@ class FakeSettingsDiskSource(
     private var hasSeenAddLoginCoachMark: Boolean? = null
     private var hasSeenGeneratorCoachMark: Boolean? = null
     private var storedIsDynamicColorsEnabled: Boolean? = null
+    private var storedHasShownAccessibilityDisclaimer: Boolean? = null
     private var storedBrowserAutofillDialogReshowTime: Instant? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
@@ -109,6 +110,8 @@ class FakeSettingsDiskSource(
 
     private val mutableIsDynamicColorsEnabled =
         bufferedMutableSharedFlow<Boolean?>()
+
+    private val mutableHasShownAccessibilityDisclaimerFlow = bufferedMutableSharedFlow<Boolean?>()
 
     private val mutableVaultRegisteredForExportFlow =
         bufferedMutableSharedFlow<Boolean?>()
@@ -160,6 +163,18 @@ class FakeSettingsDiskSource(
     override val isDynamicColorsEnabledFlow: Flow<Boolean?>
         get() = mutableIsDynamicColorsEnabled.onSubscription {
             emit(isDynamicColorsEnabled)
+        }
+
+    override var hasShownAccessibilityDisclaimer: Boolean?
+        get() = storedHasShownAccessibilityDisclaimer
+        set(value) {
+            storedHasShownAccessibilityDisclaimer = value
+            mutableHasShownAccessibilityDisclaimerFlow.tryEmit(value)
+        }
+
+    override val hasShownAccessibilityDisclaimerFlow: Flow<Boolean?>
+        get() = mutableHasShownAccessibilityDisclaimerFlow.onSubscription {
+            emit(hasShownAccessibilityDisclaimer)
         }
 
     override var screenCaptureAllowed: Boolean?

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1120,6 +1120,30 @@ class SettingsRepositoryTest {
         }
 
     @Test
+    fun `hasShownAccessibilityDisclaimerFlow should emit changes from SettingsDiskSource`() =
+        runTest {
+            fakeSettingsDiskSource.hasShownAccessibilityDisclaimer = null
+            settingsRepository.hasShownAccessibilityDisclaimerFlow.test {
+                assertFalse(awaitItem())
+
+                fakeSettingsDiskSource.hasShownAccessibilityDisclaimer = true
+                assertTrue(awaitItem())
+
+                fakeSettingsDiskSource.hasShownAccessibilityDisclaimer = false
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Test
+    fun `accessibilityDisclaimerHasBeenShown should update SettingsDiskSource`() {
+        assertNull(fakeSettingsDiskSource.hasShownAccessibilityDisclaimer)
+
+        settingsRepository.accessibilityDisclaimerHasBeenShown()
+
+        assertTrue(fakeSettingsDiskSource.hasShownAccessibilityDisclaimer == true)
+    }
+
+    @Test
     fun `clearClipboardFrequency should pull from and update SettingsDiskSource`() = runTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -612,6 +612,7 @@ select Add TOTP to store the key safely</string>
     <string name="forwarded_email_description">Generate an email alias with an external forwarding service.</string>
     <string name="accessibility_service_disclosure">Accessibility Service Disclosure</string>
     <string name="accessibility_disclosure_text">Bitwarden uses the Accessibility Service to search for login fields in apps and websites, then establish the appropriate field IDs for entering a username &amp; password when a match for the app or site is found. We do not store any of the information presented to us by the service, nor do we make any attempt to control any on-screen elements beyond text entry of credentials.</string>
+    <string name="accessibility_disclosure_start_up_text">Bitwarden offers an optional autofill method that uses Android’s Accessibility Service to detect login fields in apps and websites. If you choose to enable it, Bitwarden will identify the appropriate fields and enter your credentials when a match is found. We do not store any information observed by the service, nor do we control any on-screen elements beyond credential entry.</string>
     <string name="accept">Accept</string>
     <string name="decline">Decline</string>
     <string name="login_request_has_already_expired">Login request has already expired.</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38587](https://bitwarden.atlassian.net/browse/PM-38587)

## 📔 Objective

This PR adds a Accessibility Service Disclaimer to the App startup. This dialog is only ever displayed once and then never again.

## 📸 Screenshots

<img width="350" src="https://github.com/user-attachments/assets/7d60a953-7b2f-4ba6-a1b9-23c545206321" />


[PM-38587]: https://bitwarden.atlassian.net/browse/PM-38587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ