### PR TITLE
PM-38779: Bug: Update cursor logic to avoid exception

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManagerImpl.kt
@@ -63,13 +63,16 @@ class BrowserThirdPartyAutofillManagerImpl(
         var thirdPartyEnabled = false
         val isThirdPartyAvailable = cursor
             ?.use {
-                it.moveToFirst()
-                thirdPartyEnabled = it
-                    .getColumnIndex(THIRD_PARTY_MODE_COLUMN)
-                    .takeUnless { columnIndex -> columnIndex == -1 }
-                    ?.let { columnIndex -> it.getInt(columnIndex) != 0 }
-                    ?: false
-                true
+                if (it.moveToFirst()) {
+                    thirdPartyEnabled = it
+                        .getColumnIndex(THIRD_PARTY_MODE_COLUMN)
+                        .takeUnless { columnIndex -> columnIndex == -1 }
+                        ?.let { columnIndex -> it.getInt(columnIndex) != 0 }
+                        ?: false
+                    true
+                } else {
+                    false
+                }
             }
             ?: false
         return BrowserThirdPartyAutoFillData(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38779](https://bitwarden.atlassian.net/browse/PM-38779)

## 📔 Objective

This PR fixes a crash in the  `BrowserThirdPartyAutofillManagerImpl` where the cursor is currently empty but we were querying it anyways.


[PM-38779]: https://bitwarden.atlassian.net/browse/PM-38779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ