### PR TITLE
PM-32858: Feat: Set and Reset Password flows should use newer request models

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -109,6 +109,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
 import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
 import com.x8bit.bitwarden.data.auth.repository.util.toAccountCryptographicState
 import com.x8bit.bitwarden.data.auth.repository.util.toDeviceInfo
+import com.x8bit.bitwarden.data.auth.repository.util.toKdfRequestModel
 import com.x8bit.bitwarden.data.auth.repository.util.toOrganizations
 import com.x8bit.bitwarden.data.auth.repository.util.toRemovedPasswordUserStateJson
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
@@ -1079,16 +1080,14 @@ class AuthRepositoryImpl(
         newPassword: String,
         passwordHint: String?,
     ): ResetPasswordResult {
-        val activeAccount = authDiskSource
-            .userState
-            ?.activeAccount
+        val profile = authDiskSource.userState?.activeAccount?.profile
             ?: return ResetPasswordResult.Error(error = NoActiveUserException())
         val currentPasswordHash = currentPassword?.let { password ->
             authSdkSource
                 .hashPassword(
-                    email = activeAccount.profile.email,
+                    email = profile.email,
                     password = password,
-                    kdf = activeAccount.profile.toSdkParams(),
+                    kdf = profile.toSdkParams(),
                     purpose = HashPurpose.SERVER_AUTHORIZATION,
                 )
                 .fold(
@@ -1096,48 +1095,32 @@ class AuthRepositoryImpl(
                     onSuccess = { it },
                 )
         }
-        val userId = activeAccount.profile.userId
+        val userId = profile.userId
         return vaultSdkSource
             .updatePassword(
                 userId = userId,
                 newPassword = newPassword,
             )
-            .flatMap { updatePasswordResponse ->
-                accountsService
-                    .resetPassword(
-                        body = ResetPasswordRequestJson(
-                            currentPasswordHash = currentPasswordHash,
-                            newPasswordHash = updatePasswordResponse.passwordHash,
-                            passwordHint = passwordHint,
-                            key = updatePasswordResponse.newKey,
-                        ),
-                    )
+            .flatMap { response ->
+                accountsService.resetPassword(
+                    body = ResetPasswordRequestJson(
+                        currentPasswordHash = currentPasswordHash,
+                        passwordHint = passwordHint,
+                        kdf = profile.toKdfRequestModel(),
+                        salt = profile.email,
+                        masterPasswordAuthenticationHash = response.passwordHash,
+                        masterKeyWrappedUserKey = response.newKey,
+                    ),
+                )
+            }
+            .onSuccess {
+                toastManager.show(BitwardenString.updated_master_password)
+                // Log out the user after successful password reset. This clears all
+                // user data, so there is no need to store any of the updated info.
+                logout(reason = LogoutReason.PasswordReset, userId = userId)
             }
             .fold(
-                onSuccess = {
-                    // Update the saved master password hash.
-                    authSdkSource
-                        .hashPassword(
-                            email = activeAccount.profile.email,
-                            password = newPassword,
-                            kdf = activeAccount.profile.toSdkParams(),
-                            purpose = HashPurpose.LOCAL_AUTHORIZATION,
-                        )
-                        .onSuccess { passwordHash ->
-                            authDiskSource.storeMasterPasswordHash(
-                                userId = userId,
-                                passwordHash = passwordHash,
-                            )
-                        }
-
-                    toastManager.show(BitwardenString.updated_master_password)
-                    // Log out the user after successful password reset.
-                    // This clears all user state including forcePasswordResetReason.
-                    logout(reason = LogoutReason.PasswordReset, userId = userId)
-
-                    // Return the success.
-                    ResetPasswordResult.Success
-                },
+                onSuccess = { ResetPasswordResult.Success },
                 onFailure = { ResetPasswordResult.Error(error = it) },
             )
     }
@@ -1185,16 +1168,13 @@ class AuthRepositoryImpl(
             .flatMap { response ->
                 accountsService
                     .setPassword(
-                        body = SetPasswordRequestJson(
-                            passwordHash = response.passwordHash,
+                        body = SetPasswordRequestJson.V2(
                             passwordHint = passwordHint,
                             organizationIdentifier = organizationIdentifier,
-                            kdfIterations = profile.kdfIterations,
-                            kdfMemory = profile.kdfMemory,
-                            kdfParallelism = profile.kdfParallelism,
-                            kdfType = profile.kdfType,
-                            key = response.newKey,
-                            keys = null,
+                            kdf = profile.toKdfRequestModel(),
+                            salt = profile.email,
+                            masterPasswordAuthenticationHash = response.passwordHash,
+                            masterKeyWrappedUserKey = response.newKey,
                         ),
                     )
                     .map { response }
@@ -1300,7 +1280,7 @@ class AuthRepositoryImpl(
             .flatMap { response ->
                 accountsService
                     .setPassword(
-                        body = SetPasswordRequestJson(
+                        body = SetPasswordRequestJson.V1(
                             passwordHash = response.masterPasswordHash,
                             passwordHint = passwordHint,
                             organizationIdentifier = organizationIdentifier,
@@ -1309,7 +1289,7 @@ class AuthRepositoryImpl(
                             kdfParallelism = profile.kdfParallelism,
                             kdfType = profile.kdfType,
                             key = response.encryptedUserKey,
-                            keys = SetPasswordRequestJson.Keys(
+                            keys = SetPasswordRequestJson.V1.Keys(
                                 publicKey = response.keys.public,
                                 encryptedPrivateKey = response.keys.private,
                             ),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/AccountJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/AccountJsonExtensions.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.auth.repository.util
 
 import com.bitwarden.crypto.Kdf
+import com.bitwarden.network.model.KdfJson
 import com.bitwarden.network.model.KdfTypeJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.util.KdfParamsConstants
@@ -13,8 +14,8 @@ fun AccountJson.Profile.toSdkParams(): Kdf {
         KdfTypeJson.ARGON2_ID -> Kdf.Argon2id(
             iterations = (kdfIterations ?: KdfParamsConstants.DEFAULT_ARGON2_ITERATIONS).toUInt(),
             memory = (kdfMemory ?: KdfParamsConstants.DEFAULT_ARGON2_MEMORY).toUInt(),
-            parallelism =
-            (kdfParallelism ?: KdfParamsConstants.DEFAULT_ARGON2_PARALLELISM).toUInt(),
+            parallelism = (kdfParallelism ?: KdfParamsConstants.DEFAULT_ARGON2_PARALLELISM)
+                .toUInt(),
         )
 
         KdfTypeJson.PBKDF2_SHA256 -> Kdf.Pbkdf2(
@@ -24,3 +25,23 @@ fun AccountJson.Profile.toSdkParams(): Kdf {
         else -> Kdf.Pbkdf2(iterations = KdfParamsConstants.DEFAULT_PBKDF2_ITERATIONS.toUInt())
     }
 }
+
+/**
+ * Convert [AccountJson.Profile] to [KdfJson] params for use with Bitwarden network requests.
+ */
+fun AccountJson.Profile.toKdfRequestModel(): KdfJson =
+    when (val kdfType = this.kdfType ?: KdfTypeJson.PBKDF2_SHA256) {
+        KdfTypeJson.ARGON2_ID -> KdfJson(
+            kdfType = kdfType,
+            iterations = this.kdfIterations ?: KdfParamsConstants.DEFAULT_ARGON2_ITERATIONS,
+            memory = this.kdfMemory ?: KdfParamsConstants.DEFAULT_ARGON2_MEMORY,
+            parallelism = this.kdfParallelism ?: KdfParamsConstants.DEFAULT_ARGON2_PARALLELISM,
+        )
+
+        KdfTypeJson.PBKDF2_SHA256 -> KdfJson(
+            kdfType = kdfType,
+            iterations = this.kdfIterations ?: KdfParamsConstants.DEFAULT_PBKDF2_ITERATIONS,
+            memory = this.kdfMemory,
+            parallelism = this.kdfParallelism,
+        )
+    }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -131,6 +131,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.CookieCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.DuoCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.SsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
+import com.x8bit.bitwarden.data.auth.repository.util.toKdfRequestModel
 import com.x8bit.bitwarden.data.auth.repository.util.toRemovedPasswordUserStateJson
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.toUserState
@@ -5058,10 +5059,12 @@ class AuthRepositoryTest {
         val newPassword = "newPassword"
         val newPasswordHash = "newPasswordHash"
         val newKey = "newKey"
+        val kdf = ACCOUNT_1.profile.toKdfRequestModel()
+        val email = ACCOUNT_1.profile.email
         fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
         coEvery {
             authSdkSource.hashPassword(
-                email = ACCOUNT_1.profile.email,
+                email = email,
                 password = currentPassword,
                 kdf = ACCOUNT_1.profile.toSdkParams(),
                 purpose = HashPurpose.SERVER_AUTHORIZATION,
@@ -5081,15 +5084,17 @@ class AuthRepositoryTest {
             accountsService.resetPassword(
                 body = ResetPasswordRequestJson(
                     currentPasswordHash = currentPasswordHash,
-                    newPasswordHash = newPasswordHash,
                     passwordHint = null,
-                    key = newKey,
+                    kdf = kdf,
+                    salt = email,
+                    masterPasswordAuthenticationHash = newPasswordHash,
+                    masterKeyWrappedUserKey = newKey,
                 ),
             )
         } returns Unit.asSuccess()
         coEvery {
             authSdkSource.hashPassword(
-                email = ACCOUNT_1.profile.email,
+                email = email,
                 password = newPassword,
                 kdf = ACCOUNT_1.profile.toSdkParams(),
                 purpose = HashPurpose.LOCAL_AUTHORIZATION,
@@ -5108,7 +5113,7 @@ class AuthRepositoryTest {
         )
         coVerify {
             authSdkSource.hashPassword(
-                email = ACCOUNT_1.profile.email,
+                email = email,
                 password = currentPassword,
                 kdf = ACCOUNT_1.profile.toSdkParams(),
                 purpose = HashPurpose.SERVER_AUTHORIZATION,
@@ -5120,16 +5125,14 @@ class AuthRepositoryTest {
             accountsService.resetPassword(
                 body = ResetPasswordRequestJson(
                     currentPasswordHash = currentPasswordHash,
-                    newPasswordHash = newPasswordHash,
                     passwordHint = null,
-                    key = newKey,
+                    kdf = kdf,
+                    salt = email,
+                    masterPasswordAuthenticationHash = newPasswordHash,
+                    masterKeyWrappedUserKey = newKey,
                 ),
             )
         }
-        fakeAuthDiskSource.assertMasterPasswordHash(
-            userId = USER_ID_1,
-            passwordHash = newPasswordHash,
-        )
         verify(exactly = 1) {
             toastManager.show(messageId = BitwardenString.updated_master_password)
             userLogoutManager.logout(
@@ -5582,7 +5585,7 @@ class AuthRepositoryTest {
                 encryptedUserKey = encryptedUserKey,
                 keys = RsaKeyPair(public = publicRsaKey, private = privateRsaKey),
             )
-            val setPasswordRequestJson = SetPasswordRequestJson(
+            val setPasswordRequestJson = SetPasswordRequestJson.V1(
                 passwordHash = passwordHash,
                 passwordHint = passwordHint,
                 organizationIdentifier = organizationId,
@@ -5591,7 +5594,7 @@ class AuthRepositoryTest {
                 kdfParallelism = profile.kdfParallelism,
                 kdfType = profile.kdfType,
                 key = encryptedUserKey,
-                keys = SetPasswordRequestJson.Keys(
+                keys = SetPasswordRequestJson.V1.Keys(
                     publicKey = publicRsaKey,
                     encryptedPrivateKey = privateRsaKey,
                 ),
@@ -5640,7 +5643,7 @@ class AuthRepositoryTest {
                 encryptedUserKey = encryptedUserKey,
                 keys = RsaKeyPair(public = publicRsaKey, private = privateRsaKey),
             )
-            val setPasswordRequestJson = SetPasswordRequestJson(
+            val setPasswordRequestJson = SetPasswordRequestJson.V1(
                 passwordHash = passwordHash,
                 passwordHint = passwordHint,
                 organizationIdentifier = organizationIdentifier,
@@ -5649,7 +5652,7 @@ class AuthRepositoryTest {
                 kdfParallelism = profile.kdfParallelism,
                 kdfType = profile.kdfType,
                 key = encryptedUserKey,
-                keys = SetPasswordRequestJson.Keys(
+                keys = SetPasswordRequestJson.V1.Keys(
                     publicKey = publicRsaKey,
                     encryptedPrivateKey = privateRsaKey,
                 ),
@@ -5749,16 +5752,13 @@ class AuthRepositoryTest {
             passwordHash = passwordHash,
             newKey = encryptedUserKey,
         )
-        val setPasswordRequestJson = SetPasswordRequestJson(
-            passwordHash = passwordHash,
+        val setPasswordRequestJson = SetPasswordRequestJson.V2(
             passwordHint = passwordHint,
             organizationIdentifier = organizationIdentifier,
-            kdfIterations = profile.kdfIterations,
-            kdfMemory = profile.kdfMemory,
-            kdfParallelism = profile.kdfParallelism,
-            kdfType = profile.kdfType,
-            key = encryptedUserKey,
-            keys = null,
+            kdf = profile.toKdfRequestModel(),
+            salt = EMAIL,
+            masterPasswordAuthenticationHash = passwordHash,
+            masterKeyWrappedUserKey = encryptedUserKey,
         )
         fakeAuthDiskSource.userState = userState
         coEvery {
@@ -5849,7 +5849,7 @@ class AuthRepositoryTest {
                 encryptedUserKey = encryptedUserKey,
                 keys = RsaKeyPair(public = publicRsaKey, private = privateRsaKey),
             )
-            val setPasswordRequestJson = SetPasswordRequestJson(
+            val setPasswordRequestJson = SetPasswordRequestJson.V1(
                 passwordHash = passwordHash,
                 passwordHint = passwordHint,
                 organizationIdentifier = organizationIdentifier,
@@ -5858,7 +5858,7 @@ class AuthRepositoryTest {
                 kdfParallelism = profile.kdfParallelism,
                 kdfType = profile.kdfType,
                 key = encryptedUserKey,
-                keys = SetPasswordRequestJson.Keys(
+                keys = SetPasswordRequestJson.V1.Keys(
                     publicKey = publicRsaKey,
                     encryptedPrivateKey = privateRsaKey,
                 ),

--- a/network/src/main/kotlin/com/bitwarden/network/model/ResetPasswordRequestJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/ResetPasswordRequestJson.kt
@@ -6,22 +6,44 @@ import kotlinx.serialization.Serializable
 /**
  * Request body for resetting the password.
  *
- * @param currentPasswordHash The hash of the user's current password.
- * @param newPasswordHash The hash of the user's new password.
- * @param passwordHint The hint for the master password (nullable).
- * @param key The user key for the request (encrypted).
+ * @property currentPasswordHash The hash of the user's current password.
+ * @property passwordHint The hint for the master password (nullable).
+ * @property authenticationData The data to authenticate with a master password.
+ * @property unlockData The data to unlock with a master password.
  */
 @Serializable
 data class ResetPasswordRequestJson(
     @SerialName("masterPasswordHash")
     val currentPasswordHash: String?,
 
-    @SerialName("newMasterPasswordHash")
-    val newPasswordHash: String,
-
     @SerialName("masterPasswordHint")
     val passwordHint: String?,
 
-    @SerialName("key")
-    val key: String,
-)
+    @SerialName("authenticationData")
+    val authenticationData: MasterPasswordAuthenticationDataJson,
+
+    @SerialName("unlockData")
+    val unlockData: MasterPasswordUnlockDataJson,
+) {
+    constructor(
+        currentPasswordHash: String?,
+        passwordHint: String?,
+        kdf: KdfJson,
+        salt: String,
+        masterPasswordAuthenticationHash: String,
+        masterKeyWrappedUserKey: String,
+    ) : this(
+        currentPasswordHash = currentPasswordHash,
+        passwordHint = passwordHint,
+        authenticationData = MasterPasswordAuthenticationDataJson(
+            kdf = kdf,
+            salt = salt,
+            masterPasswordAuthenticationHash = masterPasswordAuthenticationHash,
+        ),
+        unlockData = MasterPasswordUnlockDataJson(
+            kdf = kdf,
+            salt = salt,
+            masterKeyWrappedUserKey = masterKeyWrappedUserKey,
+        ),
+    )
+}

--- a/network/src/main/kotlin/com/bitwarden/network/model/SetPasswordRequestJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/SetPasswordRequestJson.kt
@@ -4,59 +4,110 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Request body for resetting the password.
- *
- * @property kdfType The KDF type.
- * @property kdfIterations The number of iterations when calculating a user's password.
- * @property kdfMemory The amount of memory to use when calculating a password hash (MB).
- * @property kdfParallelism The number of threads to use when calculating a password hash.
- * @param key The user key for the request (encrypted).
- * @param keys A [Keys] object containing public and private keys.
- * @param organizationIdentifier The SSO organization identifier.
- * @param passwordHash The hash of the user's new password.
- * @param passwordHint The hint for the master password (nullable).
+ * Request body for setting the password.
  */
 @Serializable
-data class SetPasswordRequestJson(
-    @SerialName("kdf")
-    val kdfType: KdfTypeJson? = null,
-
-    @SerialName("kdfIterations")
-    val kdfIterations: Int? = null,
-
-    @SerialName("kdfMemory")
-    val kdfMemory: Int? = null,
-
-    @SerialName("kdfParallelism")
-    val kdfParallelism: Int? = null,
-
-    @SerialName("key")
-    val key: String,
-
-    @SerialName("keys")
-    val keys: Keys?,
-
-    @SerialName("orgIdentifier")
-    val organizationIdentifier: String,
-
-    @SerialName("masterPasswordHash")
-    val passwordHash: String?,
-
-    @SerialName("masterPasswordHint")
-    val passwordHint: String?,
-) {
+sealed class SetPasswordRequestJson {
     /**
-     * A keys object containing public and private keys.
+     * Request body for setting the password in a v2 flow.
      *
-     * @param publicKey the public key (encrypted).
-     * @param encryptedPrivateKey the private key (encrypted).
+     * @property organizationIdentifier The SSO organization identifier.
+     * @property passwordHint The hint for the master password (nullable).
+     * @property authenticationData The data to authenticate with a master password.
+     * @property unlockData The data to unlock with a master password.
      */
     @Serializable
-    data class Keys(
-        @SerialName("publicKey")
-        val publicKey: String,
+    data class V2(
+        @SerialName("orgIdentifier")
+        val organizationIdentifier: String,
 
-        @SerialName("encryptedPrivateKey")
-        val encryptedPrivateKey: String,
-    )
+        @SerialName("masterPasswordHint")
+        val passwordHint: String?,
+
+        @SerialName("masterPasswordAuthentication")
+        val authenticationData: MasterPasswordAuthenticationDataJson,
+
+        @SerialName("masterPasswordUnlock")
+        val unlockData: MasterPasswordUnlockDataJson,
+    ) : SetPasswordRequestJson() {
+        constructor(
+            organizationIdentifier: String,
+            passwordHint: String?,
+            kdf: KdfJson,
+            salt: String,
+            masterPasswordAuthenticationHash: String,
+            masterKeyWrappedUserKey: String,
+        ) : this(
+            organizationIdentifier = organizationIdentifier,
+            passwordHint = passwordHint,
+            authenticationData = MasterPasswordAuthenticationDataJson(
+                kdf = kdf,
+                salt = salt,
+                masterPasswordAuthenticationHash = masterPasswordAuthenticationHash,
+            ),
+            unlockData = MasterPasswordUnlockDataJson(
+                kdf = kdf,
+                salt = salt,
+                masterKeyWrappedUserKey = masterKeyWrappedUserKey,
+            ),
+        )
+    }
+
+    /**
+     * Request body for setting the password in a v1 flow.
+     *
+     * @property kdfType The KDF type.
+     * @property kdfIterations The number of iterations when calculating a user's password.
+     * @property kdfMemory The amount of memory to use when calculating a password hash (MB).
+     * @property kdfParallelism The number of threads to use when calculating a password hash.
+     * @property key The user key for the request (encrypted).
+     * @property keys A [Keys] object containing public and private keys.
+     * @property organizationIdentifier The SSO organization identifier.
+     * @property passwordHash The hash of the user's new password.
+     * @property passwordHint The hint for the master password (nullable).
+     */
+    @Serializable
+    data class V1(
+        @SerialName("kdf")
+        val kdfType: KdfTypeJson? = null,
+
+        @SerialName("kdfIterations")
+        val kdfIterations: Int? = null,
+
+        @SerialName("kdfMemory")
+        val kdfMemory: Int? = null,
+
+        @SerialName("kdfParallelism")
+        val kdfParallelism: Int? = null,
+
+        @SerialName("key")
+        val key: String,
+
+        @SerialName("keys")
+        val keys: Keys?,
+
+        @SerialName("orgIdentifier")
+        val organizationIdentifier: String,
+
+        @SerialName("masterPasswordHash")
+        val passwordHash: String?,
+
+        @SerialName("masterPasswordHint")
+        val passwordHint: String?,
+    ) : SetPasswordRequestJson() {
+        /**
+         * A keys object containing public and private keys.
+         *
+         * @param publicKey the public key (encrypted).
+         * @param encryptedPrivateKey the private key (encrypted).
+         */
+        @Serializable
+        data class Keys(
+            @SerialName("publicKey")
+            val publicKey: String,
+
+            @SerialName("encryptedPrivateKey")
+            val encryptedPrivateKey: String,
+        )
+    }
 }

--- a/network/src/main/kotlin/com/bitwarden/network/service/AccountsServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/AccountsServiceImpl.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.json.Json
  * The default implementation of the [AccountsService].
  */
 @Suppress("TooManyFunctions")
-internal class AccountsServiceImpl constructor(
+internal class AccountsServiceImpl(
     private val unauthenticatedAccountsApi: UnauthenticatedAccountsApi,
     private val authenticatedAccountsApi: AuthenticatedAccountsApi,
     private val unauthenticatedKeyConnectorApi: UnauthenticatedKeyConnectorApi,

--- a/network/src/test/kotlin/com/bitwarden/network/service/AccountsServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/AccountsServiceTest.kt
@@ -172,9 +172,16 @@ class AccountsServiceTest : BaseServiceTest() {
         val result = service.resetPassword(
             body = ResetPasswordRequestJson(
                 currentPasswordHash = "",
-                newPasswordHash = "",
                 passwordHint = null,
-                key = "",
+                kdf = KdfJson(
+                    iterations = 7,
+                    memory = 1,
+                    parallelism = 2,
+                    kdfType = KdfTypeJson.ARGON2_ID,
+                ),
+                salt = "",
+                masterPasswordAuthenticationHash = "",
+                masterKeyWrappedUserKey = "",
             ),
         )
         assertTrue(result.isSuccess)
@@ -187,20 +194,27 @@ class AccountsServiceTest : BaseServiceTest() {
         val result = service.resetPassword(
             body = ResetPasswordRequestJson(
                 currentPasswordHash = null,
-                newPasswordHash = "",
                 passwordHint = null,
-                key = "",
+                kdf = KdfJson(
+                    iterations = 7,
+                    memory = 1,
+                    parallelism = 2,
+                    kdfType = KdfTypeJson.ARGON2_ID,
+                ),
+                salt = "",
+                masterPasswordAuthenticationHash = "",
+                masterKeyWrappedUserKey = "",
             ),
         )
         assertTrue(result.isSuccess)
     }
 
     @Test
-    fun `setPassword with empty response is success`() = runTest {
+    fun `setPassword with v1 request and empty response is success`() = runTest {
         val response = MockResponse().setBody("")
         server.enqueue(response)
         val result = service.setPassword(
-            body = SetPasswordRequestJson(
+            body = SetPasswordRequestJson.V1(
                 passwordHash = "passwordHash",
                 passwordHint = "passwordHint",
                 organizationIdentifier = "organizationId",
@@ -209,10 +223,32 @@ class AccountsServiceTest : BaseServiceTest() {
                 kdfParallelism = 2,
                 kdfType = null,
                 key = "encryptedUserKey",
-                keys = SetPasswordRequestJson.Keys(
+                keys = SetPasswordRequestJson.V1.Keys(
                     publicKey = "public",
                     encryptedPrivateKey = "private",
                 ),
+            ),
+        )
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `setPassword with v2 request and empty response is success`() = runTest {
+        val response = MockResponse().setBody("")
+        server.enqueue(response)
+        val result = service.setPassword(
+            body = SetPasswordRequestJson.V2(
+                masterPasswordAuthenticationHash = "passwordHash",
+                passwordHint = "passwordHint",
+                organizationIdentifier = "organizationId",
+                kdf = KdfJson(
+                    iterations = 7,
+                    memory = 1,
+                    parallelism = 2,
+                    kdfType = KdfTypeJson.ARGON2_ID,
+                ),
+                salt = "sample@bitwarden.com",
+                masterKeyWrappedUserKey = "encryptedUserKey",
             ),
         )
         assertTrue(result.isSuccess)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32858](https://bitwarden.atlassian.net/browse/PM-32858)

## 📔 Objective

This PR updates the `ResetPasswordRequestJson` and `SetPasswordRequestJson` to use the new request standard. The old standard is going to be removed in the future.


[PM-32858]: https://bitwarden.atlassian.net/browse/PM-32858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ