### PR TITLE
PM-39138: Bug: Passport number should be hidden on edit screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
@@ -138,11 +138,12 @@ fun LazyListScope.vaultAddEditIdentityItems(
         )
     }
     item {
-        BitwardenTextField(
+        BitwardenPasswordField(
             label = stringResource(id = BitwardenString.passport_number),
             value = identityState.passportNumber,
             onValueChange = identityItemTypeHandlers.onPassportNumberTextChange,
-            textFieldTestTag = "IdentityPassportNumberEntry",
+            showPasswordTestTag = "IdentityShowPassportNumberButton",
+            passwordFieldTestTag = "IdentityPassportNumberEntry",
             cardStyle = CardStyle.Middle(),
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39138](https://bitwarden.atlassian.net/browse/PM-39138)

## 📔 Objective

The passport number field is now a password field on the Edit Identity screen.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/6aac473b-4bda-4112-a5d7-d2a2713e12b0" /> | <img width="350" src="https://github.com/user-attachments/assets/e5491ee8-227b-4c30-a010-cbf1d65255af" /> |


[PM-39138]: https://bitwarden.atlassian.net/browse/PM-39138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ