### PR TITLE
PM-39082: Feat: Do not show accessibility disclosure at app startup for Fdroid

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.platform.repository
 
 import android.view.autofill.AutofillManager
 import com.bitwarden.authenticatorbridge.util.generateSecretKey
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.data.manager.flightrecorder.FlightRecorderManager
 import com.bitwarden.policies.PolicyType
@@ -51,6 +52,7 @@ class SettingsRepositoryImpl(
     private val autofillManager: AutofillManager,
     private val autofillEnabledManager: AutofillEnabledManager,
     private val authDiskSource: AuthDiskSource,
+    private val buildInfoManager: BuildInfoManager,
     private val settingsDiskSource: SettingsDiskSource,
     private val vaultSdkSource: VaultSdkSource,
     flightRecorderManager: FlightRecorderManager,
@@ -375,11 +377,12 @@ class SettingsRepositoryImpl(
     override val hasShownAccessibilityDisclaimerFlow: StateFlow<Boolean>
         get() = settingsDiskSource
             .hasShownAccessibilityDisclaimerFlow
-            .map { it ?: false }
+            .map { buildInfoManager.isFdroid || it ?: false }
             .stateIn(
                 scope = unconfinedScope,
                 started = SharingStarted.Lazily,
-                initialValue = settingsDiskSource.hasShownAccessibilityDisclaimer ?: false,
+                initialValue = buildInfoManager.isFdroid ||
+                    settingsDiskSource.hasShownAccessibilityDisclaimer ?: false,
             )
 
     init {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.platform.repository.di
 
 import android.view.autofill.AutofillManager
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.data.manager.flightrecorder.FlightRecorderManager
 import com.bitwarden.data.repository.ServerConfigRepository
@@ -67,6 +68,7 @@ object PlatformRepositoryModule {
         autofillManager: AutofillManager,
         autofillEnabledManager: AutofillEnabledManager,
         authDiskSource: AuthDiskSource,
+        buildInfoManager: BuildInfoManager,
         settingsDiskSource: SettingsDiskSource,
         vaultSdkSource: VaultSdkSource,
         accessibilityEnabledManager: AccessibilityEnabledManager,
@@ -78,6 +80,7 @@ object PlatformRepositoryModule {
             autofillManager = autofillManager,
             autofillEnabledManager = autofillEnabledManager,
             authDiskSource = authDiskSource,
+            buildInfoManager = buildInfoManager,
             settingsDiskSource = settingsDiskSource,
             vaultSdkSource = vaultSdkSource,
             accessibilityEnabledManager = accessibilityEnabledManager,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -4,6 +4,7 @@ import android.view.autofill.AutofillManager
 import app.cash.turbine.test
 import com.bitwarden.authenticatorbridge.util.generateSecretKey
 import com.bitwarden.core.EnrollPinResponse
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.asFailure
@@ -75,6 +76,9 @@ class SettingsRepositoryTest {
         } returns mutableActivePolicyFlow
     }
     private val flightRecorderManager = mockk<FlightRecorderManager>()
+    private val buildInfoManager: BuildInfoManager = mockk {
+        every { isFdroid } returns false
+    }
 
     private val settingsRepository = SettingsRepositoryImpl(
         autofillManager = autofillManager,
@@ -86,6 +90,7 @@ class SettingsRepositoryTest {
         dispatcherManager = FakeDispatcherManager(),
         policyManager = policyManager,
         flightRecorderManager = flightRecorderManager,
+        buildInfoManager = buildInfoManager,
     )
 
     @BeforeEach
@@ -1119,8 +1124,9 @@ class SettingsRepositoryTest {
             }
         }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `hasShownAccessibilityDisclaimerFlow should emit changes from SettingsDiskSource`() =
+    fun `hasShownAccessibilityDisclaimerFlow should emit changes from SettingsDiskSource when fdroid is false`() =
         runTest {
             fakeSettingsDiskSource.hasShownAccessibilityDisclaimer = null
             settingsRepository.hasShownAccessibilityDisclaimerFlow.test {
@@ -1131,6 +1137,23 @@ class SettingsRepositoryTest {
 
                 fakeSettingsDiskSource.hasShownAccessibilityDisclaimer = false
                 assertFalse(awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `hasShownAccessibilityDisclaimerFlow should emit changes from SettingsDiskSource when fdroid is true`() =
+        runTest {
+            every { buildInfoManager.isFdroid } returns true
+            fakeSettingsDiskSource.hasShownAccessibilityDisclaimer = null
+            settingsRepository.hasShownAccessibilityDisclaimerFlow.test {
+                assertTrue(awaitItem())
+
+                fakeSettingsDiskSource.hasShownAccessibilityDisclaimer = true
+                expectNoEvents()
+
+                fakeSettingsDiskSource.hasShownAccessibilityDisclaimer = false
+                expectNoEvents()
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39082](https://bitwarden.atlassian.net/browse/PM-39082)

## 📔 Objective

This PR updates the accessibility disclosure to only be displayed on app-startup when in standard releases and not in the Fdroid releases.


[PM-39082]: https://bitwarden.atlassian.net/browse/PM-39082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ