### PR TITLE
[PM-40488] fix: clear clipboard setting does not clear the clipboard on Android 13+

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/ClearClipboardWorker.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/ClearClipboardWorker.kt
@@ -9,13 +9,11 @@ import android.os.Build
 import androidx.core.os.persistableBundleOf
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.core.util.isBuildVersionAtLeast
 
 /**
  * A worker to clear the clipboard manager.
  */
-@OmitFromCoverage
 class ClearClipboardWorker(
     appContext: Context,
     workerParams: WorkerParameters,
@@ -38,9 +36,7 @@ class ClearClipboardWorker(
                     )
                 },
         )
-        if (isBuildVersionAtLeast(version = Build.VERSION_CODES.P)) {
-            clipboardManager.clearPrimaryClip()
-        }
+        clipboardManager.clearPrimaryClip()
         return Result.success()
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/ClearClipboardWorker.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/ClearClipboardWorker.kt
@@ -1,11 +1,16 @@
 package com.x8bit.bitwarden.data.platform.manager.clipboard
 
+import android.content.ClipData
+import android.content.ClipDescription
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Context.CLIPBOARD_SERVICE
+import android.os.Build
+import androidx.core.os.persistableBundleOf
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.core.util.isBuildVersionAtLeast
 
 /**
  * A worker to clear the clipboard manager.
@@ -20,7 +25,22 @@ class ClearClipboardWorker(
         appContext.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
 
     override fun doWork(): Result {
-        clipboardManager.clearPrimaryClip()
+        clipboardManager.setPrimaryClip(
+            ClipData
+                .newPlainText("", "")
+                .apply {
+                    description.extras = persistableBundleOf(
+                        if (isBuildVersionAtLeast(version = Build.VERSION_CODES.TIRAMISU)) {
+                            ClipDescription.EXTRA_IS_SENSITIVE to true
+                        } else {
+                            "android.content.extra.IS_SENSITIVE" to true
+                        },
+                    )
+                },
+        )
+        if (isBuildVersionAtLeast(version = Build.VERSION_CODES.P)) {
+            clipboardManager.clearPrimaryClip()
+        }
         return Result.success()
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/ClearClipboardWorkerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/ClearClipboardWorkerTest.kt
@@ -1,0 +1,99 @@
+package com.x8bit.bitwarden.data.platform.manager.clipboard
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import androidx.work.ListenableWorker
+import com.bitwarden.ui.platform.base.BaseRobolectricTest
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+class ClearClipboardWorkerTest : BaseRobolectricTest() {
+
+    private lateinit var clipboardManager: ClipboardManager
+    private lateinit var worker: ClearClipboardWorker
+
+    @Before
+    fun setup() {
+        val context = RuntimeEnvironment.getApplication()
+        clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        worker = ClearClipboardWorker(
+            appContext = context,
+            workerParams = mockk(relaxed = true),
+        )
+    }
+
+    @Test
+    fun `doWork should clear a populated clipboard and return success`() {
+        clipboardManager.setPrimaryClip(ClipData.newPlainText("", "password"))
+
+        val result = worker.doWork()
+
+        assertTrue(clipboardManager.primaryClip?.getItemAt(0)?.text.isNullOrEmpty())
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun `doWork should return success when the clipboard is already empty`() {
+        clipboardManager.clearPrimaryClip()
+
+        val result = worker.doWork()
+
+        assertFalse(clipboardManager.hasPrimaryClip())
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `doWork should overwrite the clipboard with sensitive empty content before clearing`() {
+        val overwrittenClip = captureEmptyClipboardOverwrite()
+
+        assertTrue(
+            overwrittenClip
+                ?.description
+                ?.extras
+                ?.getBoolean(ClipDescription.EXTRA_IS_SENSITIVE) == true,
+        )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.S_V2])
+    @Test
+    fun `doWork should use the legacy sensitive extra before Android 13`() {
+        val overwrittenClip = captureEmptyClipboardOverwrite()
+
+        assertTrue(
+            overwrittenClip
+                ?.description
+                ?.extras
+                ?.getBoolean("android.content.extra.IS_SENSITIVE") == true,
+        )
+    }
+
+    private fun captureEmptyClipboardOverwrite(): ClipData? {
+        var overwrittenClip: ClipData? = null
+        val listener = ClipboardManager.OnPrimaryClipChangedListener {
+            val currentClip = clipboardManager.primaryClip
+            if (
+                overwrittenClip == null &&
+                currentClip?.getItemAt(0)?.text.isNullOrEmpty()
+            ) {
+                overwrittenClip = currentClip
+            }
+        }
+        clipboardManager.setPrimaryClip(ClipData.newPlainText("", "password"))
+        clipboardManager.addPrimaryClipChangedListener(listener)
+
+        worker.doWork()
+
+        clipboardManager.removePrimaryClipChangedListener(listener)
+        return overwrittenClip
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/ClearClipboardWorkerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/ClearClipboardWorkerTest.kt
@@ -3,33 +3,26 @@ package com.x8bit.bitwarden.data.platform.manager.clipboard
 import android.content.ClipData
 import android.content.ClipDescription
 import android.content.ClipboardManager
-import android.content.Context
 import android.os.Build
+import androidx.core.content.getSystemService
 import androidx.work.ListenableWorker
 import com.bitwarden.ui.platform.base.BaseRobolectricTest
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 class ClearClipboardWorkerTest : BaseRobolectricTest() {
 
-    private lateinit var clipboardManager: ClipboardManager
-    private lateinit var worker: ClearClipboardWorker
-
-    @Before
-    fun setup() {
-        val context = RuntimeEnvironment.getApplication()
-        clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        worker = ClearClipboardWorker(
-            appContext = context,
-            workerParams = mockk(relaxed = true),
-        )
-    }
+    private val context = RuntimeEnvironment.getApplication()
+    private val clipboardManager = requireNotNull(context.getSystemService<ClipboardManager>())
+    private val worker: ClearClipboardWorker = ClearClipboardWorker(
+        appContext = context,
+        workerParams = mockk(relaxed = true),
+    )
 
     @Test
     fun `doWork should clear a populated clipboard and return success`() {


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #7069

## 📔 Objective

The "clear clipboard" setting does not clear the clipboard on Android 13+. Setting a short interval (e.g. 10 seconds), copying a password, and waiting leaves the secret on the clipboard. Multiple users have confirmed this across recent devices (Samsung Galaxy S25+ on Android 16, Fairphone FP5 on Android 15, Samsung SM-A366B on Android 16) and app versions 2026.2.1 through 2026.6.x.

The clear is scheduled by `BitwardenClipboardManagerImpl.setText()` as a delayed `OneTimeWorkRequest` and executed by `ClearClipboardWorker.doWork()`, which relies solely on `clipboardManager.clearPrimaryClip()`. On newer Android versions `clearPrimaryClip()` can be a no-op, so the secret is never evicted.

This change makes `ClearClipboardWorker.doWork()` clear robustly: it first overwrites the primary clip with an empty, sensitive `ClipData` (marking `ClipDescription.EXTRA_IS_SENSITIVE` on API 33+, and the legacy `android.content.extra.IS_SENSITIVE` key below that, matching the pattern already used in `BitwardenClipboardManagerImpl.setText`), then calls `clearPrimaryClip()` (guarded to API 28+) to remove the placeholder entry on devices that honor it. Background clipboard restrictions on Android 10+ gate reads, not writes, so the background overwrite/clear remains permitted. The fix stays entirely within the existing worker, with no scheduling or DI changes.

A unit test (`ClearClipboardWorkerTest`) covers the Android 13+ path to prevent regression.

## 📸 Screenshots

Not applicable - this is a background-worker/behavioral fix with no UI surface.

---

AI was used for assistance.
