### PR TITLE
PM-39441: Bug: KeyConnector user should see SetPassword UI when elevated to Admin

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
@@ -246,13 +246,14 @@ fun UserStateJson.toUserState(
                     )
                 }
                 // If a user does not have a Master Password we want to check if they have another
-                // method for unlocking the vault. In the case of a TDE user we check if they
-                // have the reset password permission via their organization(S). If the user does
-                // not belong to a TDE or we check to see if they user key connector.
-                val tdeUserNeedsMasterPassword =
-                    hasManageResetPasswordPermission.takeIf { trustedDevice != null }
+                // method for unlocking the vault. In the case of a TDE or KeyConnector user we
+                // check if they have the reset password permission via their organization(S). If
+                // the user does not belong to a TDE or KeyConnector org, then they need a password.
+                val userNeedsMasterPassword = hasManageResetPasswordPermission
+                    .takeIf { trustedDevice != null || keyConnectorOptions != null }
+                    ?: true
                 val needsMasterPassword = decryptionOptions?.hasMasterPassword == false &&
-                    (tdeUserNeedsMasterPassword ?: (keyConnectorOptions == null))
+                    userNeedsMasterPassword
 
                 val hasPersonalOwnershipRestrictedOrg = getUserPolicies(
                     userId,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39441](https://bitwarden.atlassian.net/browse/PM-39441)

## 📔 Objective

This PR updates the `needsMasterPassword` state to incorporate KeyConnector users in the same way we handle TDE users. This ensure that they see the `SetPasswordScreen` when elevated to the role of Admin or Owner.


[PM-39441]: https://bitwarden.atlassian.net/browse/PM-39441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ