### PR TITLE
PM-40317: bug: All users must follow Master Password policies

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerImpl.kt
@@ -158,6 +158,7 @@ class PolicyManagerImpl(
                 this.organizationUserPolicyContext.role == OrganizationUserType.OWNER
             }
 
+            PolicyType.MASTER_PASSWORD,
             PolicyType.PASSWORD_GENERATOR,
             PolicyType.REMOVE_UNLOCK_WITH_PIN,
             PolicyType.RESTRICTED_ITEM_TYPES,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PolicyManagerTest.kt
@@ -419,7 +419,7 @@ class PolicyManagerTest {
         every { authDiskSource.getOrganizations(USER_ID) } returns null
 
         assertEquals(
-            emptyList<SyncResponseJson.Policy>(),
+            emptyList<PolicyView>(),
             policyManager.getUserPolicies(
                 userId = USER_ID,
                 type = PolicyType.ORGANIZATION_DATA_OWNERSHIP,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40317](https://bitwarden.atlassian.net/browse/PM-40317)

## 📔 Objective

This PR updates the policy rules to apply MasterPassword policies to all users.


[PM-40317]: https://bitwarden.atlassian.net/browse/PM-40317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ