### PR TITLE
[QA-2081] Part 1 - Add testTags to Block Auto-fill settings row and blocked-URI field

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -346,6 +346,7 @@ private fun AutoFillScreenContent(
             onClick = autoFillHandlers.onBlockAutoFillClick,
             cardStyle = CardStyle.Full,
             modifier = Modifier
+                .testTag("BlockAutoFillButton")
                 .standardHorizontalMargin()
                 .fillMaxWidth(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/AddEditBlockedUriDialog.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/AddEditBlockedUriDialog.kt
@@ -96,6 +96,7 @@ fun AddEditBlockedUriDialog(
                     onValueChange = onUriChange,
                     keyboardType = KeyboardType.Uri,
                     cardStyle = CardStyle.Full,
+                    textFieldTestTag = "BlockedUriEntry",
                     modifier = Modifier
                         .standardHorizontalMargin()
                         .fillMaxWidth(),


### PR DESCRIPTION
## 🎟️ Tracking

[QA-2081](https://bitwarden.atlassian.net/browse/QA-2081)

## 📔 Objective

Add stable `testTag`s to the Block Auto-fill screens so automation can drop brittle text-/class-based Appium locators for stable `resource-id`s:

- `BlockAutoFillButton` — the "Block autofill" row in Autofill settings (`AutoFillScreen.kt`), matching the sibling `DefaultUriMatchDetectionChooser`.
- `BlockedUriEntry` — the add/edit blocked-URI dialog field (`AddEditBlockedUriDialog.kt`), via `BitwardenTextField`'s `textFieldTestTag` param so the tag lands on the inner EditText.

The per-row overflow ("...") button keeps the shared static `Options` testTag. Every repeating list in the app (RecordedLogs, VaultItemListing) uses a shared static tag; per-item resolution would require a dynamic testTag with no precedent in the app, so per-URI row scoping stays on the test side.

Test-side locator swaps (bitwarden/test) will follow once a build with these tags ships.

## 📸 Screenshots

N/A — no visual change.

[QA-2081]: https://bitwarden.atlassian.net/browse/QA-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ