### PR TITLE
[PM-40274] fix(authenticator): force LTR text direction for TOTP code display

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -109,7 +110,9 @@ fun VaultVerificationCodeItem(
                 text = authCode
                     .chunked(size = 3) { it.padEnd(length = 3, padChar = ' ') }
                     .joinToString(separator = " "),
-                style = BitwardenTheme.typography.sensitiveInfoSmall,
+                style = BitwardenTheme.typography.sensitiveInfoSmall.copy(
+                    textDirection = TextDirection.Ltr,
+                ),
                 color = BitwardenTheme.colorScheme.text.primary,
             )
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/VaultVerificationCodeItem.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/VaultVerificationCodeItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -170,7 +171,11 @@ fun VaultVerificationCodeItem(
                 text = authCode
                     .chunked(size = 3) { it.padEnd(length = 3, padChar = ' ') }
                     .joinToString(separator = " "),
-                style = BitwardenTheme.typography.sensitiveInfoSmall,
+                style = BitwardenTheme.typography.sensitiveInfoSmall.copy(
+                    // Force LTR text direction so TOTP digit groups
+                    // retain correct order in RTL locales
+                    textDirection = TextDirection.Ltr,
+                ),
                 color = BitwardenTheme.colorScheme.text.primary,
             )
 
@@ -193,7 +198,11 @@ fun VaultVerificationCodeItem(
                     text = code
                         .chunked(size = 3) { it.padEnd(length = 3, padChar = ' ') }
                         .joinToString(separator = " "),
-                    style = BitwardenTheme.typography.sensitiveInfoSmall,
+                    style = BitwardenTheme.typography.sensitiveInfoSmall.copy(
+                        // Force LTR text direction so TOTP digit groups
+                        // retain correct order in RTL locales
+                        textDirection = TextDirection.Ltr,
+                    ),
                     color = BitwardenTheme.colorScheme.text.secondary,
                 )
             }


### PR DESCRIPTION
## 🎟️ Tracking

#7150

## 📔 Objective

Forces TextDirection.Ltr on TOTP code displays (authCode and nextAuthCode) in VaultVerificationCodeItem.kt.

In Right-to-Left (RTL) locales (such as Hebrew or Arabic), space-separated TOTP codes (e.g. 123 456) were previously rendered in reverse visual order (456 123) due to Compose default BiDi handling. Adding TextDirection.Ltr ensures the 6-digit verification code always renders in standard LTR order regardless of the active app language.

## 📸 Screenshots
Before : 
<img width="216" height="480" alt="image" src="https://github.com/user-attachments/assets/68fca4c5-6ca0-4985-b184-e45dc0350d60" />                <img width="216" height="480" alt="image" src="https://github.com/user-attachments/assets/25e3e890-34f7-4dd1-9304-9ca36e05a403" />

After:
<img width="216" height="480" alt="image" src="https://github.com/user-attachments/assets/85816d2e-5bf7-403b-9837-0a4a1606a213" />                <img width="216" height="480" alt="image" src="https://github.com/user-attachments/assets/ec8e5afc-568e-416c-8d6d-577a047a0774" />









