### PR TITLE
PM-39707: feat: Display unique unpaid subscription UI

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -413,6 +413,7 @@ private fun SubscriptionStatusState.premiumCardState(): PremiumCard =
         is SubscriptionStatusState.Available -> {
             when (this.status) {
                 PremiumSubscriptionStatus.PAST_DUE,
+                PremiumSubscriptionStatus.UNPAID,
                 PremiumSubscriptionStatus.UPDATE_PAYMENT,
                     -> PremiumCard.NEEDS_ATTENTION
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumSubscriptionStatus.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumSubscriptionStatus.kt
@@ -20,5 +20,6 @@ enum class PremiumSubscriptionStatus {
     PENDING_CANCELLATION,
     PAST_DUE,
     PAUSED,
+    UNPAID,
     UPDATE_PAYMENT,
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
@@ -73,14 +73,10 @@ private fun BitwardenSubscriptionResponseJson.toPremiumSubscriptionStatus():
     }
 
     SubscriptionStatusJson.CANCELED -> PremiumSubscriptionStatus.CANCELED
-
     SubscriptionStatusJson.INCOMPLETE_EXPIRED -> PremiumSubscriptionStatus.EXPIRED
-    SubscriptionStatusJson.INCOMPLETE,
-    SubscriptionStatusJson.UNPAID,
-        -> PremiumSubscriptionStatus.UPDATE_PAYMENT
-
+    SubscriptionStatusJson.INCOMPLETE -> PremiumSubscriptionStatus.UPDATE_PAYMENT
+    SubscriptionStatusJson.UNPAID -> PremiumSubscriptionStatus.UNPAID
     SubscriptionStatusJson.PAST_DUE -> PremiumSubscriptionStatus.PAST_DUE
-
     SubscriptionStatusJson.PAUSED -> PremiumSubscriptionStatus.PAUSED
 }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -422,7 +423,9 @@ private fun ColumnScope.PremiumFeatureRows() {
             ),
             headerTextStyle = BitwardenTheme.typography.titleMedium,
             showDivider = index != features.lastIndex,
-            modifier = Modifier.padding(vertical = 8.dp),
+            modifier = Modifier
+                .defaultMinSize(minHeight = 60.dp)
+                .padding(vertical = 8.dp),
         )
     }
 }
@@ -597,10 +600,9 @@ private fun SubscriptionCard(
             canceledDateText = viewState.canceledDateText,
             suspensionDateText = viewState.suspensionDateText,
             gracePeriodDays = viewState.gracePeriodDays,
-            modifier = Modifier
-                .padding(bottom = 16.dp)
-                .standardHorizontalMargin(),
+            modifier = Modifier.standardHorizontalMargin(),
         )
+        Spacer(modifier = Modifier.height(height = 16.dp))
 
         if (viewState.status?.showsFeatureList() == true) {
             PremiumFeatureRows()
@@ -611,20 +613,17 @@ private fun SubscriptionCard(
 }
 
 @Composable
-private fun SubscriptionLineItems(
+private fun ColumnScope.SubscriptionLineItems(
     viewState: PlanState.ViewState.Content.Premium,
 ) {
-    val rowModifier = Modifier
-        .fillMaxWidth()
-        .standardHorizontalMargin()
-
     BitwardenHorizontalDivider()
-
     SubscriptionLineItem(
         label = stringResource(id = BitwardenString.billing_amount),
         value = viewState.billingAmountText(),
         testTag = "BillingAmountRow",
-        modifier = rowModifier,
+        modifier = Modifier
+            .fillMaxWidth()
+            .standardHorizontalMargin(),
     )
 
     viewState.storageCostText?.let { storageCostText ->
@@ -633,7 +632,9 @@ private fun SubscriptionLineItems(
             label = stringResource(id = BitwardenString.storage_cost),
             value = storageCostText,
             testTag = "StorageCostRow",
-            modifier = rowModifier,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
         )
     }
 
@@ -643,28 +644,32 @@ private fun SubscriptionLineItems(
             label = stringResource(id = BitwardenString.discount),
             value = discountAmountText,
             testTag = "DiscountRow",
-            modifier = rowModifier,
             valueColor = BitwardenTheme.colorScheme.statusBadge.success.text,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
         )
     }
 
     BitwardenHorizontalDivider(modifier = Modifier.padding(start = 16.dp))
-
     SubscriptionLineItem(
         label = stringResource(id = BitwardenString.estimated_tax),
         value = viewState.estimatedTaxText,
         testTag = "EstimatedTaxRow",
-        modifier = rowModifier,
+        modifier = Modifier
+            .fillMaxWidth()
+            .standardHorizontalMargin(),
     )
 
     BitwardenHorizontalDivider(modifier = Modifier.padding(start = 16.dp))
-
     SubscriptionLineItem(
         label = stringResource(id = BitwardenString.total),
         value = viewState.totalText(),
         testTag = "TotalRow",
-        modifier = rowModifier,
         labelStyle = BitwardenTheme.typography.bodyLargeEmphasis,
+        modifier = Modifier
+            .fillMaxWidth()
+            .standardHorizontalMargin(),
     )
 }
 
@@ -709,7 +714,7 @@ private fun SubscriptionHeader(
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = it,
-                style = BitwardenTheme.typography.bodyMedium,
+                style = BitwardenTheme.typography.labelLargeRegular,
                 color = BitwardenTheme.colorScheme.text.secondary,
             )
         }
@@ -729,11 +734,11 @@ private fun subscriptionDescriptionText(
 ): AnnotatedString? {
     val baseStyle = spanStyleOf(
         color = BitwardenTheme.colorScheme.text.secondary,
-        textStyle = BitwardenTheme.typography.bodyMedium,
+        textStyle = BitwardenTheme.typography.labelLargeRegular,
     )
     val emphasisStyle = spanStyleOf(
         color = BitwardenTheme.colorScheme.text.secondary,
-        textStyle = BitwardenTheme.typography.bodyMediumEmphasis,
+        textStyle = BitwardenTheme.typography.labelLargeEmphasis,
     )
     return when (status) {
         PremiumSubscriptionStatus.ACTIVE -> annotatedStringResource(
@@ -756,6 +761,13 @@ private fun subscriptionDescriptionText(
         PremiumSubscriptionStatus.PENDING_CANCELLATION -> annotatedStringResource(
             id = BitwardenString.subscription_pending_cancellation_description,
             args = arrayOf(cancelAtDateText ?: PLACEHOLDER_TEXT),
+            style = baseStyle,
+            emphasisHighlightStyle = emphasisStyle,
+        )
+
+        PremiumSubscriptionStatus.UNPAID -> annotatedStringResource(
+            id = BitwardenString.subscription_unpaid_description,
+            args = arrayOf(suspensionDateText ?: PLACEHOLDER_TEXT),
             style = baseStyle,
             emphasisHighlightStyle = emphasisStyle,
         )
@@ -802,15 +814,16 @@ private fun SubscriptionLineItem(
     modifier: Modifier = Modifier,
     labelStyle: TextStyle = BitwardenTheme.typography.bodyLarge,
     labelColor: Color = BitwardenTheme.colorScheme.text.secondary,
-    valueStyle: TextStyle = BitwardenTheme.typography.bodyLarge,
+    valueStyle: TextStyle = BitwardenTheme.typography.bodyMedium,
     valueColor: Color = BitwardenTheme.colorScheme.text.primary,
 ) {
     Row(
-        modifier = modifier
-            .padding(vertical = 16.dp)
-            .testTag(testTag),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .defaultMinSize(minHeight = 60.dp)
+            .padding(vertical = 16.dp)
+            .testTag(tag = testTag),
     ) {
         Text(
             text = label,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -1157,6 +1157,7 @@ private fun PremiumSubscriptionStatus.canBeCanceled(): Boolean = when (this) {
     PremiumSubscriptionStatus.CANCELED,
     PremiumSubscriptionStatus.EXPIRED,
     PremiumSubscriptionStatus.PENDING_CANCELLATION,
+    PremiumSubscriptionStatus.UNPAID,
     PremiumSubscriptionStatus.UPDATE_PAYMENT,
         -> false
 
@@ -1178,6 +1179,7 @@ private fun PremiumSubscriptionStatus.isPremiumViewEligible(): Boolean = when (t
     PremiumSubscriptionStatus.PAST_DUE,
     PremiumSubscriptionStatus.PAUSED,
     PremiumSubscriptionStatus.PENDING_CANCELLATION,
+    PremiumSubscriptionStatus.UNPAID,
     PremiumSubscriptionStatus.UPDATE_PAYMENT,
         -> true
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/util/PremiumSubscriptionStatusExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/util/PremiumSubscriptionStatusExtensions.kt
@@ -21,6 +21,7 @@ fun PremiumSubscriptionStatus.labelRes(): Int = when (this) {
 
     PremiumSubscriptionStatus.PAST_DUE -> BitwardenString.subscription_status_past_due
     PremiumSubscriptionStatus.PAUSED -> BitwardenString.subscription_status_paused
+    PremiumSubscriptionStatus.UNPAID -> BitwardenString.subscription_status_unpaid
     PremiumSubscriptionStatus.UPDATE_PAYMENT -> BitwardenString.subscription_status_update_payment
 }
 
@@ -38,6 +39,7 @@ fun PremiumSubscriptionStatus.showsFeatureList(): Boolean = when (this) {
     PremiumSubscriptionStatus.PAST_DUE,
     PremiumSubscriptionStatus.PAUSED,
     PremiumSubscriptionStatus.PENDING_CANCELLATION,
+    PremiumSubscriptionStatus.UNPAID,
     PremiumSubscriptionStatus.UPDATE_PAYMENT,
         -> false
 }
@@ -52,6 +54,7 @@ fun PremiumSubscriptionStatus.badgeColors(): BitwardenColorScheme.StatusBadgeVar
         PremiumSubscriptionStatus.ACTIVE -> BitwardenTheme.colorScheme.statusBadge.success
         PremiumSubscriptionStatus.CANCELED,
         PremiumSubscriptionStatus.EXPIRED,
+        PremiumSubscriptionStatus.UNPAID,
             -> BitwardenTheme.colorScheme.statusBadge.error
 
         PremiumSubscriptionStatus.PAST_DUE,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
@@ -29,9 +29,7 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
 
     @Test
     fun `toSubscriptionInfo maps CANCELED to CANCELED`() {
-        val info = buildResponse(
-            status = SubscriptionStatusJson.CANCELED,
-        ).toSubscriptionInfo()
+        val info = buildResponse(status = SubscriptionStatusJson.CANCELED).toSubscriptionInfo()
         assertEquals(PremiumSubscriptionStatus.CANCELED, info.status)
     }
 
@@ -44,11 +42,15 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
     }
 
     @Test
-    fun `toSubscriptionInfo maps INCOMPLETE and UNPAID to UPDATE_PAYMENT`() {
-        listOf(SubscriptionStatusJson.INCOMPLETE, SubscriptionStatusJson.UNPAID).forEach {
-            val info = buildResponse(status = it).toSubscriptionInfo()
-            assertEquals(PremiumSubscriptionStatus.UPDATE_PAYMENT, info.status)
-        }
+    fun `toSubscriptionInfo maps INCOMPLETE to UPDATE_PAYMENT`() {
+        val info = buildResponse(status = SubscriptionStatusJson.INCOMPLETE).toSubscriptionInfo()
+        assertEquals(PremiumSubscriptionStatus.UPDATE_PAYMENT, info.status)
+    }
+
+    @Test
+    fun `toSubscriptionInfo maps UNPAID to UNPAID`() {
+        val info = buildResponse(status = SubscriptionStatusJson.UNPAID).toSubscriptionInfo()
+        assertEquals(PremiumSubscriptionStatus.UNPAID, info.status)
     }
 
     @Test

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/badge/BitwardenStatusBadge.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/badge/BitwardenStatusBadge.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,21 +29,20 @@ fun BitwardenStatusBadge(
     colors: BitwardenColorScheme.StatusBadgeVariantColors,
     modifier: Modifier = Modifier,
 ) {
-    val shape = RoundedCornerShape(size = 12.dp)
     Surface(
-        shape = shape,
+        shape = BitwardenTheme.shapes.badge,
         color = colors.background,
         modifier = modifier
             .height(24.dp)
             .border(
                 width = 1.dp,
                 color = colors.border,
-                shape = shape,
+                shape = BitwardenTheme.shapes.badge,
             ),
     ) {
         Text(
             text = label,
-            style = BitwardenTheme.typography.labelSmall,
+            style = BitwardenTheme.typography.labelMedium,
             color = colors.text,
             modifier = Modifier.padding(
                 horizontal = 8.dp,

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/shape/BitwardenShapes.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/shape/BitwardenShapes.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class BitwardenShapes(
     val actionCard: CornerBasedShape,
+    val badge: CornerBasedShape,
     val bottomSheet: CornerBasedShape,
     val coachmark: CornerBasedShape,
     val content: CornerBasedShape,

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/shape/Shapes.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/shape/Shapes.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.dp
  */
 val bitwardenShapes: BitwardenShapes = BitwardenShapes(
     actionCard = RoundedCornerShape(size = 12.dp),
+    badge = RoundedCornerShape(size = 12.dp),
     bottomSheet = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
     coachmark = RoundedCornerShape(size = 8.dp),
     content = RoundedCornerShape(size = 8.dp),

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/type/BitwardenTypography.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/type/BitwardenTypography.kt
@@ -24,6 +24,7 @@ data class BitwardenTypography(
     val bodyMediumEmphasis: TextStyle,
     val bodySmall: TextStyle,
     val labelLarge: TextStyle,
+    val labelLargeEmphasis: TextStyle,
     val labelLargeRegular: TextStyle,
     val labelMedium: TextStyle,
     val labelSmall: TextStyle,

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/type/Typography.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/type/Typography.kt
@@ -217,6 +217,18 @@ val bitwardenTypography: BitwardenTypography = BitwardenTypography(
         ),
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     ),
+    labelLargeEmphasis = TextStyle(
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        fontFamily = FontFamily(Font(R.font.dm_sans_semi_bold)),
+        fontWeight = FontWeight.W700,
+        letterSpacing = 0.sp,
+        lineHeightStyle = LineHeightStyle(
+            alignment = LineHeightStyle.Alignment.Center,
+            trim = LineHeightStyle.Trim.None,
+        ),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    ),
     labelLargeRegular = TextStyle(
         fontSize = 14.sp,
         lineHeight = 20.sp,
@@ -338,6 +350,8 @@ private fun BitwardenTypography_preview() {
             Text(text = "Body medium emphasis", style = bitwardenTypography.bodyMediumEmphasis)
             Text(text = "Body small", style = bitwardenTypography.bodySmall)
             Text(text = "Label large", style = bitwardenTypography.labelLarge)
+            Text(text = "Label large emphasis", style = bitwardenTypography.labelLargeEmphasis)
+            Text(text = "Label large regular", style = bitwardenTypography.labelLargeRegular)
             Text(text = "Label medium", style = bitwardenTypography.labelMedium)
             Text(text = "Label small", style = bitwardenTypography.labelSmall)
             Text(text = "Sensitive info small", style = bitwardenTypography.sensitiveInfoSmall)

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1312,11 +1312,13 @@ Do you want to switch to this account?</string>
     <string name="subscription_status_expired">Expired</string>
     <string name="subscription_status_past_due">Past due</string>
     <string name="subscription_status_paused">Paused</string>
+    <string name="subscription_status_unpaid">Unpaid</string>
     <string name="subscription_status_update_payment">Update payment</string>
     <string name="subscription_status_pending_cancellation">Pending cancellation</string>
     <string name="subscription_pending_cancellation_description">Your subscription is scheduled to cancel on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. You can reinstate it anytime before then.</string>
     <string name="premium_next_charge_summary">Your next charge is for <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation> USD due on <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</string>
     <string name="subscription_canceled_description">Your subscription was canceled on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. Resubscribe to continue using Premium features.</string>
+    <string name="subscription_unpaid_description">Your subscription was suspended on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. To reactivate, please resolve your past due invoices.</string>
     <string name="subscription_update_payment_description">We couldn’t process your payment. Update your payment method before your subscription ends on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>.</string>
     <plurals name="subscription_past_due_description">
         <item quantity="one">You have a grace period of <annotation arg="0">%1$d</annotation> day from your subscription expiration date. Please resolve the past due invoices by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39707](https://bitwarden.atlassian.net/browse/PM-39707)

## 📔 Objective

This PR adds a unique UI for the `Unpaid` subscription state and addresses some minor UI discrepancies.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/5dab0d1b-3c82-4ee4-a1b2-fe6b950cd940" /> | <img width="350" src="https://github.com/user-attachments/assets/48ad199f-b499-4db4-b22c-7d29dc33fd02" /> |


[PM-39707]: https://bitwarden.atlassian.net/browse/PM-39707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ