### PR TITLE
🍒 PM-38513: Bug: Do not emit policies before we have recieved them

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerImpl.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 
@@ -95,15 +96,15 @@ class PolicyManagerImpl(
             },
         featureFlagManager.getFeatureFlagFlow(key = FlagKey.PoliciesInAcceptedState),
     ) { policies, organizations, isEnabled ->
-        this
-            .filterPolicies(
-                type = type,
-                policies = policies,
-                organizations = organizations,
-                isPoliciesInAcceptedStateEnabled = isEnabled,
-            )
-            .orEmpty()
+        filterPolicies(
+            type = type,
+            policies = policies,
+            organizations = organizations,
+            isPoliciesInAcceptedStateEnabled = isEnabled,
+        )
     }
+        // We do not have any policies yet if it is null, so do not emit at all.
+        .filterNotNull()
 
     private fun filterPolicies(
         type: PolicyType,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38513](https://bitwarden.atlassian.net/browse/PM-38513)

## 📔 Objective

This PR fixes a bug in the `PolicyManager` where we would emit policies before we had received them.


[PM-38513]: https://bitwarden.atlassian.net/browse/PM-38513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ