### PR TITLE
[PM-39461] bug: Fix QR scan reliability by using Y plane rowStride in analyzer

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/feature/qrcodescan/util/QrCodeAnalyzerImpl.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/feature/qrcodescan/util/QrCodeAnalyzerImpl.kt
@@ -29,9 +29,10 @@ class QrCodeAnalyzerImpl : QrCodeAnalyzer {
         if (isQrCodeInAnalysis) return
         isQrCodeInAnalysis = true
 
+        val plane = image.planes[0]
         val source = PlanarYUVLuminanceSource(
-            image.planes[0].buffer.toByteArray(),
-            image.width,
+            plane.buffer.toByteArray(),
+            plane.rowStride,
             image.height,
             0,
             0,


### PR DESCRIPTION
Solves issue #6264 

QR codes did not scan on some phones. Inspired by https://github.com/Redth/ZXing.Net.Maui/pull/202, I tried using plane.rowStride instead of image.width for the dataWidth parameter of PlanarYUVLuminanceSource. This fixed the issue on my Motorola G9 Power and G9 Plus; both can now successfully scan QR codes in the Authenticator app. I have no other devices (that didn't have the scanning problem before) to test.