### PR TITLE
PM-39072: Feat: Update premium action card copy

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -599,7 +599,7 @@ private fun ActionCard(
                     id = BitwardenString
                         .a_premium_plan_gives_you_more_tools_to_stay_secure_and_in_control,
                 ),
-                actionText = stringResource(id = BitwardenString.upgrade_to_premium),
+                actionText = stringResource(id = BitwardenString.learn_more),
                 onActionClick = { vaultHandlers.actionCardClick(actionCardState) },
                 onDismissClick = { vaultHandlers.dismissActionCardClick(actionCardState) },
                 modifier = modifier,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -1649,7 +1649,7 @@ class VaultScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "Unlock advanced security features")
             .assertIsDisplayed()
         composeTestRule
-            .onNodeWithText(text = "Upgrade to Premium")
+            .onNodeWithText(text = "Learn more")
             .assertIsDisplayed()
     }
 
@@ -1661,7 +1661,7 @@ class VaultScreenTest : BitwardenComposeTest() {
         )
 
         composeTestRule
-            .onNodeWithText(text = "Upgrade to Premium")
+            .onNodeWithText(text = "Learn more")
             .assertIsDisplayed()
             .performClick()
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39072](https://bitwarden.atlassian.net/browse/PM-39072)

## 📔 Objective

This PR updates the premium action card on the VaultScreen to use new copy.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/3834545e-ff7b-4677-9006-489614ca0ca3" /> | <img width="350" src="https://github.com/user-attachments/assets/ef1425ef-1d10-4b0e-8955-6a1a99eca92a" /> |


[PM-39072]: https://bitwarden.atlassian.net/browse/PM-39072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ