### PR TITLE
PM-39599: Bug: Must be unlocked to reset your password

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -79,7 +79,8 @@ class RootNavViewModel @Inject constructor(
 
             userState?.activeAccount?.needsMasterPassword == true -> RootNavState.SetPassword
 
-            userState?.activeAccount?.needsPasswordReset == true -> RootNavState.ResetPassword
+            userState?.activeAccount?.isVaultUnlocked == true &&
+                userState.activeAccount.needsPasswordReset -> RootNavState.ResetPassword
 
             specialCircumstance is SpecialCircumstance.RegistrationEvent -> {
                 getRegistrationEventNavState(specialCircumstance)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -157,7 +157,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
                         isPremium = true,
                         isPremiumFromSelf = true,
                         isLoggedIn = false,
-                        isVaultUnlocked = false,
+                        isVaultUnlocked = true,
                         needsPasswordReset = true,
                         isBiometricsEnabled = false,
                         organizations = emptyList(),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39599](https://bitwarden.atlassian.net/browse/PM-39599)

## 📔 Objective

This PR updates the `ResetPassword` state to require the user to be unlocked. This is required in order to utilize the SDK appropriately when creating the new password.


[PM-39599]: https://bitwarden.atlassian.net/browse/PM-39599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ