### PR TITLE
Bug: Handle token refreshes when token is not present

### DIFF
--- a/network/src/main/kotlin/com/bitwarden/network/interceptor/AuthTokenManager.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/interceptor/AuthTokenManager.kt
@@ -47,12 +47,11 @@ internal class AuthTokenManager(
             // If the same request keeps failing, let's just let the 401 pass through.
             return null
         }
-        val accessToken = requireNotNull(
-            response
-                .request
-                .header(name = HEADER_KEY_AUTHORIZATION)
-                ?.substringAfter(delimiter = HEADER_VALUE_BEARER_PREFIX),
-        )
+        val accessToken = response
+            .request
+            .header(name = HEADER_KEY_AUTHORIZATION)
+            ?.substringAfter(delimiter = HEADER_VALUE_BEARER_PREFIX)
+            ?: return null
         return when (val userId = parseJwtTokenDataOrNull(accessToken)?.userId) {
             null -> {
                 // We are unable to get the user ID, let's just let the 401 pass through.

--- a/network/src/test/kotlin/com/bitwarden/network/interceptor/AuthTokenManagerTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/interceptor/AuthTokenManagerTest.kt
@@ -110,6 +110,15 @@ class AuthTokenManagerTest {
         }
 
         @Test
+        fun `returns null when no token is available`() {
+            assertNull(authTokenManager.authenticate(null, RESPONSE_401_NO_TOKEN))
+
+            verify(exactly = 0) {
+                refreshTokenProvider.refreshAccessTokenSynchronously(any())
+            }
+        }
+
+        @Test
         fun `returns null when refresh is failure`() {
             every { parseJwtTokenDataOrNull(JWT_ACCESS_TOKEN) } returns JTW_TOKEN
             every {
@@ -306,6 +315,17 @@ private val JTW_TOKEN = JwtTokenDataJson(
 )
 
 private const val JWT_ACCESS_TOKEN = "jwt"
+
+private val RESPONSE_401_NO_TOKEN = Response.Builder()
+    .code(401)
+    .request(
+        request = Request.Builder()
+            .url("https://www.bitwarden.com")
+            .build(),
+    )
+    .protocol(Protocol.HTTP_2)
+    .message("Unauthenticated")
+    .build()
 
 private val RESPONSE_401 = Response.Builder()
     .code(401)


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Stumbled upon a crash that can occur now that we allow optionally authenticated calls to be made. This means the access token might not be present when the authenticator is invoked (and that's OK) 
