### PR TITLE
PM-40295: bug: MP policy check happen directly durring login and unlock

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
@@ -2,7 +2,6 @@ package com.x8bit.bitwarden.data.auth.repository
 
 import com.bitwarden.network.model.GetTokenResponseJson
 import com.bitwarden.network.model.TwoFactorDataModel
-import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.manager.AuthRequestManager
 import com.x8bit.bitwarden.data.auth.manager.KdfManager
@@ -19,8 +18,6 @@ import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordHintResult
-import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
-import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.PrevalidateSsoResult
 import com.x8bit.bitwarden.data.auth.repository.model.RegisterResult
 import com.x8bit.bitwarden.data.auth.repository.model.RemovePasswordResult
@@ -42,6 +39,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
 import com.x8bit.bitwarden.data.auth.util.YubiKeyResult
 import com.x8bit.bitwarden.data.platform.datasource.network.authenticator.AuthenticatorProvider
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
+import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -54,6 +52,7 @@ interface AuthRepository :
     AuthRequestManager,
     BiometricsEncryptionManager,
     KdfManager,
+    PasswordPolicyManager,
     UserStateManager {
     /**
      * Models the current auth state.
@@ -120,16 +119,6 @@ interface AuthRepository :
      * The currently persisted state indicating whether the user has trusted this device.
      */
     var shouldTrustDevice: Boolean
-
-    /**
-     * Return the cached password policies for the current user.
-     */
-    val passwordPolicies: List<PolicyInformation.MasterPassword>
-
-    /**
-     * The reason for resetting the password.
-     */
-    val passwordResetReason: ForcePasswordResetReason?
 
     /**
      * The organization for the active user.
@@ -374,13 +363,6 @@ interface AuthRepository :
     suspend fun getPasswordBreachCount(password: String): BreachCountResult
 
     /**
-     * Get the password strength for the given [email] and [password] combo.
-     * If no value is passed for the [email] will use the active email of the current active
-     * account via the [userStateFlow].
-     */
-    fun getPasswordStrength(email: String? = null, password: String): PasswordStrengthResult
-
-    /**
      * Validates the master password for the current logged-in user.
      */
     suspend fun validatePassword(password: String): ValidatePasswordResult
@@ -389,12 +371,6 @@ interface AuthRepository :
      * Validates the PIN for the current logged-in user.
      */
     suspend fun validatePinUserKey(pin: String): ValidatePinResult
-
-    /**
-     * Validates the given [password] against the master password
-     * policies for the current user.
-     */
-    fun validatePasswordAgainstPolicies(password: String): Boolean
 
     /**
      * Send a verification email.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -51,8 +51,6 @@ import com.bitwarden.network.service.HaveIBeenPwnedService
 import com.bitwarden.network.service.IdentityService
 import com.bitwarden.network.service.OrganizationService
 import com.bitwarden.network.util.isSslHandShakeError
-import com.bitwarden.policies.PolicyType
-import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
@@ -61,7 +59,6 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetRea
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.datasource.network.model.DeviceDataModel
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
-import com.x8bit.bitwarden.data.auth.datasource.sdk.util.toInt
 import com.x8bit.bitwarden.data.auth.datasource.sdk.util.toKdfTypeJson
 import com.x8bit.bitwarden.data.auth.manager.AuthRequestManager
 import com.x8bit.bitwarden.data.auth.manager.KdfManager
@@ -83,7 +80,6 @@ import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordHintResult
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
-import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.PrevalidateSsoResult
 import com.x8bit.bitwarden.data.auth.repository.model.RegisterResult
 import com.x8bit.bitwarden.data.auth.repository.model.RemovePasswordResult
@@ -105,15 +101,14 @@ import com.x8bit.bitwarden.data.auth.repository.util.DuoCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.SsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
 import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
-import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
 import com.x8bit.bitwarden.data.auth.repository.util.toAccountCryptographicState
 import com.x8bit.bitwarden.data.auth.repository.util.toDeviceInfo
 import com.x8bit.bitwarden.data.auth.repository.util.toOrganizations
+import com.x8bit.bitwarden.data.auth.repository.util.toPolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.toUserState
 import com.x8bit.bitwarden.data.auth.repository.util.updateForcePasswordReset
 import com.x8bit.bitwarden.data.auth.repository.util.updateMasterPasswordUnlock
-import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
 import com.x8bit.bitwarden.data.auth.util.KdfParamsConstants.DEFAULT_PBKDF2_ITERATIONS
 import com.x8bit.bitwarden.data.auth.util.YubiKeyResult
 import com.x8bit.bitwarden.data.auth.util.toSdkParams
@@ -122,9 +117,8 @@ import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
-import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
-import com.x8bit.bitwarden.data.platform.manager.util.getActivePolicies
+import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManager
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.util.appLinksScheme
@@ -143,13 +137,10 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -162,7 +153,7 @@ import javax.inject.Singleton
  */
 @Suppress("LargeClass", "LongParameterList", "TooManyFunctions")
 @Singleton
-class AuthRepositoryImpl(
+internal class AuthRepositoryImpl(
     private val clock: Clock,
     private val accountsService: AccountsService,
     private val devicesService: DevicesService,
@@ -182,11 +173,11 @@ class AuthRepositoryImpl(
     private val keyConnectorManager: KeyConnectorManager,
     private val trustedDeviceManager: TrustedDeviceManager,
     private val userLogoutManager: UserLogoutManager,
-    private val policyManager: PolicyManager,
     private val userStateManager: UserStateManager,
     private val kdfManager: KdfManager,
     private val toastManager: ToastManager,
     private val featureFlagManager: FeatureFlagManager,
+    passwordPolicyManager: PasswordPolicyManager,
     logsManager: LogsManager,
     pushManager: PushManager,
     dispatcherManager: DispatcherManager,
@@ -194,6 +185,7 @@ class AuthRepositoryImpl(
     AuthRequestManager by authRequestManager,
     BiometricsEncryptionManager by biometricsEncryptionManager,
     KdfManager by kdfManager,
+    PasswordPolicyManager by passwordPolicyManager,
     UserStateManager by userStateManager {
     /**
      * A scope intended for use when simply collecting multiple flows in order to combine them. The
@@ -230,12 +222,6 @@ class AuthRepositoryImpl(
     private var resendNewDeviceOtpRequestJson: ResendNewDeviceOtpRequestJson? = null
 
     private var organizationIdentifier: String? = null
-
-    /**
-     * The password that needs to be checked against any organization policies before
-     * the user can complete the login flow. This value is stored using the user ID.
-     */
-    private var passwordsToCheckMap = mutableMapOf<String, String>()
 
     private var keyConnectorResponse: GetTokenResponseJson.Success? = null
 
@@ -299,16 +285,6 @@ class AuthRepositoryImpl(
             }
         }
 
-    override val passwordPolicies: List<PolicyInformation.MasterPassword>
-        get() = policyManager.getActivePolicies()
-
-    override val passwordResetReason: ForcePasswordResetReason?
-        get() = authDiskSource
-            .userState
-            ?.activeAccount
-            ?.profile
-            ?.forcePasswordResetReason
-
     override val organizations: List<Organization>
         get() = activeUserId
             ?.let { authDiskSource.getOrganizations(it) }
@@ -363,52 +339,6 @@ class AuthRepositoryImpl(
         pushManager
             .logoutFlow
             .onEach { logout(userId = it.userId, reason = LogoutReason.Notification) }
-            .launchIn(unconfinedScope)
-
-        // When the policies for the user have been set, complete the login process.
-        policyManager
-            .getActivePoliciesFlow(type = PolicyType.MASTER_PASSWORD)
-            .onEach { policies ->
-                val userId = activeUserId ?: return@onEach
-
-                // If the user is logging on without a password, the check should complete.
-                val passwordToCheck = passwordsToCheckMap.remove(key = userId) ?: return@onEach
-
-                // If the password already has to be reset for some other reason, there's no
-                // need to check the password policies.
-                if (passwordResetReason != null) return@onEach
-
-                // Otherwise check the user's password against the policies and set or
-                // clear the force reset reason accordingly.
-                authDiskSource.userState = authDiskSource.userState?.updateForcePasswordReset(
-                    userId = userId,
-                    reason = ForcePasswordResetReason
-                        .WEAK_MASTER_PASSWORD_ON_LOGIN
-                        .takeIf {
-                            !passwordPassesPolicies(
-                                password = passwordToCheck,
-                                policies = policies,
-                            )
-                        },
-                )
-            }
-            .launchIn(unconfinedScope)
-
-        // Clear the cached password whenever the user is no longer active
-        // or the vault is locked for that user.
-        merge(
-            authDiskSource
-                .userSwitchingChangesFlow
-                .mapNotNull { it.previousActiveUserId },
-            vaultRepository
-                .vaultUnlockDataStateFlow
-                .filter { vaultUnlockDataList ->
-                    // Clear if the active user is not currently unlocking or unlocked
-                    vaultUnlockDataList.none { it.userId == activeUserId }
-                }
-                .mapNotNull { activeUserId },
-        )
-            .onEach { userId -> passwordsToCheckMap.remove(key = userId) }
             .launchIn(unconfinedScope)
     }
 
@@ -1537,11 +1467,6 @@ class AuthRepositoryImpl(
             )
     }
 
-    override fun validatePasswordAgainstPolicies(
-        password: String,
-    ): Boolean = passwordPolicies
-        .all { validatePasswordAgainstPolicy(password, it) }
-
     override suspend fun sendVerificationEmail(
         email: String,
         name: String,
@@ -1618,62 +1543,6 @@ class AuthRepositoryImpl(
             onSuccess = { RevokeFromOrganizationResult.Success },
             onFailure = { RevokeFromOrganizationResult.Error(error = it) },
         )
-
-    @Suppress("CyclomaticComplexMethod")
-    private fun validatePasswordAgainstPolicy(
-        password: String,
-        policy: PolicyInformation.MasterPassword,
-    ): Boolean {
-        // Check the password against all the enforced rules in the policy.
-        policy.minLength?.let { minLength ->
-            if (minLength > 0 && password.length < minLength) return false
-        }
-        policy.minComplexity?.let { minComplexity ->
-            // If there was a problem checking the complexity of the password, ignore
-            // the complexity checks and continue checking the other aspects of the policy.
-            val profile = authDiskSource.userState?.activeAccount?.profile ?: return@let
-            val passwordStrengthResult = getPasswordStrength(profile.email, password)
-            val passwordStrength = (passwordStrengthResult as? PasswordStrengthResult.Success)
-                ?.passwordStrength
-                ?.toInt()
-                ?: return@let
-            if (minComplexity > 0 && passwordStrength < minComplexity) return false
-        }
-        policy.requireUpper?.let { requiresUpper ->
-            if (requiresUpper && !password.any { it.isUpperCase() }) return false
-        }
-        policy.requireLower?.let { requiresLower ->
-            if (requiresLower && !password.any { it.isLowerCase() }) return false
-        }
-        policy.requireNumbers?.let { requiresNumbers ->
-            if (requiresNumbers && !password.any { it.isDigit() }) return false
-        }
-        policy.requireSpecial?.let { requiresSpecial ->
-            if (requiresSpecial && !password.contains("^.*[!@#$%\\^&*].*$".toRegex())) return false
-        }
-
-        return true
-    }
-
-    /**
-     * Return true if there are any [PolicyInformation.MasterPassword] policies that the user's
-     * master password has failed to pass.
-     */
-    private fun passwordPassesPolicies(
-        password: String,
-        policies: List<PolicyView>,
-    ): Boolean {
-        // If there are no master password policies that are enabled and should be
-        // enforced on login, the check should complete.
-        val passwordPolicies = policies
-            .mapNotNull { it.policyInformation as? PolicyInformation.MasterPassword }
-            .filter { it.enforceOnLogin == true }
-
-        // Check the password against all the policies.
-        return passwordPolicies.all { policy ->
-            validatePasswordAgainstPolicy(password, policy)
-        }
-    }
 
     /**
      * Enrolls the active user in password reset if their organization requires it.
@@ -1810,9 +1679,15 @@ class AuthRepositoryImpl(
         orgIdentifier: String?,
         userConfirmedKeyConnector: Boolean,
     ): LoginResult = userStateManager.userStateTransaction {
+        val passwordPolicyInfo = loginResponse.masterPasswordPolicyOptions?.toPolicyInformation()
         val userStateJson = loginResponse.toUserState(
             previousUserState = authDiskSource.userState,
             environmentUrlData = environmentRepository.environment.environmentUrlData,
+            passwordPassesPolicy = if (password != null && passwordPolicyInfo != null) {
+                passwordPassesPolicy(password = password, policyInfo = passwordPolicyInfo)
+            } else {
+                true
+            },
         )
         val profile = userStateJson.activeAccount.profile
         val userId = profile.userId
@@ -1893,9 +1768,6 @@ class AuthRepositoryImpl(
                         passwordHash = passwordHash,
                     )
                 }
-
-            // Cache the password to verify against any password policies after the sync completes.
-            passwordsToCheckMap.put(userId, it)
         }
 
         settingsRepository.hasUserLoggedInOrCreatedAccount = true

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
@@ -26,6 +26,7 @@ import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManager
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
@@ -69,7 +70,7 @@ object AuthRepositoryModule {
         trustedDeviceManager: TrustedDeviceManager,
         userLogoutManager: UserLogoutManager,
         pushManager: PushManager,
-        policyManager: PolicyManager,
+        passwordPolicyManager: PasswordPolicyManager,
         logsManager: LogsManager,
         userStateManager: UserStateManager,
         kdfManager: KdfManager,
@@ -97,7 +98,7 @@ object AuthRepositoryModule {
         trustedDeviceManager = trustedDeviceManager,
         userLogoutManager = userLogoutManager,
         pushManager = pushManager,
-        policyManager = policyManager,
+        passwordPolicyManager = passwordPolicyManager,
         logsManager = logsManager,
         userStateManager = userStateManager,
         kdfManager = kdfManager,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensions.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 fun GetTokenResponseJson.Success.toUserState(
     previousUserState: UserStateJson?,
     environmentUrlData: EnvironmentUrlDataJson,
+    passwordPassesPolicy: Boolean,
 ): UserStateJson {
     val jwtTokenData = requireNotNull(parseJwtTokenDataOrNull(jwtToken = this.accessToken))
     val userId = jwtTokenData.userId
@@ -33,7 +34,9 @@ fun GetTokenResponseJson.Success.toUserState(
             avatarColorHex = null,
             hasPremiumPersonally = jwtTokenData.hasPremium,
             hasPremiumFromOrganization = null,
-            forcePasswordResetReason = this.toForcePasswordResetReason(),
+            forcePasswordResetReason = this.toForcePasswordResetReason(
+                passwordPassesPolicy = passwordPassesPolicy,
+            ),
             kdfType = this.kdfType,
             kdfIterations = this.kdfIterations,
             kdfMemory = this.kdfMemory,
@@ -66,7 +69,9 @@ fun GetTokenResponseJson.Success.toUserState(
 /**
  * Determines the [ForcePasswordResetReason] from the [GetTokenResponseJson.Success].
  */
-private fun GetTokenResponseJson.Success.toForcePasswordResetReason(): ForcePasswordResetReason? =
+private fun GetTokenResponseJson.Success.toForcePasswordResetReason(
+    passwordPassesPolicy: Boolean,
+): ForcePasswordResetReason? =
     this
         .userDecryptionOptions
         ?.let { decryptionOptionsJson ->
@@ -82,3 +87,5 @@ private fun GetTokenResponseJson.Success.toForcePasswordResetReason(): ForcePass
                 ?: ForcePasswordResetReason.ADMIN_FORCE_PASSWORD_RESET
                     .takeIf { this.shouldForcePasswordReset }
         }
+        ?: ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN
+            .takeUnless { passwordPassesPolicy }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/MasterPasswordPolicyOptionsJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/MasterPasswordPolicyOptionsJsonExtensions.kt
@@ -1,0 +1,18 @@
+package com.x8bit.bitwarden.data.auth.repository.util
+
+import com.bitwarden.network.model.MasterPasswordPolicyOptionsJson
+import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
+
+/**
+ * Converts the [MasterPasswordPolicyOptionsJson] to a [PolicyInformation.MasterPassword].
+ */
+fun MasterPasswordPolicyOptionsJson.toPolicyInformation(): PolicyInformation.MasterPassword =
+    PolicyInformation.MasterPassword(
+        minLength = this.minimumLength,
+        minComplexity = this.minimumComplexity,
+        requireUpper = this.shouldRequireUppercase,
+        requireLower = this.shouldRequireLowercase,
+        requireNumbers = this.shouldRequireNumbers,
+        requireSpecial = this.shouldRequireSpecialCharacters,
+        enforceOnLogin = this.shouldEnforceOnLogin,
+    )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -77,6 +77,8 @@ import com.x8bit.bitwarden.data.platform.manager.network.NetworkCookieManager
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkCookieManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkPermissionManager
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkPermissionManagerImpl
+import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManager
+import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.restriction.RestrictionManager
 import com.x8bit.bitwarden.data.platform.manager.restriction.RestrictionManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.sdk.SdkPlatformApiFactory
@@ -271,6 +273,18 @@ object PlatformManagerModule {
         authDiskSource = authDiskSource,
         authSdkSource = authSdkSource,
         featureFlagManager = featureFlagManager,
+    )
+
+    @Provides
+    @Singleton
+    fun providePasswordPolicyManager(
+        authDiskSource: AuthDiskSource,
+        authSdkSource: AuthSdkSource,
+        policyManager: PolicyManager,
+    ): PasswordPolicyManager = PasswordPolicyManagerImpl(
+        authDiskSource = authDiskSource,
+        authSdkSource = authSdkSource,
+        policyManager = policyManager,
     )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/PasswordPolicyManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/PasswordPolicyManager.kt
@@ -1,0 +1,40 @@
+package com.x8bit.bitwarden.data.platform.manager.policy
+
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
+import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
+import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
+
+/**
+ * A manager for password policy requirements.
+ */
+interface PasswordPolicyManager {
+    /**
+     * Return the cached password policies for the current user.
+     */
+    val passwordPolicies: List<PolicyInformation.MasterPassword>
+
+    /**
+     * The reason for resetting the password.
+     */
+    val passwordResetReason: ForcePasswordResetReason?
+
+    /**
+     * Get the password strength for the given [email] and [password] combo. If no value is
+     * passed for the [email] will use the active email of the current active account.
+     */
+    fun getPasswordStrength(email: String? = null, password: String): PasswordStrengthResult
+
+    /**
+     * Validates the given [password] against the master password policies for the current user.
+     */
+    fun validatePasswordAgainstPolicies(password: String, isCreation: Boolean = true): Boolean
+
+    /**
+     * Return true if the user's master password passes the requirements of the
+     * [PolicyInformation.MasterPassword].
+     */
+    fun passwordPassesPolicy(
+        password: String,
+        policyInfo: PolicyInformation.MasterPassword,
+    ): Boolean
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/PasswordPolicyManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/PasswordPolicyManagerImpl.kt
@@ -1,0 +1,100 @@
+package com.x8bit.bitwarden.data.platform.manager.policy
+
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
+import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
+import com.x8bit.bitwarden.data.auth.datasource.sdk.util.toInt
+import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
+import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
+import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.util.getActivePolicies
+
+/**
+ * The default [PasswordPolicyManager] implementation. This class is responsible for validating
+ * that password adhere to password policies.
+ */
+internal class PasswordPolicyManagerImpl(
+    private val authDiskSource: AuthDiskSource,
+    private val authSdkSource: AuthSdkSource,
+    private val policyManager: PolicyManager,
+) : PasswordPolicyManager {
+    private val activeAccountProfile: AccountJson.Profile?
+        get() = authDiskSource.userState?.activeAccount?.profile
+
+    override val passwordPolicies: List<PolicyInformation.MasterPassword>
+        get() = policyManager.getActivePolicies()
+
+    override val passwordResetReason: ForcePasswordResetReason?
+        get() = activeAccountProfile?.forcePasswordResetReason
+
+    override fun getPasswordStrength(
+        email: String?,
+        password: String,
+    ): PasswordStrengthResult = authSdkSource
+        .passwordStrength(
+            email = email ?: activeAccountProfile?.email.orEmpty(),
+            password = password,
+        )
+        .fold(
+            onSuccess = { PasswordStrengthResult.Success(passwordStrength = it) },
+            onFailure = { PasswordStrengthResult.Error(error = it) },
+        )
+
+    override fun validatePasswordAgainstPolicies(
+        password: String,
+        isCreation: Boolean,
+    ): Boolean = passwordPolicies
+        .filter {
+            // We always enforce password policies when creating a new passowrd or if the policy
+            // is being enforced on login.
+            isCreation || it.enforceOnLogin == true
+        }
+        .all { validatePasswordAgainstPolicy(password = password, policy = it) }
+
+    override fun passwordPassesPolicy(
+        password: String,
+        policyInfo: PolicyInformation.MasterPassword,
+    ): Boolean = if (policyInfo.enforceOnLogin == true) {
+        validatePasswordAgainstPolicy(password = password, policy = policyInfo)
+    } else {
+        // If the master password policy is not enabled and enforced on login, the check
+        // should complete.
+        true
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun validatePasswordAgainstPolicy(
+        password: String,
+        policy: PolicyInformation.MasterPassword,
+    ): Boolean {
+        // Check the password against all the enforced rules in the policy.
+        policy.minLength?.let { minLength ->
+            if (minLength > 0 && password.length < minLength) return false
+        }
+        policy.minComplexity?.let { minComplexity ->
+            // If there was a problem checking the complexity of the password, ignore
+            // the complexity checks and continue checking the other aspects of the policy.
+            val profile = activeAccountProfile ?: return@let
+            val passwordStrengthResult = getPasswordStrength(profile.email, password)
+            val passwordStrength = (passwordStrengthResult as? PasswordStrengthResult.Success)
+                ?.passwordStrength
+                ?.toInt()
+                ?: return@let
+            if (minComplexity > 0 && passwordStrength < minComplexity) return false
+        }
+        policy.requireUpper?.let { requiresUpper ->
+            if (requiresUpper && !password.any { it.isUpperCase() }) return false
+        }
+        policy.requireLower?.let { requiresLower ->
+            if (requiresLower && !password.any { it.isLowerCase() }) return false
+        }
+        policy.requireNumbers?.let { requiresNumbers ->
+            if (requiresNumbers && !password.any { it.isDigit() }) return false
+        }
+        policy.requireSpecial?.let { requiresSpecial ->
+            if (requiresSpecial && !password.contains("^.*[!@#$%\\^&*].*$".toRegex())) return false
+        }
+        return true
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -21,6 +21,8 @@ import com.bitwarden.data.manager.appstate.AppStateManager
 import com.bitwarden.data.manager.appstate.model.AppCreationState
 import com.bitwarden.data.manager.appstate.model.AppForegroundState
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.manager.KdfManager
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
@@ -29,9 +31,11 @@ import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.UpdateKdfMinimumsResult
 import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
+import com.x8bit.bitwarden.data.auth.repository.util.updateForcePasswordReset
 import com.x8bit.bitwarden.data.auth.repository.util.userAccountTokens
 import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
+import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
@@ -41,6 +45,7 @@ import com.x8bit.bitwarden.data.vault.manager.model.VaultStateEvent
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
 import com.x8bit.bitwarden.data.vault.repository.util.logTag
+import com.x8bit.bitwarden.data.vault.repository.util.password
 import com.x8bit.bitwarden.data.vault.repository.util.statusFor
 import com.x8bit.bitwarden.data.vault.repository.util.toV2UpgradeToken
 import com.x8bit.bitwarden.data.vault.repository.util.toVaultUnlockResult
@@ -82,7 +87,7 @@ private const val MAXIMUM_INVALID_UNLOCK_ATTEMPTS = 5
  * Primary implementation [VaultLockManager].
  */
 @Suppress("TooManyFunctions", "LongParameterList")
-class VaultLockManagerImpl(
+internal class VaultLockManagerImpl(
     private val clock: Clock,
     private val realtimeManager: RealtimeManager,
     private val authDiskSource: AuthDiskSource,
@@ -94,6 +99,7 @@ class VaultLockManagerImpl(
     private val trustedDeviceManager: TrustedDeviceManager,
     private val kdfManager: KdfManager,
     private val pinProtectedUserKeyManager: PinProtectedUserKeyManager,
+    private val passwordPolicyManager: PasswordPolicyManager,
     dispatcherManager: DispatcherManager,
     context: Context,
 ) : VaultLockManager {
@@ -106,7 +112,8 @@ class VaultLockManagerImpl(
      */
     private val userIdTimerJobMap: MutableMap<String, TimeoutJobData> = concurrentMapOf()
 
-    private val activeUserId: String? get() = authDiskSource.userState?.activeUserId
+    private val userState: UserStateJson? get() = authDiskSource.userState
+    private val activeUserId: String? get() = userState?.activeUserId
 
     private val mutableVaultUnlockDataStateFlow =
         MutableStateFlow<List<VaultUnlockData>>(emptyList())
@@ -222,7 +229,7 @@ class VaultLockManagerImpl(
                             initializeCryptoResult
                                 .toVaultUnlockResult()
                                 .also {
-                                    hashAndStoreMasterPassword(
+                                    processMasterPassword(
                                         initUserCryptoMethod = initUserCryptoMethod,
                                         email = email,
                                         kdf = kdf,
@@ -254,19 +261,20 @@ class VaultLockManagerImpl(
 
     /**
      * Hashes a password and stores it as the master password hash for a given user.
+     * The password is also validated against any stored Master Password policies.
      */
-    private suspend fun hashAndStoreMasterPassword(
+    private suspend fun processMasterPassword(
         initUserCryptoMethod: InitUserCryptoMethod,
         email: String,
         kdf: Kdf,
         userId: String,
     ) {
-        (initUserCryptoMethod as? InitUserCryptoMethod.MasterPasswordUnlock)?.let {
+        initUserCryptoMethod.password?.let { password ->
             // Save the master password hash.
             authSdkSource
                 .hashPassword(
                     email = email,
-                    password = initUserCryptoMethod.password,
+                    password = password,
                     kdf = kdf,
                     purpose = HashPurpose.LOCAL_AUTHORIZATION,
                 )
@@ -276,6 +284,17 @@ class VaultLockManagerImpl(
                         passwordHash = it,
                     )
                 }
+
+            // If there is currently no forcePasswordResetReason, then we want to check to see if
+            // the password is strong enough based on known policies.
+            if (userState?.accounts[userId]?.profile?.forcePasswordResetReason == null &&
+                !passwordPolicyManager.validatePasswordAgainstPolicies(password, false)
+            ) {
+                authDiskSource.userState = userState?.updateForcePasswordReset(
+                    userId = userId,
+                    reason = ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN,
+                )
+            }
         }
     }
 
@@ -675,7 +694,7 @@ class VaultLockManagerImpl(
         userId: String,
         initUserCryptoMethod: InitUserCryptoMethod,
     ): VaultUnlockResult {
-        val account = authDiskSource.userState?.accounts?.get(userId)
+        val account = userState?.accounts?.get(userId)
             ?: return VaultUnlockResult.InvalidStateError(error = NoActiveUserException())
         val accountCryptographicState = authDiskSource
             .getAccountCryptographicState(userId = userId)
@@ -699,19 +718,7 @@ class VaultLockManagerImpl(
     }
 
     private suspend fun updateKdfIfNeeded(initUserCryptoMethod: InitUserCryptoMethod) {
-        val password = when (initUserCryptoMethod) {
-            is InitUserCryptoMethod.MasterPasswordUnlock -> initUserCryptoMethod.password
-            is InitUserCryptoMethod.AuthRequest,
-            is InitUserCryptoMethod.DecryptedKey,
-            is InitUserCryptoMethod.DeviceKey,
-            is InitUserCryptoMethod.KeyConnector,
-            is InitUserCryptoMethod.KeyConnectorUrl,
-            is InitUserCryptoMethod.Pin,
-            is InitUserCryptoMethod.PinEnvelope,
-            is InitUserCryptoMethod.PinState,
-                -> return
-        }
-
+        val password = initUserCryptoMethod.password ?: return
         kdfManager
             .updateKdfToMinimumsIfNeeded(
                 password = password,
@@ -768,7 +775,7 @@ class VaultLockManagerImpl(
          * Indicates the app has entered a Created state.
          *
          * @param firstTimeCreation if this is the first time the process is being created.
-         * @param createdForAutofill if the the creation event is due to an activity being launched
+         * @param createdForAutofill if the creation event is due to an activity being launched
          * for autofill.
          */
         data class AppCreated(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
@@ -27,6 +27,7 @@ import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
+import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
@@ -184,6 +185,7 @@ object VaultManagerModule {
         trustedDeviceManager: TrustedDeviceManager,
         kdfManager: KdfManager,
         pinProtectedUserKeyManager: PinProtectedUserKeyManager,
+        passwordPolicyManager: PasswordPolicyManager,
     ): VaultLockManager =
         VaultLockManagerImpl(
             context = context,
@@ -199,6 +201,7 @@ object VaultManagerModule {
             trustedDeviceManager = trustedDeviceManager,
             kdfManager = kdfManager,
             pinProtectedUserKeyManager = pinProtectedUserKeyManager,
+            passwordPolicyManager = passwordPolicyManager,
         )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/InitUserCryptoMethodExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/InitUserCryptoMethodExtensions.kt
@@ -18,3 +18,20 @@ val InitUserCryptoMethod.logTag: String
         is InitUserCryptoMethod.KeyConnectorUrl -> "Key Connector Url"
         is InitUserCryptoMethod.MasterPasswordUnlock -> "Master Password Unlock"
     }
+
+/**
+ * Returns the password for the given [InitUserCryptoMethod] if available.
+ */
+val InitUserCryptoMethod.password: String?
+    get() = when (this) {
+        is InitUserCryptoMethod.MasterPasswordUnlock -> this.password
+        is InitUserCryptoMethod.AuthRequest,
+        is InitUserCryptoMethod.DecryptedKey,
+        is InitUserCryptoMethod.DeviceKey,
+        is InitUserCryptoMethod.KeyConnector,
+        is InitUserCryptoMethod.KeyConnectorUrl,
+        is InitUserCryptoMethod.Pin,
+        is InitUserCryptoMethod.PinEnvelope,
+        is InitUserCryptoMethod.PinState,
+            -> null
+    }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -40,6 +40,7 @@ import com.bitwarden.network.model.GetTokenResponseJson
 import com.bitwarden.network.model.IdentityTokenAuthModel
 import com.bitwarden.network.model.KdfJson
 import com.bitwarden.network.model.KdfTypeJson
+import com.bitwarden.network.model.MasterPasswordPolicyOptionsJson
 import com.bitwarden.network.model.MasterPasswordUnlockDataJson
 import com.bitwarden.network.model.OrganizationAutoEnrollStatusResponseJson
 import com.bitwarden.network.model.OrganizationKeysResponseJson
@@ -71,8 +72,6 @@ import com.bitwarden.network.service.DevicesService
 import com.bitwarden.network.service.HaveIBeenPwnedService
 import com.bitwarden.network.service.IdentityService
 import com.bitwarden.network.service.OrganizationService
-import com.bitwarden.policies.PolicyType
-import com.bitwarden.policies.PolicyView
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
@@ -82,11 +81,6 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.PendingAuthRequestJso
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
-import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_0
-import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_1
-import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_2
-import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_3
-import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_4
 import com.x8bit.bitwarden.data.auth.datasource.sdk.util.toKdfRequestModel
 import com.x8bit.bitwarden.data.auth.manager.AuthRequestManager
 import com.x8bit.bitwarden.data.auth.manager.KdfManager
@@ -97,6 +91,7 @@ import com.x8bit.bitwarden.data.auth.manager.UserStateManager
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequest
 import com.x8bit.bitwarden.data.auth.manager.model.MigrateExistingUserToKeyConnectorResult
 import com.x8bit.bitwarden.data.auth.manager.model.MigrateNewUserToKeyConnectorResult
+import com.x8bit.bitwarden.data.auth.repository.AuthRepositoryTest.Companion.MASTER_PASSWORD_POLICY_OPTIONS
 import com.x8bit.bitwarden.data.auth.repository.model.AuthState
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.DeleteAccountResult
@@ -110,7 +105,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordHintResult
-import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
+import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.PrevalidateSsoResult
 import com.x8bit.bitwarden.data.auth.repository.model.RegisterResult
 import com.x8bit.bitwarden.data.auth.repository.model.RemovePasswordResult
@@ -140,13 +135,12 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSo
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
-import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.model.NotificationLogoutData
+import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
-import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
@@ -255,16 +249,11 @@ class AuthRepositoryTest {
 
     private val mutableLogoutFlow = bufferedMutableSharedFlow<NotificationLogoutData>()
     private val mutableSyncOrgKeysFlow = bufferedMutableSharedFlow<String>()
-    private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<PolicyView>>()
     private val pushManager: PushManager = mockk {
         every { logoutFlow } returns mutableLogoutFlow
         every { syncOrgKeysFlow } returns mutableSyncOrgKeysFlow
     }
-    private val policyManager: PolicyManager = mockk {
-        every {
-            getActivePoliciesFlow(type = PolicyType.MASTER_PASSWORD)
-        } returns mutableActivePolicyFlow
-    }
+    private val passwordPolicyManager: PasswordPolicyManager = mockk()
     private val logsManager: LogsManager = mockk {
         every { setUserData(userId = any(), environmentType = any()) } just runs
     }
@@ -318,7 +307,7 @@ class AuthRepositoryTest {
         userLogoutManager = userLogoutManager,
         dispatcherManager = dispatcherManager,
         pushManager = pushManager,
-        policyManager = policyManager,
+        passwordPolicyManager = passwordPolicyManager,
         logsManager = logsManager,
         userStateManager = userStateManager,
         kdfManager = kdfManager,
@@ -403,124 +392,6 @@ class AuthRepositoryTest {
     }
 
     @Test
-    @Suppress("MaxLineLength")
-    fun `loading the policies should emit masterPasswordPolicyFlow if the password fails any checks`() =
-        runTest {
-            val successResponse = GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS
-            coEvery {
-                identityService.preLogin(email = EMAIL)
-            } returns PRE_LOGIN_SUCCESS.asSuccess()
-            coEvery {
-                identityService.getToken(
-                    email = EMAIL,
-                    authModel = IdentityTokenAuthModel.MasterPassword(
-                        username = EMAIL,
-                        password = PASSWORD_HASH,
-                    ),
-                    uniqueAppId = UNIQUE_APP_ID,
-                    deeplinkScheme = DEEPLINK_SCHEME,
-                )
-            } returns successResponse.asSuccess()
-            coEvery {
-                vaultRepository.unlockVault(
-                    accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE_V2,
-                    userId = USER_ID_1,
-                    email = EMAIL,
-                    kdf = ACCOUNT_1.profile.toSdkParams(),
-                    initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
-                        password = PASSWORD,
-                        masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK,
-                    ),
-                    organizationKeys = null,
-                )
-            } returns VaultUnlockResult.Success
-            coEvery { vaultRepository.syncIfNecessary() } just runs
-            every {
-                GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
-                    previousUserState = null,
-                    environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
-                )
-            } returns SINGLE_USER_STATE_1
-
-            // Start the login flow so that all the necessary data is cached.
-            val result = repository.login(email = EMAIL, password = PASSWORD)
-
-            // Set policies that will fail the password.
-            mutableActivePolicyFlow.emit(
-                listOf(
-                    createMockPolicyView(
-                        type = PolicyType.MASTER_PASSWORD,
-                        enabled = true,
-                        data = """
-                            {
-                              "minLength":100,
-                              "minComplexity":null,
-                              "requireUpper":null,
-                              "requireLower":null,
-                              "requireNumbers":null,
-                              "requireSpecial":null,
-                              "enforceOnLogin":true
-                            }
-                        """,
-                    ),
-                ),
-            )
-
-            // Verify the results.
-            assertEquals(LoginResult.Success, result)
-            assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
-            coVerify { identityService.preLogin(email = EMAIL) }
-            fakeAuthDiskSource.assertAccountCryptographicState(
-                userId = USER_ID_1,
-                accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE_V2,
-            )
-            fakeAuthDiskSource.assertMasterPasswordHash(
-                userId = USER_ID_1,
-                passwordHash = PASSWORD_HASH,
-            )
-            coVerify {
-                identityService.getToken(
-                    email = EMAIL,
-                    authModel = IdentityTokenAuthModel.MasterPassword(
-                        username = EMAIL,
-                        password = PASSWORD_HASH,
-                    ),
-                    uniqueAppId = UNIQUE_APP_ID,
-                    deeplinkScheme = DEEPLINK_SCHEME,
-                )
-                vaultRepository.unlockVault(
-                    accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE_V2,
-                    userId = USER_ID_1,
-                    email = EMAIL,
-                    kdf = ACCOUNT_1.profile.toSdkParams(),
-                    initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
-                        password = PASSWORD,
-                        masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK,
-                    ),
-                    organizationKeys = null,
-                )
-                vaultRepository.syncIfNecessary()
-            }
-            assertEquals(
-                UserStateJson(
-                    activeUserId = USER_ID_1,
-                    accounts = mapOf(
-                        USER_ID_1 to ACCOUNT_1.copy(
-                            profile = ACCOUNT_1.profile.copy(
-                                forcePasswordResetReason = ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN,
-                            ),
-                        ),
-                    ),
-                ),
-                fakeAuthDiskSource.userState,
-            )
-            verify(exactly = 1) {
-                userStateManager.hasPendingAccountAddition = false
-                settingsRepository.setDefaultsIfNecessary(userId = USER_ID_1)
-            }
-        }
-
-    @Test
     fun `rememberedEmailAddress should pull from and update AuthDiskSource`() {
         // AuthDiskSource and the repository start with the same value.
         assertNull(repository.rememberedEmailAddress)
@@ -576,25 +447,6 @@ class AuthRepositoryTest {
         // Updating AuthDiskSource updates the repository
         fakeAuthDiskSource.storeShouldTrustDevice(userId = USER_ID_1, shouldTrustDevice = false)
         assertEquals(false, repository.shouldTrustDevice)
-    }
-
-    @Test
-    fun `passwordResetReason should pull from the user's profile in AuthDiskSource`() = runTest {
-        val updatedProfile = ACCOUNT_1.profile.copy(
-            forcePasswordResetReason = ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN,
-        )
-        fakeAuthDiskSource.userState = UserStateJson(
-            activeUserId = USER_ID_1,
-            accounts = mapOf(
-                USER_ID_1 to ACCOUNT_1.copy(
-                    profile = updatedProfile,
-                ),
-            ),
-        )
-        assertEquals(
-            ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN,
-            repository.passwordResetReason,
-        )
     }
 
     @Test
@@ -2051,6 +1903,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(email = EMAIL, password = PASSWORD)
@@ -2101,6 +1954,235 @@ class AuthRepositoryTest {
 
     @Test
     @Suppress("MaxLineLength")
+    fun `login get token succeeds with master password policy options that the password fails should force a password reset`() =
+        runTest {
+            val successResponse = GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.copy(
+                masterPasswordPolicyOptions = MASTER_PASSWORD_POLICY_OPTIONS,
+            )
+            val weakPasswordUserState = SINGLE_USER_STATE_1.copy(
+                accounts = mapOf(
+                    USER_ID_1 to ACCOUNT_1.copy(
+                        profile = ACCOUNT_1.profile.copy(
+                            forcePasswordResetReason = ForcePasswordResetReason
+                                .WEAK_MASTER_PASSWORD_ON_LOGIN,
+                        ),
+                    ),
+                ),
+            )
+            every {
+                passwordPolicyManager.passwordPassesPolicy(
+                    password = PASSWORD,
+                    policyInfo = MASTER_PASSWORD_POLICY_INFORMATION,
+                )
+            } returns false
+            coEvery {
+                identityService.preLogin(email = EMAIL)
+            } returns PRE_LOGIN_SUCCESS.asSuccess()
+            coEvery {
+                identityService.getToken(
+                    email = EMAIL,
+                    authModel = IdentityTokenAuthModel.MasterPassword(
+                        username = EMAIL,
+                        password = PASSWORD_HASH,
+                    ),
+                    uniqueAppId = UNIQUE_APP_ID,
+                    deeplinkScheme = DEEPLINK_SCHEME,
+                )
+            } returns successResponse.asSuccess()
+            coEvery {
+                vaultRepository.unlockVault(
+                    accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE_V2,
+                    userId = USER_ID_1,
+                    email = EMAIL,
+                    kdf = ACCOUNT_1.profile.toSdkParams(),
+                    initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
+                        password = PASSWORD,
+                        masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK,
+                    ),
+                    organizationKeys = null,
+                )
+            } returns VaultUnlockResult.Success
+            coEvery { vaultRepository.syncIfNecessary() } just runs
+            every {
+                successResponse.toUserState(
+                    previousUserState = null,
+                    environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = false,
+                )
+            } returns weakPasswordUserState
+
+            val result = repository.login(email = EMAIL, password = PASSWORD)
+
+            assertEquals(LoginResult.Success, result)
+            fakeAuthDiskSource.assertUserState(weakPasswordUserState)
+            verify(exactly = 1) {
+                passwordPolicyManager.passwordPassesPolicy(
+                    password = PASSWORD,
+                    policyInfo = MASTER_PASSWORD_POLICY_INFORMATION,
+                )
+            }
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `login get token succeeds with master password policy options that the password passes should not force a password reset`() =
+        runTest {
+            val successResponse = GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.copy(
+                masterPasswordPolicyOptions = MASTER_PASSWORD_POLICY_OPTIONS,
+            )
+            every {
+                passwordPolicyManager.passwordPassesPolicy(
+                    password = PASSWORD,
+                    policyInfo = MASTER_PASSWORD_POLICY_INFORMATION,
+                )
+            } returns true
+            coEvery {
+                identityService.preLogin(email = EMAIL)
+            } returns PRE_LOGIN_SUCCESS.asSuccess()
+            coEvery {
+                identityService.getToken(
+                    email = EMAIL,
+                    authModel = IdentityTokenAuthModel.MasterPassword(
+                        username = EMAIL,
+                        password = PASSWORD_HASH,
+                    ),
+                    uniqueAppId = UNIQUE_APP_ID,
+                    deeplinkScheme = DEEPLINK_SCHEME,
+                )
+            } returns successResponse.asSuccess()
+            coEvery {
+                vaultRepository.unlockVault(
+                    accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE_V2,
+                    userId = USER_ID_1,
+                    email = EMAIL,
+                    kdf = ACCOUNT_1.profile.toSdkParams(),
+                    initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
+                        password = PASSWORD,
+                        masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK,
+                    ),
+                    organizationKeys = null,
+                )
+            } returns VaultUnlockResult.Success
+            coEvery { vaultRepository.syncIfNecessary() } just runs
+            every {
+                successResponse.toUserState(
+                    previousUserState = null,
+                    environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
+                )
+            } returns SINGLE_USER_STATE_1
+
+            val result = repository.login(email = EMAIL, password = PASSWORD)
+
+            assertEquals(LoginResult.Success, result)
+            fakeAuthDiskSource.assertUserState(SINGLE_USER_STATE_1)
+            verify(exactly = 1) {
+                passwordPolicyManager.passwordPassesPolicy(
+                    password = PASSWORD,
+                    policyInfo = MASTER_PASSWORD_POLICY_INFORMATION,
+                )
+            }
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `login get token succeeds without master password policy options should not check the password against any policy`() =
+        runTest {
+            coEvery {
+                identityService.preLogin(email = EMAIL)
+            } returns PRE_LOGIN_SUCCESS.asSuccess()
+            coEvery {
+                identityService.getToken(
+                    email = EMAIL,
+                    authModel = IdentityTokenAuthModel.MasterPassword(
+                        username = EMAIL,
+                        password = PASSWORD_HASH,
+                    ),
+                    uniqueAppId = UNIQUE_APP_ID,
+                    deeplinkScheme = DEEPLINK_SCHEME,
+                )
+            } returns GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.asSuccess()
+            coEvery {
+                vaultRepository.unlockVault(
+                    accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE_V2,
+                    userId = USER_ID_1,
+                    email = EMAIL,
+                    kdf = ACCOUNT_1.profile.toSdkParams(),
+                    initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
+                        password = PASSWORD,
+                        masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK,
+                    ),
+                    organizationKeys = null,
+                )
+            } returns VaultUnlockResult.Success
+            coEvery { vaultRepository.syncIfNecessary() } just runs
+            every {
+                GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
+                    previousUserState = null,
+                    environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
+                )
+            } returns SINGLE_USER_STATE_1
+
+            val result = repository.login(email = EMAIL, password = PASSWORD)
+
+            assertEquals(LoginResult.Success, result)
+            verify(exactly = 0) {
+                passwordPolicyManager.passwordPassesPolicy(
+                    password = any(),
+                    policyInfo = any(),
+                )
+            }
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `SSO login get token succeeds with master password policy options should not check the password against any policy`() =
+        runTest {
+            val successResponse = GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.copy(
+                masterPasswordPolicyOptions = MASTER_PASSWORD_POLICY_OPTIONS,
+            )
+            coEvery {
+                identityService.getToken(
+                    email = EMAIL,
+                    authModel = IdentityTokenAuthModel.SingleSignOn(
+                        ssoCode = SSO_CODE,
+                        ssoCodeVerifier = SSO_CODE_VERIFIER,
+                        ssoRedirectUri = SSO_REDIRECT_URI,
+                    ),
+                    uniqueAppId = UNIQUE_APP_ID,
+                    deeplinkScheme = DEEPLINK_SCHEME,
+                )
+            } returns successResponse.asSuccess()
+            coEvery { vaultRepository.syncIfNecessary() } just runs
+            every {
+                successResponse.toUserState(
+                    previousUserState = null,
+                    environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
+                )
+            } returns SINGLE_USER_STATE_1
+
+            val result = repository.login(
+                email = EMAIL,
+                ssoCode = SSO_CODE,
+                ssoCodeVerifier = SSO_CODE_VERIFIER,
+                ssoRedirectUri = SSO_REDIRECT_URI,
+                organizationIdentifier = ORGANIZATION_IDENTIFIER,
+            )
+
+            assertEquals(LoginResult.Success, result)
+            fakeAuthDiskSource.assertUserState(SINGLE_USER_STATE_1)
+            verify(exactly = 0) {
+                passwordPolicyManager.passwordPassesPolicy(
+                    password = any(),
+                    policyInfo = any(),
+                )
+            }
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
     fun `login get token succeeds with accountKeys with null nested fields should unlock vault with null properties`() =
         runTest {
             val successResponse = GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.copy(
@@ -2141,6 +2223,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(email = EMAIL, password = PASSWORD)
@@ -2231,6 +2314,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(email = EMAIL, password = PASSWORD)
@@ -2317,6 +2401,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(
@@ -2417,6 +2502,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = SINGLE_USER_STATE_2,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns MULTI_USER_STATE
 
@@ -2581,6 +2667,7 @@ class AuthRepositoryTest {
             successResponse.toUserState(
                 previousUserState = null,
                 environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = true,
             )
         } returns SINGLE_USER_STATE_1
         val finalResult = repository.login(
@@ -2677,6 +2764,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val finalResult = repository.login(
@@ -2740,6 +2828,7 @@ class AuthRepositoryTest {
             GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                 previousUserState = null,
                 environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = true,
             )
         } returns SINGLE_USER_STATE_1
         val result = repository.login(email = EMAIL, password = PASSWORD)
@@ -2950,6 +3039,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             coEvery {
@@ -3042,6 +3132,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             coEvery {
@@ -3230,6 +3321,7 @@ class AuthRepositoryTest {
             successResponse.toUserState(
                 previousUserState = null,
                 environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = true,
             )
         } returns SINGLE_USER_STATE_1
         coEvery {
@@ -3369,6 +3461,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(
@@ -3437,6 +3530,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(
@@ -3514,6 +3608,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
 
@@ -3599,6 +3694,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(
@@ -3692,6 +3788,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(
@@ -3784,6 +3881,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
 
@@ -3897,6 +3995,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(
@@ -3992,6 +4091,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             val result = repository.login(
@@ -4046,6 +4146,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
 
@@ -4138,6 +4239,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             coEvery {
@@ -4232,6 +4334,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
 
@@ -4318,6 +4421,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
 
@@ -4421,6 +4525,7 @@ class AuthRepositoryTest {
                 successResponse.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
 
@@ -4496,6 +4601,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = SINGLE_USER_STATE_2,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns MULTI_USER_STATE
 
@@ -4656,6 +4762,7 @@ class AuthRepositoryTest {
             successResponse.toUserState(
                 previousUserState = null,
                 environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = true,
             )
         } returns SINGLE_USER_STATE_1
         val finalResult = repository.login(
@@ -4702,6 +4809,7 @@ class AuthRepositoryTest {
             GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                 previousUserState = null,
                 environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = true,
             )
         } returns SINGLE_USER_STATE_1
         val result = repository.login(
@@ -6486,54 +6594,6 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `getPasswordStrength returns expected results for various strength levels`() {
-        every {
-            authSdkSource.passwordStrength(any(), eq("level_0"))
-        } returns LEVEL_0.asSuccess()
-
-        every {
-            authSdkSource.passwordStrength(any(), eq("level_1"))
-        } returns LEVEL_1.asSuccess()
-
-        every {
-            authSdkSource.passwordStrength(any(), eq("level_2"))
-        } returns LEVEL_2.asSuccess()
-
-        every {
-            authSdkSource.passwordStrength(any(), eq("level_3"))
-        } returns LEVEL_3.asSuccess()
-
-        every {
-            authSdkSource.passwordStrength(any(), eq("level_4"))
-        } returns LEVEL_4.asSuccess()
-
-        assertEquals(
-            PasswordStrengthResult.Success(LEVEL_0),
-            repository.getPasswordStrength(EMAIL, "level_0"),
-        )
-
-        assertEquals(
-            PasswordStrengthResult.Success(LEVEL_1),
-            repository.getPasswordStrength(EMAIL, "level_1"),
-        )
-
-        assertEquals(
-            PasswordStrengthResult.Success(LEVEL_2),
-            repository.getPasswordStrength(EMAIL, "level_2"),
-        )
-
-        assertEquals(
-            PasswordStrengthResult.Success(LEVEL_3),
-            repository.getPasswordStrength(EMAIL, "level_3"),
-        )
-
-        assertEquals(
-            PasswordStrengthResult.Success(LEVEL_4),
-            repository.getPasswordStrength(EMAIL, "level_4"),
-        )
-    }
-
-    @Test
     fun `validatePassword with no current user returns ValidatePasswordResult Error`() = runTest {
         val password = "password"
         fakeAuthDiskSource.userState = null
@@ -6854,66 +6914,6 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `validatePasswordAgainstPolicy validates password against policy requirements`() = runTest {
-        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
-
-        // A helper method to set a policy with the given parameters.
-        fun setPolicy(
-            minLength: Int = 0,
-            minComplexity: Int? = null,
-            requireUpper: Boolean = false,
-            requireLower: Boolean = false,
-            requireNumbers: Boolean = false,
-            requireSpecial: Boolean = false,
-        ) {
-            every {
-                policyManager.getActivePolicies(type = PolicyType.MASTER_PASSWORD)
-            } returns listOf(
-                createMockPolicyView(
-                    type = PolicyType.MASTER_PASSWORD,
-                    enabled = true,
-                    data = """
-                      {
-                        "minLength":$minLength,
-                        "minComplexity":$minComplexity,
-                        "requireUpper":$requireUpper,
-                        "requireLower":$requireLower,
-                        "requireNumbers":$requireNumbers,
-                        "requireSpecial":$requireSpecial,
-                        "enforceOnLogin":true
-                      }
-                    """,
-                ),
-            )
-        }
-
-        setPolicy(minLength = 10)
-        assertFalse(repository.validatePasswordAgainstPolicies(password = "123"))
-
-        val password = "simple"
-        coEvery {
-            authSdkSource.passwordStrength(
-                email = SINGLE_USER_STATE_1.activeAccount.profile.email,
-                password = password,
-            )
-        } returns LEVEL_0.asSuccess()
-        setPolicy(minComplexity = 10)
-        assertFalse(repository.validatePasswordAgainstPolicies(password = password))
-
-        setPolicy(requireUpper = true)
-        assertFalse(repository.validatePasswordAgainstPolicies(password = "lower"))
-
-        setPolicy(requireLower = true)
-        assertFalse(repository.validatePasswordAgainstPolicies(password = "UPPER"))
-
-        setPolicy(requireNumbers = true)
-        assertFalse(repository.validatePasswordAgainstPolicies(password = "letters"))
-
-        setPolicy(requireSpecial = true)
-        assertFalse(repository.validatePasswordAgainstPolicies(password = "letters"))
-    }
-
-    @Test
     fun `sendVerificationEmail success should return success`() = runTest {
         coEvery {
             identityService.sendVerificationEmail(
@@ -7179,6 +7179,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             every { settingsRepository.getUserHasLoggedInValue(USER_ID_1) } returns false
@@ -7237,6 +7238,7 @@ class AuthRepositoryTest {
                 GET_TOKEN_WITH_ACCOUNT_KEYS_RESPONSE_SUCCESS.toUserState(
                     previousUserState = null,
                     environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                    passwordPassesPolicy = true,
                 )
             } returns SINGLE_USER_STATE_1
             every { settingsRepository.getUserHasLoggedInValue(USER_ID_1) } returns true
@@ -7394,6 +7396,30 @@ class AuthRepositoryTest {
             trustedDeviceUserDecryptionOptions = TRUSTED_DEVICE_DECRYPTION_OPTIONS,
             keyConnectorUserDecryptionOptions = null,
             masterPasswordUnlock = null,
+        )
+
+        private val MASTER_PASSWORD_POLICY_OPTIONS = MasterPasswordPolicyOptionsJson(
+            minimumComplexity = 3,
+            minimumLength = 12,
+            shouldRequireUppercase = true,
+            shouldRequireLowercase = true,
+            shouldRequireNumbers = true,
+            shouldRequireSpecialCharacters = true,
+            shouldEnforceOnLogin = true,
+        )
+
+        /**
+         * The [PolicyInformation.MasterPassword] that [MASTER_PASSWORD_POLICY_OPTIONS] maps to via
+         * `toPolicyInformation`.
+         */
+        private val MASTER_PASSWORD_POLICY_INFORMATION = PolicyInformation.MasterPassword(
+            minLength = 12,
+            minComplexity = 3,
+            requireUpper = true,
+            requireLower = true,
+            requireNumbers = true,
+            requireSpecial = true,
+            enforceOnLogin = true,
         )
 
         @Deprecated(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensionsTest.kt
@@ -40,6 +40,7 @@ class GetTokenResponseExtensionsTest {
             GET_TOKEN_RESPONSE_SUCCESS.toUserState(
                 previousUserState = null,
                 environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = true,
             ),
         )
     }
@@ -53,6 +54,7 @@ class GetTokenResponseExtensionsTest {
             GET_TOKEN_RESPONSE_SUCCESS.toUserState(
                 previousUserState = SINGLE_USER_STATE_2,
                 environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = true,
             ),
         )
     }
@@ -80,6 +82,119 @@ class GetTokenResponseExtensionsTest {
             tokenResponse.toUserState(
                 previousUserState = null,
                 environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = true,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toUserState with a failing password and no userDecryptionOptions sets WEAK_MASTER_PASSWORD_ON_LOGIN`() {
+        val expectedState = SINGLE_USER_STATE_1.copy(
+            accounts = mapOf(
+                USER_ID_1 to ACCOUNT_1.copy(
+                    profile = PROFILE_1.copy(
+                        forcePasswordResetReason = ForcePasswordResetReason
+                            .WEAK_MASTER_PASSWORD_ON_LOGIN,
+                    ),
+                ),
+            ),
+        )
+        every { parseJwtTokenDataOrNull(ACCESS_TOKEN_1) } returns JWT_TOKEN_DATA
+
+        assertEquals(
+            expectedState,
+            GET_TOKEN_RESPONSE_SUCCESS.toUserState(
+                previousUserState = null,
+                environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = false,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toUserState with a failing password and userDecryptionOptions without a reason sets WEAK_MASTER_PASSWORD_ON_LOGIN`() {
+        val tokenResponse = GET_TOKEN_RESPONSE_SUCCESS.copy(
+            userDecryptionOptions = USER_DECRYPTION_OPTIONS_WITHOUT_REASON,
+        )
+        val expectedState = SINGLE_USER_STATE_1.copy(
+            accounts = mapOf(
+                USER_ID_1 to ACCOUNT_1.copy(
+                    profile = PROFILE_1.copy(
+                        forcePasswordResetReason = ForcePasswordResetReason
+                            .WEAK_MASTER_PASSWORD_ON_LOGIN,
+                        userDecryptionOptions = USER_DECRYPTION_OPTIONS_WITHOUT_REASON,
+                    ),
+                ),
+            ),
+        )
+        every { parseJwtTokenDataOrNull(ACCESS_TOKEN_1) } returns JWT_TOKEN_DATA
+
+        assertEquals(
+            expectedState,
+            tokenResponse.toUserState(
+                previousUserState = null,
+                environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = false,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toUserState with a failing password prefers TDE_USER_WITHOUT_PASSWORD_HAS_PASSWORD_RESET_PERMISSION`() {
+        val tokenResponse = GET_TOKEN_RESPONSE_SUCCESS.copy(
+            userDecryptionOptions = USER_DECRYPTION_OPTIONS,
+        )
+        val expectedState = SINGLE_USER_STATE_1.copy(
+            accounts = mapOf(
+                USER_ID_1 to ACCOUNT_1.copy(
+                    profile = PROFILE_1.copy(
+                        forcePasswordResetReason = ForcePasswordResetReason
+                            .TDE_USER_WITHOUT_PASSWORD_HAS_PASSWORD_RESET_PERMISSION,
+                        userDecryptionOptions = USER_DECRYPTION_OPTIONS,
+                    ),
+                ),
+            ),
+        )
+        every { parseJwtTokenDataOrNull(ACCESS_TOKEN_1) } returns JWT_TOKEN_DATA
+
+        assertEquals(
+            expectedState,
+            tokenResponse.toUserState(
+                previousUserState = null,
+                environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `toUserState with a failing password prefers ADMIN_FORCE_PASSWORD_RESET`() {
+        val tokenResponse = GET_TOKEN_RESPONSE_SUCCESS.copy(
+            shouldForcePasswordReset = true,
+            userDecryptionOptions = USER_DECRYPTION_OPTIONS_WITHOUT_REASON,
+        )
+        val expectedState = SINGLE_USER_STATE_1.copy(
+            accounts = mapOf(
+                USER_ID_1 to ACCOUNT_1.copy(
+                    profile = PROFILE_1.copy(
+                        forcePasswordResetReason = ForcePasswordResetReason
+                            .ADMIN_FORCE_PASSWORD_RESET,
+                        userDecryptionOptions = USER_DECRYPTION_OPTIONS_WITHOUT_REASON,
+                    ),
+                ),
+            ),
+        )
+        every { parseJwtTokenDataOrNull(ACCESS_TOKEN_1) } returns JWT_TOKEN_DATA
+
+        assertEquals(
+            expectedState,
+            tokenResponse.toUserState(
+                previousUserState = null,
+                environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+                passwordPassesPolicy = false,
             ),
         )
     }
@@ -126,6 +241,17 @@ private val USER_DECRYPTION_OPTIONS = UserDecryptionOptionsJson(
         hasLoginApprovingDevice = true,
         hasManageResetPasswordPermission = true,
     ),
+    keyConnectorUserDecryptionOptions = null,
+    masterPasswordUnlock = null,
+)
+
+/**
+ * Decryption options that produce no [ForcePasswordResetReason] of their own, so that the
+ * weak-password fallback is the only reason left in play.
+ */
+private val USER_DECRYPTION_OPTIONS_WITHOUT_REASON = UserDecryptionOptionsJson(
+    hasMasterPassword = true,
+    trustedDeviceUserDecryptionOptions = null,
     keyConnectorUserDecryptionOptions = null,
     masterPasswordUnlock = null,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/MasterPasswordPolicyOptionsJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/MasterPasswordPolicyOptionsJsonExtensionsTest.kt
@@ -1,0 +1,60 @@
+package com.x8bit.bitwarden.data.auth.repository.util
+
+import com.bitwarden.network.model.MasterPasswordPolicyOptionsJson
+import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MasterPasswordPolicyOptionsJsonExtensionsTest {
+    @Test
+    fun `toPolicyInformation should map every field to its policy counterpart`() {
+        val json = MasterPasswordPolicyOptionsJson(
+            minimumComplexity = 3,
+            minimumLength = 12,
+            shouldRequireUppercase = true,
+            shouldRequireLowercase = false,
+            shouldRequireNumbers = true,
+            shouldRequireSpecialCharacters = false,
+            shouldEnforceOnLogin = true,
+        )
+
+        assertEquals(
+            PolicyInformation.MasterPassword(
+                minLength = 12,
+                minComplexity = 3,
+                requireUpper = true,
+                requireLower = false,
+                requireNumbers = true,
+                requireSpecial = false,
+                enforceOnLogin = true,
+            ),
+            json.toPolicyInformation(),
+        )
+    }
+
+    @Test
+    fun `toPolicyInformation should preserve null fields`() {
+        val json = MasterPasswordPolicyOptionsJson(
+            minimumComplexity = null,
+            minimumLength = null,
+            shouldRequireUppercase = null,
+            shouldRequireLowercase = null,
+            shouldRequireNumbers = null,
+            shouldRequireSpecialCharacters = null,
+            shouldEnforceOnLogin = null,
+        )
+
+        assertEquals(
+            PolicyInformation.MasterPassword(
+                minLength = null,
+                minComplexity = null,
+                requireUpper = null,
+                requireLower = null,
+                requireNumbers = null,
+                requireSpecial = null,
+                enforceOnLogin = null,
+            ),
+            json.toPolicyInformation(),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/PasswordPolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/PasswordPolicyManagerTest.kt
@@ -1,0 +1,461 @@
+package com.x8bit.bitwarden.data.platform.manager.policy
+
+import com.bitwarden.core.data.util.asFailure
+import com.bitwarden.core.data.util.asSuccess
+import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
+import com.bitwarden.network.model.KdfTypeJson
+import com.bitwarden.network.model.MasterPasswordUnlockDataJson
+import com.bitwarden.network.model.UserDecryptionOptionsJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
+import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength
+import com.x8bit.bitwarden.data.auth.datasource.sdk.util.toKdfRequestModel
+import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
+import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
+import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
+import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class PasswordPolicyManagerTest {
+
+    private val fakeAuthDiskSource = FakeAuthDiskSource()
+    private val authSdkSource: AuthSdkSource = mockk()
+    private val policyManager: PolicyManager = mockk {
+        every { getActivePolicies(type = PolicyType.MASTER_PASSWORD) } returns emptyList()
+    }
+
+    private val passwordPolicyManager: PasswordPolicyManager = PasswordPolicyManagerImpl(
+        authDiskSource = fakeAuthDiskSource,
+        authSdkSource = authSdkSource,
+        policyManager = policyManager,
+    )
+
+    @Test
+    fun `passwordPolicies should return the active master password policies`() {
+        setPolicies(
+            createPolicyJson(minLength = 12, requireUpper = true),
+            createPolicyJson(minComplexity = 3, enforceOnLogin = false),
+        )
+
+        assertEquals(
+            listOf(
+                PolicyInformation.MasterPassword(
+                    minLength = 12,
+                    minComplexity = null,
+                    requireUpper = true,
+                    requireLower = false,
+                    requireNumbers = false,
+                    requireSpecial = false,
+                    enforceOnLogin = true,
+                ),
+                PolicyInformation.MasterPassword(
+                    minLength = 0,
+                    minComplexity = 3,
+                    requireUpper = false,
+                    requireLower = false,
+                    requireNumbers = false,
+                    requireSpecial = false,
+                    enforceOnLogin = false,
+                ),
+            ),
+            passwordPolicyManager.passwordPolicies,
+        )
+    }
+
+    @Test
+    fun `passwordResetReason should pull from the user's profile in AuthDiskSource`() {
+        fakeAuthDiskSource.userState = UserStateJson(
+            activeUserId = USER_ID_1,
+            accounts = mapOf(
+                USER_ID_1 to ACCOUNT_1.copy(
+                    profile = PROFILE_1.copy(
+                        forcePasswordResetReason = ForcePasswordResetReason
+                            .WEAK_MASTER_PASSWORD_ON_LOGIN,
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(
+            ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN,
+            passwordPolicyManager.passwordResetReason,
+        )
+    }
+
+    @Test
+    fun `passwordResetReason should return null when there is no active user`() {
+        assertNull(passwordPolicyManager.passwordResetReason)
+    }
+
+    @Test
+    fun `getPasswordStrength returns expected results for various strength levels`() {
+        PasswordStrength.entries.forEach { strength ->
+            every {
+                authSdkSource.passwordStrength(email = any(), password = strength.name)
+            } returns strength.asSuccess()
+
+            assertEquals(
+                PasswordStrengthResult.Success(strength),
+                passwordPolicyManager.getPasswordStrength(
+                    email = EMAIL,
+                    password = strength.name,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `getPasswordStrength failure should return Error`() {
+        val error = Throwable("Fail")
+        every {
+            authSdkSource.passwordStrength(email = EMAIL, password = PASSWORD)
+        } returns error.asFailure()
+
+        assertEquals(
+            PasswordStrengthResult.Error(error = error),
+            passwordPolicyManager.getPasswordStrength(email = EMAIL, password = PASSWORD),
+        )
+    }
+
+    @Test
+    fun `getPasswordStrength with a null email should use the active account email`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        every {
+            authSdkSource.passwordStrength(email = EMAIL, password = PASSWORD)
+        } returns PasswordStrength.LEVEL_3.asSuccess()
+
+        assertEquals(
+            PasswordStrengthResult.Success(PasswordStrength.LEVEL_3),
+            passwordPolicyManager.getPasswordStrength(password = PASSWORD),
+        )
+        verify(exactly = 1) {
+            authSdkSource.passwordStrength(email = EMAIL, password = PASSWORD)
+        }
+    }
+
+    @Test
+    fun `getPasswordStrength with a null email and no active account should use an empty email`() {
+        every {
+            authSdkSource.passwordStrength(email = "", password = PASSWORD)
+        } returns PasswordStrength.LEVEL_3.asSuccess()
+
+        assertEquals(
+            PasswordStrengthResult.Success(PasswordStrength.LEVEL_3),
+            passwordPolicyManager.getPasswordStrength(password = PASSWORD),
+        )
+        verify(exactly = 1) {
+            authSdkSource.passwordStrength(email = "", password = PASSWORD)
+        }
+    }
+
+    @Test
+    fun `validatePasswordAgainstPolicies should return true when there are no active policies`() {
+        assertTrue(passwordPolicyManager.validatePasswordAgainstPolicies(password = "123"))
+    }
+
+    @Test
+    fun `validatePasswordAgainstPolicies validates password against policy requirements`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+
+        setPolicies(createPolicyJson(minLength = 10))
+        assertFalse(passwordPolicyManager.validatePasswordAgainstPolicies(password = "123"))
+
+        val password = "simple"
+        coEvery {
+            authSdkSource.passwordStrength(email = EMAIL, password = password)
+        } returns PasswordStrength.LEVEL_0.asSuccess()
+        setPolicies(createPolicyJson(minComplexity = 10))
+        assertFalse(passwordPolicyManager.validatePasswordAgainstPolicies(password = password))
+
+        setPolicies(createPolicyJson(requireUpper = true))
+        assertFalse(passwordPolicyManager.validatePasswordAgainstPolicies(password = "lower"))
+
+        setPolicies(createPolicyJson(requireLower = true))
+        assertFalse(passwordPolicyManager.validatePasswordAgainstPolicies(password = "UPPER"))
+
+        setPolicies(createPolicyJson(requireNumbers = true))
+        assertFalse(passwordPolicyManager.validatePasswordAgainstPolicies(password = "letters"))
+
+        setPolicies(createPolicyJson(requireSpecial = true))
+        assertFalse(passwordPolicyManager.validatePasswordAgainstPolicies(password = "letters"))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validatePasswordAgainstPolicies should return true when the password satisfies every requirement`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        val password = "Str0ng!Password"
+        every {
+            authSdkSource.passwordStrength(email = EMAIL, password = password)
+        } returns PasswordStrength.LEVEL_4.asSuccess()
+        setPolicies(
+            createPolicyJson(
+                minLength = 10,
+                minComplexity = 3,
+                requireUpper = true,
+                requireLower = true,
+                requireNumbers = true,
+                requireSpecial = true,
+            ),
+        )
+
+        assertTrue(passwordPolicyManager.validatePasswordAgainstPolicies(password = password))
+    }
+
+    @Test
+    fun `validatePasswordAgainstPolicies should ignore a minLength of zero`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        setPolicies(createPolicyJson(minLength = 0))
+
+        assertTrue(passwordPolicyManager.validatePasswordAgainstPolicies(password = "a"))
+        verify(exactly = 0) {
+            authSdkSource.passwordStrength(email = any(), password = any())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validatePasswordAgainstPolicies should ignore a minComplexity of zero even for the weakest password`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        // Note that the strength is still requested from the SDK before the zero check happens.
+        every {
+            authSdkSource.passwordStrength(email = EMAIL, password = "a")
+        } returns PasswordStrength.LEVEL_0.asSuccess()
+        setPolicies(createPolicyJson(minComplexity = 0))
+
+        assertTrue(passwordPolicyManager.validatePasswordAgainstPolicies(password = "a"))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validatePasswordAgainstPolicies with isCreation false should ignore policies not enforced on login`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        setPolicies(
+            createPolicyJson(minLength = 100, enforceOnLogin = false),
+            createPolicyJson(minLength = 100, enforceOnLogin = null),
+        )
+
+        assertTrue(
+            passwordPolicyManager.validatePasswordAgainstPolicies(
+                password = "123",
+                isCreation = false,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validatePasswordAgainstPolicies with isCreation false should enforce policies enforced on login`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        setPolicies(createPolicyJson(minLength = 100, enforceOnLogin = true))
+
+        assertFalse(
+            passwordPolicyManager.validatePasswordAgainstPolicies(
+                password = "123",
+                isCreation = false,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validatePasswordAgainstPolicies with isCreation true should enforce policies not enforced on login`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        setPolicies(createPolicyJson(minLength = 100, enforceOnLogin = false))
+
+        assertFalse(
+            passwordPolicyManager.validatePasswordAgainstPolicies(
+                password = "123",
+                isCreation = true,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validatePasswordAgainstPolicies with a minComplexity policy and no active account should skip the complexity check`() {
+        setPolicies(createPolicyJson(minComplexity = 4))
+
+        assertTrue(passwordPolicyManager.validatePasswordAgainstPolicies(password = "123"))
+        verify(exactly = 0) {
+            authSdkSource.passwordStrength(email = any(), password = any())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validatePasswordAgainstPolicies with a minComplexity policy should skip the complexity check when the strength lookup fails`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        every {
+            authSdkSource.passwordStrength(email = EMAIL, password = "123")
+        } returns Throwable("Fail").asFailure()
+        setPolicies(createPolicyJson(minComplexity = 4))
+
+        assertTrue(passwordPolicyManager.validatePasswordAgainstPolicies(password = "123"))
+    }
+
+    @Test
+    fun `passwordPassesPolicy should return true when enforceOnLogin is null or false`() {
+        listOf(null, false).forEach { enforceOnLogin ->
+            assertTrue(
+                passwordPolicyManager.passwordPassesPolicy(
+                    password = "123",
+                    policyInfo = PolicyInformation.MasterPassword(
+                        minLength = 100,
+                        minComplexity = null,
+                        requireUpper = null,
+                        requireLower = null,
+                        requireNumbers = null,
+                        requireSpecial = null,
+                        enforceOnLogin = enforceOnLogin,
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `passwordPassesPolicy should return false when enforced on login and the password fails the policy`() {
+        assertFalse(
+            passwordPolicyManager.passwordPassesPolicy(
+                password = "123",
+                policyInfo = PolicyInformation.MasterPassword(
+                    minLength = 100,
+                    minComplexity = null,
+                    requireUpper = null,
+                    requireLower = null,
+                    requireNumbers = null,
+                    requireSpecial = null,
+                    enforceOnLogin = true,
+                ),
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `passwordPassesPolicy should return true when enforced on login and the password passes the policy`() {
+        assertTrue(
+            passwordPolicyManager.passwordPassesPolicy(
+                password = "Str0ng!Password",
+                policyInfo = PolicyInformation.MasterPassword(
+                    minLength = 10,
+                    minComplexity = null,
+                    requireUpper = true,
+                    requireLower = true,
+                    requireNumbers = true,
+                    requireSpecial = true,
+                    enforceOnLogin = true,
+                ),
+            ),
+        )
+    }
+
+    /**
+     * Sets the active master password policies to the given [policyDataJson] payloads, each of
+     * which should be created via [createPolicyJson].
+     */
+    private fun setPolicies(vararg policyDataJson: String) {
+        every {
+            policyManager.getActivePolicies(type = PolicyType.MASTER_PASSWORD)
+        } returns policyDataJson.map { data ->
+            createMockPolicyView(
+                type = PolicyType.MASTER_PASSWORD,
+                enabled = true,
+                data = data,
+            )
+        }
+    }
+}
+
+/**
+ * Builds the `data` payload of a master password [PolicyView].
+ */
+@Suppress("LongParameterList")
+private fun createPolicyJson(
+    minLength: Int = 0,
+    minComplexity: Int? = null,
+    requireUpper: Boolean = false,
+    requireLower: Boolean = false,
+    requireNumbers: Boolean = false,
+    requireSpecial: Boolean = false,
+    enforceOnLogin: Boolean? = true,
+): String =
+    """
+    {
+      "minLength":$minLength,
+      "minComplexity":$minComplexity,
+      "requireUpper":$requireUpper,
+      "requireLower":$requireLower,
+      "requireNumbers":$requireNumbers,
+      "requireSpecial":$requireSpecial,
+      "enforceOnLogin":$enforceOnLogin
+    }
+    """
+
+private const val EMAIL = "test@bitwarden.com"
+private const val PASSWORD = "password"
+private const val USER_ID_1 = "2a135b23-e1fb-42c9-bec3-573857bc8181"
+private const val ENCRYPTED_USER_KEY = "encryptedUserKey"
+
+private val BASE_PROFILE_1 = AccountJson.Profile(
+    userId = USER_ID_1,
+    email = EMAIL,
+    isEmailVerified = true,
+    name = "Bitwarden Tester",
+    hasPremiumPersonally = false,
+    hasPremiumFromOrganization = null,
+    stamp = null,
+    organizationId = null,
+    avatarColorHex = null,
+    forcePasswordResetReason = null,
+    kdfType = KdfTypeJson.ARGON2_ID,
+    kdfIterations = 600000,
+    kdfMemory = 16,
+    kdfParallelism = 4,
+    userDecryptionOptions = null,
+    isTwoFactorEnabled = false,
+    creationDate = Instant.parse("2024-09-13T01:00:00.00Z"),
+)
+
+private val PROFILE_1 = BASE_PROFILE_1.copy(
+    userDecryptionOptions = UserDecryptionOptionsJson(
+        hasMasterPassword = true,
+        trustedDeviceUserDecryptionOptions = null,
+        keyConnectorUserDecryptionOptions = null,
+        masterPasswordUnlock = MasterPasswordUnlockDataJson(
+            kdf = BASE_PROFILE_1.toSdkParams().toKdfRequestModel(),
+            masterKeyWrappedUserKey = ENCRYPTED_USER_KEY,
+            salt = EMAIL,
+        ),
+    ),
+)
+private val ACCOUNT_1 = AccountJson(
+    profile = PROFILE_1,
+    settings = AccountJson.Settings(
+        environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+    ),
+)
+
+private val SINGLE_USER_STATE_1 = UserStateJson(
+    activeUserId = USER_ID_1,
+    accounts = mapOf(
+        USER_ID_1 to ACCOUNT_1,
+    ),
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -21,6 +21,7 @@ import com.bitwarden.data.manager.appstate.model.AppCreationState
 import com.bitwarden.data.manager.appstate.model.AppForegroundState
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
@@ -31,6 +32,8 @@ import com.x8bit.bitwarden.data.auth.manager.model.LogoutEvent
 import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.UpdateKdfMinimumsResult
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
+import com.x8bit.bitwarden.data.auth.repository.util.updateForcePasswordReset
+import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
@@ -118,6 +121,9 @@ class VaultLockManagerTest {
     private val pinProtectedUserKeyManager: PinProtectedUserKeyManager = mockk {
         coEvery { migratePinProtectedUserKeyIfNeeded(userId = any()) } just runs
     }
+    private val passwordPolicyManager: PasswordPolicyManager = mockk {
+        every { validatePasswordAgainstPolicies(password = any(), isCreation = any()) } returns true
+    }
 
     private val vaultLockManager: VaultLockManager = VaultLockManagerImpl(
         context = context,
@@ -133,6 +139,7 @@ class VaultLockManagerTest {
         dispatcherManager = fakeDispatcherManager,
         kdfManager = kdfManager,
         pinProtectedUserKeyManager = pinProtectedUserKeyManager,
+        passwordPolicyManager = passwordPolicyManager,
     )
 
     @Test
@@ -1672,7 +1679,6 @@ class VaultLockManagerTest {
             val kdf = MOCK_PROFILE.toSdkParams()
             val email = MOCK_PROFILE.email
             val masterPassword = "mockValue"
-            val privateKey = "54321"
             val organizationKeys = mapOf("orgId1" to "orgKey1")
             coEvery {
                 vaultSdkSource.initializeCrypto(
@@ -1843,6 +1849,303 @@ class VaultLockManagerTest {
                 trustedDeviceManager.trustThisDeviceIfNecessary(userId = USER_ID)
                 kdfManager.updateKdfToMinimumsIfNeeded(password = masterPassword)
             }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `unlockVault with initUserCryptoMethod masterPasswordUnlock should validate the password against policies`() =
+        runTest {
+            val kdf = MOCK_PROFILE.toSdkParams()
+            val email = MOCK_PROFILE.email
+            val masterPassword = "mockValue"
+            val initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
+                password = masterPassword,
+                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+            )
+            coEvery {
+                vaultSdkSource.initializeCrypto(
+                    userId = USER_ID,
+                    request = InitUserCryptoRequest(
+                        accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                        userId = USER_ID,
+                        kdfParams = kdf,
+                        email = email,
+                        method = initUserCryptoMethod,
+                        upgradeToken = null,
+                    ),
+                )
+            } returns InitializeCryptoResult.Success.asSuccess()
+            coEvery {
+                trustedDeviceManager.trustThisDeviceIfNecessary(userId = USER_ID)
+            } returns false.asSuccess()
+            mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+
+            val result = vaultLockManager.unlockVault(
+                accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                userId = USER_ID,
+                email = email,
+                kdf = kdf,
+                initUserCryptoMethod = initUserCryptoMethod,
+                organizationKeys = null,
+            )
+
+            assertEquals(VaultUnlockResult.Success, result)
+            verify(exactly = 1) {
+                passwordPolicyManager.validatePasswordAgainstPolicies(
+                    password = masterPassword,
+                    isCreation = false,
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `unlockVault with initUserCryptoMethod masterPasswordUnlock when the password fails policies should store WEAK_MASTER_PASSWORD_ON_LOGIN`() =
+        runTest {
+            val kdf = MOCK_PROFILE.toSdkParams()
+            val email = MOCK_PROFILE.email
+            val masterPassword = "mockValue"
+            val initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
+                password = masterPassword,
+                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+            )
+            every {
+                passwordPolicyManager.validatePasswordAgainstPolicies(
+                    password = masterPassword,
+                    isCreation = false,
+                )
+            } returns false
+            coEvery {
+                vaultSdkSource.initializeCrypto(
+                    userId = USER_ID,
+                    request = InitUserCryptoRequest(
+                        accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                        userId = USER_ID,
+                        kdfParams = kdf,
+                        email = email,
+                        method = initUserCryptoMethod,
+                        upgradeToken = null,
+                    ),
+                )
+            } returns InitializeCryptoResult.Success.asSuccess()
+            coEvery {
+                trustedDeviceManager.trustThisDeviceIfNecessary(userId = USER_ID)
+            } returns false.asSuccess()
+            mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+
+            val result = vaultLockManager.unlockVault(
+                accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                userId = USER_ID,
+                email = email,
+                kdf = kdf,
+                initUserCryptoMethod = initUserCryptoMethod,
+                organizationKeys = null,
+            )
+
+            assertEquals(VaultUnlockResult.Success, result)
+            fakeAuthDiskSource.assertUserState(
+                userState = MOCK_USER_STATE.updateForcePasswordReset(
+                    userId = USER_ID,
+                    reason = ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN,
+                ),
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `unlockVault with initUserCryptoMethod masterPasswordUnlock when the password passes policies should leave the user state unchanged`() =
+        runTest {
+            val kdf = MOCK_PROFILE.toSdkParams()
+            val email = MOCK_PROFILE.email
+            val masterPassword = "mockValue"
+            val initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
+                password = masterPassword,
+                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+            )
+            coEvery {
+                vaultSdkSource.initializeCrypto(
+                    userId = USER_ID,
+                    request = InitUserCryptoRequest(
+                        accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                        userId = USER_ID,
+                        kdfParams = kdf,
+                        email = email,
+                        method = initUserCryptoMethod,
+                        upgradeToken = null,
+                    ),
+                )
+            } returns InitializeCryptoResult.Success.asSuccess()
+            coEvery {
+                trustedDeviceManager.trustThisDeviceIfNecessary(userId = USER_ID)
+            } returns false.asSuccess()
+            mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+
+            val result = vaultLockManager.unlockVault(
+                accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                userId = USER_ID,
+                email = email,
+                kdf = kdf,
+                initUserCryptoMethod = initUserCryptoMethod,
+                organizationKeys = null,
+            )
+
+            assertEquals(VaultUnlockResult.Success, result)
+            fakeAuthDiskSource.assertUserState(userState = MOCK_USER_STATE)
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `unlockVault with initUserCryptoMethod masterPasswordUnlock when a forcePasswordResetReason already exists should not validate the password`() =
+        runTest {
+            val kdf = MOCK_PROFILE.toSdkParams()
+            val email = MOCK_PROFILE.email
+            val masterPassword = "mockValue"
+            val initialUserState = MOCK_USER_STATE.updateForcePasswordReset(
+                userId = USER_ID,
+                reason = ForcePasswordResetReason.ADMIN_FORCE_PASSWORD_RESET,
+            )
+            val initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
+                password = masterPassword,
+                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+            )
+            coEvery {
+                vaultSdkSource.initializeCrypto(
+                    userId = USER_ID,
+                    request = InitUserCryptoRequest(
+                        accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                        userId = USER_ID,
+                        kdfParams = kdf,
+                        email = email,
+                        method = initUserCryptoMethod,
+                        upgradeToken = null,
+                    ),
+                )
+            } returns InitializeCryptoResult.Success.asSuccess()
+            coEvery {
+                trustedDeviceManager.trustThisDeviceIfNecessary(userId = USER_ID)
+            } returns false.asSuccess()
+            mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
+            fakeAuthDiskSource.userState = initialUserState
+
+            val result = vaultLockManager.unlockVault(
+                accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                userId = USER_ID,
+                email = email,
+                kdf = kdf,
+                initUserCryptoMethod = initUserCryptoMethod,
+                organizationKeys = null,
+            )
+
+            assertEquals(VaultUnlockResult.Success, result)
+            fakeAuthDiskSource.assertUserState(userState = initialUserState)
+            verify(exactly = 0) {
+                passwordPolicyManager.validatePasswordAgainstPolicies(
+                    password = any(),
+                    isCreation = any(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `unlockVault with an initUserCryptoMethod without a password should not validate the password`() =
+        runTest {
+            val kdf = MOCK_PROFILE.toSdkParams()
+            val email = MOCK_PROFILE.email
+            val initUserCryptoMethod = InitUserCryptoMethod.DecryptedKey(
+                decryptedUserKey = "decryptedUserKey",
+            )
+            coEvery {
+                vaultSdkSource.initializeCrypto(
+                    userId = USER_ID,
+                    request = InitUserCryptoRequest(
+                        accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                        userId = USER_ID,
+                        kdfParams = kdf,
+                        email = email,
+                        method = initUserCryptoMethod,
+                        upgradeToken = null,
+                    ),
+                )
+            } returns InitializeCryptoResult.Success.asSuccess()
+            coEvery {
+                trustedDeviceManager.trustThisDeviceIfNecessary(userId = USER_ID)
+            } returns false.asSuccess()
+            mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+
+            val result = vaultLockManager.unlockVault(
+                accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                userId = USER_ID,
+                email = email,
+                kdf = kdf,
+                initUserCryptoMethod = initUserCryptoMethod,
+                organizationKeys = null,
+            )
+
+            assertEquals(VaultUnlockResult.Success, result)
+            fakeAuthDiskSource.assertUserState(userState = MOCK_USER_STATE)
+            verify(exactly = 0) {
+                passwordPolicyManager.validatePasswordAgainstPolicies(
+                    password = any(),
+                    isCreation = any(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `unlockVault with initUserCryptoMethod masterPasswordUnlock when the password fails policies should store the reason even when the unlock fails`() =
+        runTest {
+            val kdf = MOCK_PROFILE.toSdkParams()
+            val email = MOCK_PROFILE.email
+            val masterPassword = "mockValue"
+            val error = Throwable("Fail")
+            val initUserCryptoMethod = InitUserCryptoMethod.MasterPasswordUnlock(
+                password = masterPassword,
+                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+            )
+            every {
+                passwordPolicyManager.validatePasswordAgainstPolicies(
+                    password = masterPassword,
+                    isCreation = false,
+                )
+            } returns false
+            coEvery {
+                vaultSdkSource.initializeCrypto(
+                    userId = USER_ID,
+                    request = InitUserCryptoRequest(
+                        accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                        userId = USER_ID,
+                        kdfParams = kdf,
+                        email = email,
+                        method = initUserCryptoMethod,
+                        upgradeToken = null,
+                    ),
+                )
+            } returns InitializeCryptoResult.AuthenticationError(error = error).asSuccess()
+            mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+
+            val result = vaultLockManager.unlockVault(
+                accountCryptographicState = ACCOUNT_CRYPTOGRAPHIC_STATE,
+                userId = USER_ID,
+                email = email,
+                kdf = kdf,
+                initUserCryptoMethod = initUserCryptoMethod,
+                organizationKeys = null,
+            )
+
+            assertEquals(VaultUnlockResult.AuthenticationError(error = error), result)
+            fakeAuthDiskSource.assertUserState(
+                userState = MOCK_USER_STATE.updateForcePasswordReset(
+                    userId = USER_ID,
+                    reason = ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN,
+                ),
+            )
         }
 
     /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/InitUserCryptoMethodExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/InitUserCryptoMethodExtensionsTest.kt
@@ -1,0 +1,88 @@
+package com.x8bit.bitwarden.data.vault.repository.util
+
+import com.bitwarden.core.AuthRequestMethod
+import com.bitwarden.core.InitUserCryptoMethod
+import com.bitwarden.core.MasterPasswordUnlockData
+import com.bitwarden.crypto.Kdf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class InitUserCryptoMethodExtensionsTest {
+    @Test
+    fun `password returns the password for MasterPasswordUnlock`() {
+        assertEquals(
+            MASTER_PASSWORD,
+            MASTER_PASSWORD_UNLOCK_METHOD.password,
+        )
+    }
+
+    @Test
+    fun `password returns null for all non-MasterPasswordUnlock methods`() {
+        LOG_TAG_MAP
+            .keys
+            .filterNot { it is InitUserCryptoMethod.MasterPasswordUnlock }
+            .forEach { method -> assertNull(method.password) }
+    }
+
+    @Test
+    fun `logTag returns the correct label for each method`() {
+        LOG_TAG_MAP.forEach { (method, expectedLogTag) ->
+            assertEquals(expectedLogTag, method.logTag)
+        }
+    }
+}
+
+private const val MASTER_PASSWORD: String = "mockMasterPassword"
+
+/**
+ * Must be declared as the [InitUserCryptoMethod] supertype. Typed as the concrete
+ * `MasterPasswordUnlock` subclass, `password` would resolve to that data class's own member
+ * property instead of the extension under test.
+ */
+private val MASTER_PASSWORD_UNLOCK_METHOD: InitUserCryptoMethod =
+    InitUserCryptoMethod.MasterPasswordUnlock(
+        password = MASTER_PASSWORD,
+        masterPasswordUnlock = MasterPasswordUnlockData(
+            kdf = Kdf.Pbkdf2(iterations = 1u),
+            masterKeyWrappedUserKey = "mockMasterKeyWrappedUserKey",
+            salt = "mockSalt",
+        ),
+    )
+
+/**
+ * Every [InitUserCryptoMethod] subclass mapped to its expected log tag. Adding a subclass to the
+ * SDK breaks the `when` blocks in the production code; this map must be updated alongside them.
+ */
+private val LOG_TAG_MAP: Map<InitUserCryptoMethod, String> = mapOf(
+    MASTER_PASSWORD_UNLOCK_METHOD to "Master Password Unlock",
+    InitUserCryptoMethod.AuthRequest(
+        requestPrivateKey = "mockRequestPrivateKey",
+        method = AuthRequestMethod.UserKey(protectedUserKey = "mockProtectedUserKey"),
+    ) to "Auth Request",
+    InitUserCryptoMethod.DecryptedKey(
+        decryptedUserKey = "mockDecryptedUserKey",
+    ) to "Decrypted Key (Never Lock/Biometrics)",
+    InitUserCryptoMethod.DeviceKey(
+        deviceKey = "mockDeviceKey",
+        protectedDevicePrivateKey = "mockProtectedDevicePrivateKey",
+        deviceProtectedUserKey = "mockDeviceProtectedUserKey",
+    ) to "Device Key",
+    InitUserCryptoMethod.KeyConnector(
+        masterKey = "mockMasterKey",
+        userKey = "mockUserKey",
+    ) to "Key Connector",
+    InitUserCryptoMethod.KeyConnectorUrl(
+        url = "mockUrl",
+        keyConnectorKeyWrappedUserKey = "mockKeyConnectorKeyWrappedUserKey",
+    ) to "Key Connector Url",
+    InitUserCryptoMethod.Pin(
+        pin = "mockPin",
+        pinProtectedUserKey = "mockPinProtectedUserKey",
+    ) to "Pin",
+    InitUserCryptoMethod.PinEnvelope(
+        pin = "mockPin",
+        pinProtectedUserKeyEnvelope = "mockPinProtectedUserKeyEnvelope",
+    ) to "Pin Envelope",
+    InitUserCryptoMethod.PinState(pin = "mockPin") to "Pin State",
+)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40295](https://bitwarden.atlassian.net/browse/PM-40295)

## 📔 Objective

This PR moves all the MasterPassword Policy logic into a new class and adds the policy check on vault unlock as well as login.


[PM-40295]: https://bitwarden.atlassian.net/browse/PM-40295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ