### PR TITLE
PM-40651: feat: Add feature flag for FedRAMP

### DIFF
--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -45,6 +45,7 @@ sealed class FlagKey<out T : Any> {
                 DebugDisableSelfHostPremiumCheck,
                 FillAssistTargetingRules,
                 PoliciesInAcceptedState,
+                FedRamp,
             )
         }
     }
@@ -167,6 +168,14 @@ sealed class FlagKey<out T : Any> {
      */
     data object PoliciesInAcceptedState : FlagKey<Boolean>() {
         override val keyName: String get() = "pm-34145-policies-in-accepted-state"
+        override val defaultValue: Boolean get() = false
+    }
+
+    /**
+     * Data object holding the feature flag key for the FedRAMP feature.
+     */
+    data object FedRamp : FlagKey<Boolean>() {
+        override val keyName: String get() = "fedramp-gov-region"
         override val defaultValue: Boolean get() = false
     }
 

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
@@ -60,6 +60,10 @@ class FlagKeyTest {
             FlagKey.PoliciesInAcceptedState.keyName,
             "pm-34145-policies-in-accepted-state",
         )
+        assertEquals(
+            FlagKey.FedRamp.keyName,
+            "fedramp-gov-region",
+        )
     }
 
     @Test
@@ -79,6 +83,7 @@ class FlagKeyTest {
                 FlagKey.FillAssistTargetingRules,
                 FlagKey.ManageDevices,
                 FlagKey.PoliciesInAcceptedState,
+                FlagKey.FedRamp,
             ).all {
                 !it.defaultValue
             },

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
@@ -39,6 +39,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.FillAssistTargetingRules,
     FlagKey.DebugDisableSelfHostPremiumCheck,
     FlagKey.PoliciesInAcceptedState,
+    FlagKey.FedRamp,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -101,4 +102,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.DebugDisableSelfHostPremiumCheck -> {
         stringResource(BitwardenString.debug_disable_self_host_premium_check)
     }
+
+    FlagKey.FedRamp -> stringResource(BitwardenString.fed_ramp)
 }

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -56,6 +56,7 @@
     <string name="fill_assist_targeting_rules">Fill Assist Targeting Rules</string>
     <string name="debug_disable_self_host_premium_check">Debug: Disable self-host premium check</string>
     <string name="policies_in_accepted_state">Policies in accepted state</string>
+    <string name="fed_ramp">FedRAMP</string>
 
     <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40651](https://bitwarden.atlassian.net/browse/PM-40651)

## 📔 Objective

This PR adds a feature flag for FedRAMP, the flag does not do anything at this time.


[PM-40651]: https://bitwarden.atlassian.net/browse/PM-40651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ