### PR TITLE
[PM-39840] fix: Use dedicated OkHttpClient for fill-assist to prevent load-balancer prompt

### DIFF
--- a/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
@@ -113,7 +113,7 @@ internal class RetrofitsImpl(
 
     // For requests to external (non-Bitwarden) URLs. CookieInterceptor must be excluded because
     // it treats all 302s as Bitwarden load-balancer auth redirects, which is only correct for
-    // Bitwarden own infrastructure.
+    // Bitwarden's own infrastructure.
     private val externalOkHttpClient: OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(headersInterceptor)
         .configureSsl(certificateProvider = certificateProvider)

--- a/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
@@ -111,9 +111,10 @@ internal class RetrofitsImpl(
         .configureSsl(certificateProvider = certificateProvider)
         .build()
 
-    // Fill-assist might use HTTP 302 redirects for content delivery.
-    // CookieInterceptor treats all 302s as auth redirects.
-    private val fillAssistOkHttpClient: OkHttpClient = OkHttpClient.Builder()
+    // For requests to external (non-Bitwarden) URLs. CookieInterceptor must be excluded because
+    // it treats all 302s as Bitwarden load-balancer auth redirects, which is only correct for
+    // Bitwarden's own infrastructure.
+    private val externalOkHttpClient: OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(headersInterceptor)
         .configureSsl(certificateProvider = certificateProvider)
         .build()
@@ -175,7 +176,7 @@ internal class RetrofitsImpl(
         baseRetrofit
             .newBuilder()
             .client(
-                fillAssistOkHttpClient
+                externalOkHttpClient
                     .newBuilder()
                     .addInterceptor(baseUrlInterceptor)
                     .addInterceptor(loggingInterceptor)

--- a/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
@@ -67,7 +67,7 @@ internal class RetrofitsImpl(
     //region Fill-Assist Retrofit
 
     override val fillAssistRetrofit: Retrofit by lazy {
-        createFillAssistRetrofit(
+        createExternalRetrofit(
             baseUrlInterceptor = baseUrlInterceptors.fillAssistInterceptor,
         )
     }
@@ -113,7 +113,7 @@ internal class RetrofitsImpl(
 
     // For requests to external (non-Bitwarden) URLs. CookieInterceptor must be excluded because
     // it treats all 302s as Bitwarden load-balancer auth redirects, which is only correct for
-    // Bitwarden's own infrastructure.
+    // Bitwarden own infrastructure.
     private val externalOkHttpClient: OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(headersInterceptor)
         .configureSsl(certificateProvider = certificateProvider)
@@ -170,7 +170,7 @@ internal class RetrofitsImpl(
             )
             .build()
 
-    private fun createFillAssistRetrofit(
+    private fun createExternalRetrofit(
         baseUrlInterceptor: BaseUrlInterceptor,
     ): Retrofit =
         baseRetrofit

--- a/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
@@ -26,7 +26,7 @@ internal class RetrofitsImpl(
     authTokenManager: AuthTokenManager,
     baseUrlInterceptors: BaseUrlInterceptors,
     cookieInterceptor: CookieInterceptor,
-    headersInterceptor: HeadersInterceptor,
+    private val headersInterceptor: HeadersInterceptor,
     json: Json,
     private val permissionInterceptor: PermissionInterceptor,
     private val certificateProvider: CertificateProvider,
@@ -67,7 +67,7 @@ internal class RetrofitsImpl(
     //region Fill-Assist Retrofit
 
     override val fillAssistRetrofit: Retrofit by lazy {
-        createUnauthenticatedRetrofit(
+        createFillAssistRetrofit(
             baseUrlInterceptor = baseUrlInterceptors.fillAssistInterceptor,
         )
     }
@@ -108,6 +108,14 @@ internal class RetrofitsImpl(
     private val baseOkHttpClient: OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(headersInterceptor)
         .addNetworkInterceptor(cookieInterceptor)
+        .configureSsl(certificateProvider = certificateProvider)
+        .build()
+
+    // Fill-assist might use HTTP 302 redirects for content delivery.
+    // CookieInterceptor treats all 302s as auth redirects and PermissionInterceptor does a DNS
+    // preflight that can fail spuriously — both must be excluded from this client.
+    private val fillAssistOkHttpClient: OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(headersInterceptor)
         .configureSsl(certificateProvider = certificateProvider)
         .build()
 
@@ -158,6 +166,20 @@ internal class RetrofitsImpl(
                     .addInterceptor(baseUrlInterceptor)
                     .addInterceptor(loggingInterceptor)
                     .addInterceptor(permissionInterceptor)
+                    .build(),
+            )
+            .build()
+
+    private fun createFillAssistRetrofit(
+        baseUrlInterceptor: BaseUrlInterceptor,
+    ): Retrofit =
+        baseRetrofit
+            .newBuilder()
+            .client(
+                fillAssistOkHttpClient
+                    .newBuilder()
+                    .addInterceptor(baseUrlInterceptor)
+                    .addInterceptor(loggingInterceptor)
                     .build(),
             )
             .build()

--- a/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
@@ -26,7 +26,7 @@ internal class RetrofitsImpl(
     authTokenManager: AuthTokenManager,
     baseUrlInterceptors: BaseUrlInterceptors,
     cookieInterceptor: CookieInterceptor,
-    private val headersInterceptor: HeadersInterceptor,
+    headersInterceptor: HeadersInterceptor,
     json: Json,
     private val permissionInterceptor: PermissionInterceptor,
     private val certificateProvider: CertificateProvider,
@@ -112,8 +112,7 @@ internal class RetrofitsImpl(
         .build()
 
     // Fill-assist might use HTTP 302 redirects for content delivery.
-    // CookieInterceptor treats all 302s as auth redirects and PermissionInterceptor does a DNS
-    // preflight that can fail spuriously — both must be excluded from this client.
+    // CookieInterceptor treats all 302s as auth redirects.
     private val fillAssistOkHttpClient: OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(headersInterceptor)
         .configureSsl(certificateProvider = certificateProvider)
@@ -180,6 +179,7 @@ internal class RetrofitsImpl(
                     .newBuilder()
                     .addInterceptor(baseUrlInterceptor)
                     .addInterceptor(loggingInterceptor)
+                    .addInterceptor(permissionInterceptor)
                     .build(),
             )
             .build()

--- a/network/src/test/kotlin/com/bitwarden/network/retrofit/RetrofitsTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/retrofit/RetrofitsTest.kt
@@ -47,6 +47,9 @@ class RetrofitsTest {
         every { eventsInterceptor } returns mockk {
             mockIntercept { isEventsInterceptorCalled = true }
         }
+        every { fillAssistInterceptor } returns mockk {
+            mockIntercept { isFillAssistInterceptorCalled = true }
+        }
     }
     private val cookieInterceptor = mockk<CookieInterceptor> {
         mockIntercept { isCookieInterceptorCalled = true }
@@ -82,6 +85,7 @@ class RetrofitsTest {
     private var isHeadersInterceptorCalled = false
     private var isIdentityInterceptorCalled = false
     private var isEventsInterceptorCalled = false
+    private var isFillAssistInterceptorCalled = false
     private var isRefreshAuthenticatorCalled = false
 
     @Before
@@ -249,6 +253,27 @@ class RetrofitsTest {
     }
 
     @Test
+    fun `fillAssistRetrofit should invoke the correct interceptors`() = runBlocking {
+        val testApi = retrofits
+            .fillAssistRetrofit
+            .createMockRetrofit()
+            .create<TestApi>()
+
+        server.enqueue(MockResponse().setBody("""{}"""))
+
+        testApi.test()
+
+        assertFalse(isAuthInterceptorCalled)
+        assertFalse(isApiInterceptorCalled)
+        assertFalse(isCookieInterceptorCalled)
+        assertTrue(isPermissionInterceptorCalled)
+        assertTrue(isHeadersInterceptorCalled)
+        assertFalse(isIdentityInterceptorCalled)
+        assertFalse(isEventsInterceptorCalled)
+        assertTrue(isFillAssistInterceptorCalled)
+    }
+
+    @Test
     fun `createStaticRetrofit when authenticated should invoke the correct interceptors`() =
         runBlocking {
             val testApi = retrofits
@@ -312,7 +337,7 @@ class RetrofitsTest {
 
             retrofits.createStaticRetrofit()
 
-            verify(exactly = 1) {
+            verify(exactly = 2) {
                 anyConstructed<OkHttpClient.Builder>().sslSocketFactory(any(), any())
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39840

## 📔 Objective

The fill-assist service fetches targeting rules from `https://github.com/bitwarden/map-the-web/releases/latest/download/manifest.json`. GitHub's CDN responds with an HTTP 302 redirect for content delivery.

The `CookieInterceptor`, present on the shared unauthenticated `OkHttpClient`, treats any 302 response as a Bitwarden load-balancer auth redirect. It calls `cookieProvider.acquireCookies(hostname)` as a side effect before throwing `CookieRedirectException`, which navigates the app to the "Sync with Browser" load-balancer screen — even though the 302 was a legitimate CDN redirect unrelated to Bitwarden authentication.

This affected users on self-hosted environments without a load balancer (USQA, USDEV, and similar), blocking sign-in and vault unlock.

**Fix:** Introduce a dedicated `fillAssistOkHttpClient` in `RetrofitsImpl` that keeps headers and SSL certificate validation but excludes `CookieInterceptor` and `PermissionInterceptor`. `fillAssistRetrofit` now uses this client so OkHttp's default redirect handling processes the CDN 302 correctly.