### PR TITLE
[QA-1911] Add testTag to Flight Recorder logging duration dropdown

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreen.kt
@@ -140,6 +140,7 @@ private fun FlightRecorderContent(
             selectedOption = state.selectedDuration,
             onOptionSelected = onDurationSelected,
             modifier = Modifier
+                .testTag("LoggingDurationChooser")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
         )


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/QA-1911

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Adds Modifier.testTag("LoggingDurationChooser") to the duration dropdown on the Flight Recorder screen, surfacing it as resource-id="LoggingDurationChooser". This matches the existing <Name>Chooser convention (ThemeChooser, VaultTimeoutChooser, ClearClipboardChooser) and lets test automation drop the XPath workaround in favor of the standard ID-based DropDown.GetElementValue() pattern.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
