### PR TITLE
PM-38637: Bug: Add additional CRL distrobution server to clear-text permitted list

### DIFF
--- a/app/src/beta/res/xml/network_security_config.xml
+++ b/app/src/beta/res/xml/network_security_config.xml
@@ -18,6 +18,7 @@
         <!-- CRL Distribution Servers -->
         <domain includeSubdomains="true">c.lencr.org</domain>
         <domain includeSubdomains="true">c.pki.goog</domain>
+        <domain includeSubdomains="true">crls.certainly.com</domain>
 
         <!-- OCSP Responder Servers -->
         <domain includeSubdomains="true">o.pki.goog</domain>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -18,6 +18,7 @@
         <!-- CRL Distribution Servers -->
         <domain includeSubdomains="true">c.lencr.org</domain>
         <domain includeSubdomains="true">c.pki.goog</domain>
+        <domain includeSubdomains="true">crls.certainly.com</domain>
 
         <!-- OCSP Responder Servers -->
         <domain includeSubdomains="true">o.pki.goog</domain>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38637](https://bitwarden.atlassian.net/browse/PM-38637)

## 📔 Objective

This PR adds `crls.certainly.com` to the list of domains that are allowed to be used with clear-text (http) for CRL checking.


[PM-38637]: https://bitwarden.atlassian.net/browse/PM-38637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ