### PR TITLE
PM-37177: bug: Update subscriptionStatusStateFlow for each getSubscription call

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -382,12 +383,20 @@ class PremiumStateManagerImpl(
             .flatMapLatest {
                 flow {
                     emit(SubscriptionStatusState.Loading)
-                    emit(fetchSubscriptionStatusOnce())
+                    emit(billingRepository.getSubscription().toSubscriptionStatusState())
+                    // This is here to ensure that other places that call
+                    // getSubscription also update this flow
+                    emitAll(
+                        billingRepository
+                            .getSubscriptionFlow()
+                            .map { it.toSubscriptionStatusState() },
+                    )
                 }
             }
+            .distinctUntilChanged()
 
-    private suspend fun fetchSubscriptionStatusOnce(): SubscriptionStatusState =
-        when (val result = billingRepository.getSubscription()) {
+    private fun SubscriptionResult.toSubscriptionStatusState(): SubscriptionStatusState =
+        when (val result = this) {
             is SubscriptionResult.Success -> {
                 SubscriptionStatusState.Available(status = result.subscription.status)
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepository.kt
@@ -4,6 +4,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.CustomerPortalResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -37,4 +38,10 @@ interface BillingRepository {
      * [SubscriptionResult.NotFound] in that case instead of [SubscriptionResult.Error].
      */
     suspend fun getSubscription(): SubscriptionResult
+
+    /**
+     * A flow that emits the result of every [getSubscription] call. New collectors receive nothing
+     * until the next [getSubscription] invocation rather than the most recent result.
+     */
+    fun getSubscriptionFlow(): Flow<SubscriptionResult>
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
@@ -8,6 +8,9 @@ import com.x8bit.bitwarden.data.billing.repository.model.CustomerPortalResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
 import com.x8bit.bitwarden.data.billing.repository.util.toSubscriptionInfo
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -17,6 +20,11 @@ class BillingRepositoryImpl(
     playBillingManager: PlayBillingManager,
     private val billingService: BillingService,
 ) : BillingRepository {
+
+    private val mutableSubscriptionResultFlow = MutableSharedFlow<SubscriptionResult>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
 
     override val isInAppBillingSupportedFlow: StateFlow<Boolean> =
         playBillingManager.isInAppBillingSupportedFlow
@@ -66,4 +74,7 @@ class BillingRepositoryImpl(
                 },
                 onFailure = { SubscriptionResult.Error(error = it) },
             )
+            .also { mutableSubscriptionResultFlow.emit(it) }
+
+    override fun getSubscriptionFlow(): Flow<SubscriptionResult> = mutableSubscriptionResultFlow
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -54,9 +54,13 @@ class PremiumStateManagerTest {
     }
 
     private val mutableIsInAppBillingSupportedFlow = MutableStateFlow(true)
+    private val mutableSubscriptionResultFlow = MutableSharedFlow<SubscriptionResult>(
+        extraBufferCapacity = 1,
+    )
     private val billingRepository: BillingRepository = mockk {
         every { isInAppBillingSupportedFlow } returns mutableIsInAppBillingSupportedFlow
         coEvery { getSubscription() } returns SubscriptionResult.NotFound
+        every { getSubscriptionFlow() } returns mutableSubscriptionResultFlow
     }
 
     private val fakeSettingsDiskSource = FakeSettingsDiskSource()
@@ -1011,6 +1015,40 @@ class PremiumStateManagerTest {
                     SubscriptionStatusState.Available(
                         status = PremiumSubscriptionStatus.PAST_DUE,
                     ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `subscriptionStatusStateFlow updates when BillingRepository getSubscriptionFlow emits`() =
+        runTest {
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(hasPremiumPersonally = true),
+            )
+            coEvery {
+                billingRepository.getSubscription()
+            } returns SubscriptionResult.Success(
+                subscription = createSubscriptionInfo(
+                    status = PremiumSubscriptionStatus.ACTIVE,
+                ),
+            )
+            val manager = createManager()
+            manager.subscriptionStatusStateFlow.test {
+                assertEquals(
+                    SubscriptionStatusState.Available(status = PremiumSubscriptionStatus.ACTIVE),
+                    awaitItem(),
+                )
+                // A getSubscription() call from elsewhere re-emits through the shared flow.
+                mutableSubscriptionResultFlow.emit(
+                    SubscriptionResult.Success(
+                        subscription = createSubscriptionInfo(
+                            status = PremiumSubscriptionStatus.PAST_DUE,
+                        ),
+                    ),
+                )
+                assertEquals(
+                    SubscriptionStatusState.Available(status = PremiumSubscriptionStatus.PAST_DUE),
                     awaitItem(),
                 )
             }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.billing.repository
 
+import app.cash.turbine.test
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.network.model.BitwardenSubscriptionResponseJson
@@ -220,6 +221,86 @@ class BillingRepositoryTest {
                 SubscriptionResult.Error(error = exception),
                 result,
             )
+        }
+
+    @Test
+    fun `getSubscriptionFlow should emit Success when getSubscription returns Success`() =
+        runTest {
+            coEvery {
+                billingService.getSubscription()
+            } returns GetSubscriptionResponse.Success(ACTIVE_SUBSCRIPTION_RESPONSE).asSuccess()
+
+            repository.getSubscriptionFlow().test {
+                repository.getSubscription()
+
+                assertEquals(
+                    SubscriptionResult.Success(
+                        subscription = SubscriptionInfo(
+                            status = PremiumSubscriptionStatus.ACTIVE,
+                            cadence = PlanCadence.ANNUALLY,
+                            seatsCost = BigDecimal("19.80"),
+                            storageCost = null,
+                            discountAmount = null,
+                            estimatedTax = BigDecimal.ZERO,
+                            nextChargeTotal = BigDecimal("19.80"),
+                            nextCharge = null,
+                            cancelAt = null,
+                            canceledDate = null,
+                            suspensionDate = null,
+                            gracePeriodDays = null,
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `getSubscriptionFlow should emit NotFound when getSubscription returns NotFound`() =
+        runTest {
+            coEvery {
+                billingService.getSubscription()
+            } returns GetSubscriptionResponse.NotFound.asSuccess()
+
+            repository.getSubscriptionFlow().test {
+                expectNoEvents()
+
+                repository.getSubscription()
+                assertEquals(SubscriptionResult.NotFound, awaitItem())
+            }
+        }
+
+    @Test
+    fun `getSubscriptionFlow should emit Error when getSubscription returns failure`() =
+        runTest {
+            val exception = RuntimeException("Network error")
+            coEvery { billingService.getSubscription() } returns exception.asFailure()
+
+            repository.getSubscriptionFlow().test {
+                expectNoEvents()
+
+                repository.getSubscription()
+                assertEquals(SubscriptionResult.Error(error = exception), awaitItem())
+            }
+        }
+
+    @Test
+    fun `getSubscriptionFlow should emit a result for each call to getSubscription`() =
+        runTest {
+            val exception = RuntimeException("Network error")
+            coEvery {
+                billingService.getSubscription()
+            } returns GetSubscriptionResponse.NotFound.asSuccess() andThen exception.asFailure()
+
+            repository.getSubscriptionFlow().test {
+                expectNoEvents()
+
+                repository.getSubscription()
+                assertEquals(SubscriptionResult.NotFound, awaitItem())
+
+                repository.getSubscription()
+                assertEquals(SubscriptionResult.Error(error = exception), awaitItem())
+            }
         }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37177](https://bitwarden.atlassian.net/browse/PM-37177)

## 📔 Objective

This PR updates the `subscriptionStatusStateFlow` to emit the latest values from _any_ `getSubscription` request. This ensures that all parts of the app stay up-to-date.


[PM-39765]: https://bitwarden.atlassian.net/browse/PM-39765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-37177]: https://bitwarden.atlassian.net/browse/PM-37177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ