### PR TITLE
[PM-38918] fix: PM-38644, UI/UX inconsistency: Passport number in Identity items is not a hidden field

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
@@ -163,13 +163,21 @@ fun VaultItemIdentityContent(
         }
         identityState.passportNumber?.let { passportNumber ->
             item(key = "passportNumber") {
-                IdentityCopyField(
+                BitwardenPasswordField(
                     label = stringResource(id = BitwardenString.passport_number),
                     value = passportNumber,
-                    copyContentDescription = stringResource(id = BitwardenString.copy_passport_number),
-                    textFieldTestTag = "IdentityPassportNumberEntry",
-                    copyActionTestTag = "IdentityCopyPassportNumberButton",
-                    onCopyClick = vaultIdentityItemTypeHandlers.onCopyPassportNumberClick,
+                    onValueChange = {},
+                    readOnly = true,
+                    actions = {
+                        BitwardenStandardIconButton(
+                            vectorIconRes = BitwardenDrawable.ic_copy,
+                            contentDescription = stringResource(id = BitwardenString.copy_passport_number),
+                            onClick = vaultIdentityItemTypeHandlers.onCopyPassportNumberClick,
+                            modifier = Modifier.testTag(tag = "IdentityCopyPassportNumberButton"),
+                        )
+                    },
+                    passwordFieldTestTag = "IdentityPassportNumberEntry",
+                    showPasswordTestTag = "IdentityViewPassportNumberButton",
                     cardStyle = identityState
                         .propertyList
                         .toListItemCardStyle(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/android/issues/7031

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
* **Fixes Bug:** [PM-38644]
* **The Problem:** The passport number field in identity item was not a hidden field (it did not had a toggle to view/hide) while all other BW apps/clients had it.
* **The Solution:** This PR successfully adds the toggle to view/hide passport number by replacing the IdentityCopyField composable with BitwardenPasswordField composable.
* **Impact:** Makes UI/UX consistent with other BW apps/clients

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/43dd161f-cdef-4792-b9ce-7dbac415fa88" />



[PM-38644]: https://bitwarden.atlassian.net/browse/PM-38644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ