### PR TITLE
PM-39480: Feat: Update the Accessibility Disclaimer copy

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepository.kt
@@ -44,6 +44,11 @@ interface DebugMenuRepository {
     fun resetCoachMarkTourStatuses()
 
     /**
+     * Resets the value for displaying the accessibility disclaimer.
+     */
+    fun resetAccessibilityDisclaimer()
+
+    /**
      * Manipulates the state to force showing the onboarding carousel.
      *
      * @param userStateUpdateTrigger A passable lambda to trigger a user state update.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryImpl.kt
@@ -64,6 +64,10 @@ class DebugMenuRepositoryImpl(
         settingsDiskSource.storeShouldShowAddLoginCoachMark(shouldShow = null)
     }
 
+    override fun resetAccessibilityDisclaimer() {
+        settingsDiskSource.hasShownAccessibilityDisclaimer = null
+    }
+
     override fun modifyStateToShowOnboardingCarousel(
         userStateUpdateTrigger: () -> Unit,
     ) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/accessibilitydisclosure/AccessibilityDisclosureScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/accessibilitydisclosure/AccessibilityDisclosureScreen.kt
@@ -63,8 +63,8 @@ fun AccessibilityDisclosureScreen(
             .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
     ) {
         AccessibilityDisclosureContent(
-            onAcceptClick = {
-                viewModel.trySendAction(AccessibilityDisclosureAction.AcceptClicked)
+            iUnderstandClick = {
+                viewModel.trySendAction(AccessibilityDisclosureAction.IUnderstandClick)
             },
             onCloseAppClick = {
                 viewModel.trySendAction(AccessibilityDisclosureAction.CloseAppClick)
@@ -74,9 +74,10 @@ fun AccessibilityDisclosureScreen(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun AccessibilityDisclosureContent(
-    onAcceptClick: () -> Unit,
+    iUnderstandClick: () -> Unit,
     onCloseAppClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -111,8 +112,32 @@ private fun AccessibilityDisclosureContent(
         Spacer(modifier = Modifier.height(height = 12.dp))
 
         Text(
-            text = stringResource(id = BitwardenString.accessibility_disclosure_start_up_text),
+            text = stringResource(id = BitwardenString.accessibility_disclosure_start_up_text_1),
             style = BitwardenTheme.typography.bodyMedium,
+            color = BitwardenTheme.colorScheme.text.secondary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+
+        Spacer(modifier = Modifier.height(height = 12.dp))
+
+        Text(
+            text = stringResource(id = BitwardenString.accessibility_disclosure_start_up_text_2),
+            style = BitwardenTheme.typography.bodySmall,
+            color = BitwardenTheme.colorScheme.text.primary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+
+        Spacer(modifier = Modifier.height(height = 12.dp))
+
+        Text(
+            text = stringResource(id = BitwardenString.accessibility_disclosure_start_up_text_3),
+            style = BitwardenTheme.typography.bodySmall,
             color = BitwardenTheme.colorScheme.text.primary,
             textAlign = TextAlign.Center,
             modifier = Modifier
@@ -123,8 +148,8 @@ private fun AccessibilityDisclosureContent(
         Spacer(modifier = Modifier.height(height = 24.dp))
 
         BitwardenFilledButton(
-            label = stringResource(id = BitwardenString.accept),
-            onClick = onAcceptClick,
+            label = stringResource(id = BitwardenString.i_understand),
+            onClick = iUnderstandClick,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
@@ -150,7 +175,7 @@ private fun AccessibilityDisclosureContent(
 private fun AccessibilityDisclosureContent_preview() {
     BitwardenTheme {
         AccessibilityDisclosureContent(
-            onAcceptClick = {},
+            iUnderstandClick = {},
             onCloseAppClick = {},
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/accessibilitydisclosure/AccessibilityDisclosureViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/accessibilitydisclosure/AccessibilityDisclosureViewModel.kt
@@ -22,12 +22,12 @@ class AccessibilityDisclosureViewModel @Inject constructor(
 ) {
     override fun handleAction(action: AccessibilityDisclosureAction) {
         when (action) {
-            AccessibilityDisclosureAction.AcceptClicked -> handleAcceptClicked()
+            AccessibilityDisclosureAction.IUnderstandClick -> handleIUnderstandClick()
             AccessibilityDisclosureAction.CloseAppClick -> handleCloseAppClick()
         }
     }
 
-    private fun handleAcceptClicked() {
+    private fun handleIUnderstandClick() {
         settingsRepository.accessibilityDisclaimerHasBeenShown()
         sendEvent(AccessibilityDisclosureEvent.Dismiss)
     }
@@ -63,9 +63,9 @@ sealed class AccessibilityDisclosureEvent {
  */
 sealed class AccessibilityDisclosureAction {
     /**
-     * User clicked the accept button.
+     * User clicked the "I understand" button.
      */
-    data object AcceptClicked : AccessibilityDisclosureAction()
+    data object IUnderstandClick : AccessibilityDisclosureAction()
 
     /**
      * User clicked the close app button.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -101,7 +101,15 @@ fun DebugMenuScreen(
                     viewModel.trySendAction(DebugMenuAction.RestartOnboardingCarousel)
                 },
             )
-            Spacer(Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(height = 16.dp))
+            BitwardenFilledButton(
+                label = stringResource(id = BitwardenString.reset_accessibility_disclaimer),
+                onClick = { viewModel.trySendAction(DebugMenuAction.ResetAccessibilityDisclaimer) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+            Spacer(modifier = Modifier.height(height = 8.dp))
             BitwardenFilledButton(
                 label = stringResource(BitwardenString.reset_coach_mark_tour_status),
                 onClick = { viewModel.trySendAction(DebugMenuAction.ResetCoachMarkTourStatuses) },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
@@ -67,7 +67,12 @@ class DebugMenuViewModel @Inject constructor(
             DebugMenuAction.ClearSsoCookies -> handleClearSsoCookies()
             DebugMenuAction.ResetPremiumUpgradeBanner -> handleResetPremiumUpgradeBanner()
             DebugMenuAction.ShowUpgradedToPremiumCard -> handleShowUpgradedToPremiumCard()
+            DebugMenuAction.ResetAccessibilityDisclaimer -> handleResetAccessibilityDisclaimer()
         }
+    }
+
+    private fun handleResetAccessibilityDisclaimer() {
+        debugMenuRepository.resetAccessibilityDisclaimer()
     }
 
     private fun handleShowUpgradedToPremiumCard() {
@@ -185,6 +190,11 @@ sealed class DebugMenuAction {
      * The user has clicked the restart onboarding button for the onboarding section.
      */
     data object RestartOnboarding : DebugMenuAction()
+
+    /**
+     * The user has clicked the reset accessibility disclaimer button.
+     */
+    data object ResetAccessibilityDisclaimer : DebugMenuAction()
 
     /**
      * The user has clicked the restart onboarding button for the onboarding section.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
@@ -160,6 +160,17 @@ class DebugMenuRepositoryTest {
     }
 
     @Test
+    fun `resetAccessibilityDisclaimer calls settings disk source setting value back to null`() {
+        every { mockSettingsDiskSource.hasShownAccessibilityDisclaimer = null } just runs
+
+        debugMenuRepository.resetAccessibilityDisclaimer()
+
+        verify(exactly = 1) {
+            mockSettingsDiskSource.hasShownAccessibilityDisclaimer = null
+        }
+    }
+
+    @Test
     fun `resetCoachMarkTourStatuses calls settings disk source setting values back to null`() {
         every {
             mockSettingsDiskSource.storeShouldShowGeneratorCoachMark(shouldShow = any())

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/accessibilitydisclosure/AccessibilityDisclosureScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/accessibilitydisclosure/AccessibilityDisclosureScreenTest.kt
@@ -40,13 +40,13 @@ class AccessibilityDisclosureScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `accept button click should send AcceptClicked action`() {
+    fun `i understand button click should send IUnderstandClick action`() {
         composeTestRule
-            .onNodeWithText(text = "Accept")
+            .onNodeWithText(text = "I understand")
             .performScrollTo()
             .performClick()
         verify(exactly = 1) {
-            viewModel.trySendAction(AccessibilityDisclosureAction.AcceptClicked)
+            viewModel.trySendAction(AccessibilityDisclosureAction.IUnderstandClick)
         }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/accessibilitydisclosure/AccessibilityDisclosureViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/accessibilitydisclosure/AccessibilityDisclosureViewModelTest.kt
@@ -25,10 +25,10 @@ class AccessibilityDisclosureViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `AcceptClicked should mark disclaimer as shown and emit Dismiss event`() = runTest {
+    fun `IUnderstandClick should mark disclaimer as shown and emit Dismiss event`() = runTest {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
-            viewModel.trySendAction(AccessibilityDisclosureAction.AcceptClicked)
+            viewModel.trySendAction(AccessibilityDisclosureAction.IUnderstandClick)
             assertEquals(AccessibilityDisclosureEvent.Dismiss, awaitItem())
         }
         verify(exactly = 1) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
@@ -172,6 +172,18 @@ class DebugMenuScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `reset accessibility disclaimer should send ResetAccessibilityDisclaimer action`() {
+        composeTestRule
+            .onNodeWithText("Reset accessibility disclaimer")
+            .performScrollTo()
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(DebugMenuAction.ResetAccessibilityDisclaimer)
+        }
+    }
+
+    @Test
     fun `reset all coach mark tours should send ResetCoachMarkTourStatuses action`() {
         composeTestRule
             .onNodeWithText("Reset all coach mark tours")

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -39,6 +39,7 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
         coEvery { resetFeatureFlagOverrides() } just runs
         every { updateFeatureFlag<Boolean>(any(), any()) } just runs
         every { resetOnboardingStatusForCurrentUser() } just runs
+        every { resetAccessibilityDisclaimer() } just runs
         every {
             modifyStateToShowOnboardingCarousel(userStateUpdateTrigger = any())
         } answers {
@@ -131,6 +132,15 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
         verify(exactly = 1) {
             mockDebugMenuRepository.modifyStateToShowOnboardingCarousel(any())
             mockAuthRepository.hasPendingAccountAddition = true
+        }
+    }
+
+    @Test
+    fun `ResetAccessibilityDisclaimer should call repository to reset values`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(DebugMenuAction.ResetAccessibilityDisclaimer)
+        verify(exactly = 1) {
+            mockDebugMenuRepository.resetAccessibilityDisclaimer()
         }
     }
 

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -612,7 +612,10 @@ select Add TOTP to store the key safely</string>
     <string name="forwarded_email_description">Generate an email alias with an external forwarding service.</string>
     <string name="accessibility_service_disclosure">Accessibility Service Disclosure</string>
     <string name="accessibility_disclosure_text">Bitwarden uses the Accessibility Service to search for login fields in apps and websites, then establish the appropriate field IDs for entering a username &amp; password when a match for the app or site is found. We do not store any of the information presented to us by the service, nor do we make any attempt to control any on-screen elements beyond text entry of credentials.</string>
-    <string name="accessibility_disclosure_start_up_text">Bitwarden offers an optional autofill method that uses Android’s Accessibility Service to detect login fields in apps and websites. If you choose to enable it, Bitwarden will identify the appropriate fields and enter your credentials when a match is found. We do not store any information observed by the service, and we do not control any on-screen elements beyond credential entry.</string>
+    <string name="accessibility_disclosure_start_up_text_1">This notice is required before Bitwarden can offer accessibility-based autofill.</string>
+    <string name="accessibility_disclosure_start_up_text_2">Bitwarden offers an optional autofill method that uses Android’s Accessibility Service to detect login fields. If you enable it, Bitwarden will identify the appropriate fields and fill in your credentials when a match is found.</string>
+    <string name="accessibility_disclosure_start_up_text_3">We don’t store any information about what’s onscreen while you use the Accessibility Service, and we don’t control any onscreen elements beyond credential entry.</string>
+    <string name="i_understand">I understand</string>
     <string name="accept">Accept</string>
     <string name="decline">Decline</string>
     <string name="login_request_has_already_expired">Login request has already expired.</string>

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -27,6 +27,7 @@
     <string name="restart_onboarding_carousel">Show Onboarding Carousel</string>
     <string name="restart_onboarding_carousel_details">This will force the change to app state which will cause the first time carousel to show. The carousel will continue to show for any \"new\" account until a login is completed. May need to exit debug menu manually.</string>
     <string name="reset_coach_mark_tour_status">Reset all coach mark tours</string>
+    <string name="reset_accessibility_disclaimer">Reset accessibility disclaimer</string>
     <string name="generate_crash">Generate crash</string>
     <string name="generate_error_report">Generate error report</string>
     <string name="error_reports">Error reports</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39480](https://bitwarden.atlassian.net/browse/PM-39480)

## 📔 Objective

This PR updates the Accessibility Disclaimer to match the latest designs.

Additionally, a new debug menu option was added to help with testing.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/29fc6118-28e0-47ae-ab9f-b0bf5ecc09fb" /> | <img width="350" src="https://github.com/user-attachments/assets/a7a78763-ce55-49e9-8430-6f315d38ddfd" /> |


[PM-39480]: https://bitwarden.atlassian.net/browse/PM-39480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ