### PR TITLE
tech-debt: Trust user certificates in debug builds

### DIFF
--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -19,8 +19,11 @@
         <domain includeSubdomains="true">bitwarden.eu</domain>
         <domain includeSubdomains="true">bitwarden.pw</domain>
         <trust-anchors>
-            <!-- Only trust pre-installed CAs for Bitwarden domains and all subdomains -->
+            <!-- Trust pre-installed CAs for Bitwarden domains and all subdomains -->
             <certificates src="system" />
+
+            <!-- Additionally trust user added CAs -->
+            <certificates src="user" />
         </trust-anchors>
     </domain-config>
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the debug `network_security_config` to allow user certificates on the Bitwarden domains.
