### PR TITLE
[PM-39762] bug: Fix RTL divider padding

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/ModifierExtensions.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/ModifierExtensions.kt
@@ -186,7 +186,7 @@ fun Modifier.topDivider(
         if (enabled) {
             val (startX, endX) = when (layoutDirection) {
                 LayoutDirection.Ltr -> paddingStart.toPx() to (size.width - paddingEnd.toPx())
-                LayoutDirection.Rtl -> (size.width - paddingEnd.toPx()) to paddingStart.toPx()
+                LayoutDirection.Rtl -> (size.width - paddingStart.toPx()) to paddingEnd.toPx()
             }
             drawLine(
                 alpha = alpha,
@@ -218,7 +218,7 @@ fun Modifier.bottomDivider(
         if (enabled) {
             val (startX, endX) = when (layoutDirection) {
                 LayoutDirection.Ltr -> paddingStart.toPx() to (size.width - paddingEnd.toPx())
-                LayoutDirection.Rtl -> (size.width - paddingEnd.toPx()) to paddingStart.toPx()
+                LayoutDirection.Rtl -> (size.width - paddingStart.toPx()) to paddingEnd.toPx()
             }
             drawLine(
                 alpha = alpha,


### PR DESCRIPTION
## 🎟️ Tracking

No linked issue. While reviewing RTL layout behavior, I noticed that `topDivider` and `bottomDivider` were resolving `paddingStart` and `paddingEnd` to the wrong physical sides when `LayoutDirection.Rtl` is active.

## 📔 Objective

Fix RTL divider padding in `ModifierExtensions`.

`paddingStart` should resolve to the right side in RTL layouts, and `paddingEnd` should resolve to the left side. This updates `topDivider` and `bottomDivider` so dividers with start padding, such as card/list item dividers, are drawn with the correct inset in RTL.

## 📸 Screenshots

Force RTL layout direction was enabled from Android Developer options to isolate RTL behavior while keeping the app text readable.

| Before - English with Force RTL | After - English with Force RTL |
| --- | --- |
| <img width="300" alt="before-force-rtl" src="https://github.com/user-attachments/assets/a6da5c02-dbcb-4199-9685-f48a114c1e01" /> | <img width="300" alt="after-force-rtl" src="https://github.com/user-attachments/assets/27e5e49f-ccac-4af6-9f7a-f63933bc6fdb" /> |

| After - LTR |
| --- |
| <img width="300" alt="after-ltr" src="https://github.com/user-attachments/assets/e39bec31-bf2c-4d7c-85bc-61ff99a4af1d" /> |


The visible divider inset moves to the correct leading side in the Force RTL after screenshot, while LTR remains unchanged.