### PR TITLE
[PM-38808] Support optional encrypted Cipher.name

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
@@ -829,7 +829,7 @@ fun Cipher.toFailureCipherListView(): CipherListView =
         folderId = folderId,
         collectionIds = collectionIds,
         key = key,
-        name = name,
+        name = name.orEmpty(),
         subtitle = "",
         type = when (type) {
             CipherType.LOGIN -> CipherListViewType.Login(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38808

## 📔 Objective

The SDK is making the encrypted `Cipher.name` field optional (`String` → `String?`) as part of the blob encryption migration ([sdk-internal#1122](https://github.com/bitwarden/sdk-internal/pull/1122)) — blob-encrypted ciphers carry the name inside the sealed `data` blob rather than as a top-level field.

`Cipher.toFailureCipherListView()` builds a `CipherListView` (whose `name` is non-null) directly from the encrypted `Cipher`, so the now-nullable `name` no longer compiles. This falls back to an empty string when the name is absent.

The decrypted `CipherView` / `CipherListView` `name` fields are unchanged, so all UI and sorting is unaffected.

> Pairs with the SDK version bump.
