### PR TITLE
QA-2177: fix: Expose BlockedUriEntry testTag to accessibility tree

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/AddEditBlockedUriDialog.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/AddEditBlockedUriDialog.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -50,6 +52,7 @@ fun AddEditBlockedUriDialog(
         val scrollState = rememberScrollState()
         Column(
             modifier = Modifier
+                .semantics { testTagsAsResourceId = true }
                 .requiredHeightIn(
                     max = configuration.maxDialogHeight,
                 )


### PR DESCRIPTION
## 🎯 Objective

Make the `BlockedUriEntry` field in the "Add/Edit blocked URI" dialog discoverable by Appium/UIAutomator and any other `resource-id`-based test automation.

## 🔍 Root cause

`AddEditBlockedUriDialog` renders inside a raw Compose `Dialog`. A Compose `testTag` is only exported into the Android accessibility node tree as a `resource-id` when an ancestor node sets `Modifier.semantics { testTagsAsResourceId = true }`.

- `BitwardenScaffold` sets this flag for normal screen content, and every Bitwarden dialog wrapper (`BitwardenTwoButtonDialog`, `BitwardenBasicDialog`, etc.) sets it on its own root.
- A Compose `Dialog` is a **separate composition window**, so the scaffold's flag does not reach it — each dialog must enable the flag itself.
- `AddEditBlockedUriDialog` never did, so `textFieldTestTag = "BlockedUriEntry"` was visible to Compose UI tests (`onNodeWithTag`) but **never emitted as a `resource-id`**, making it invisible to Appium.

## 🛠️ Change

Added `Modifier.semantics { testTagsAsResourceId = true }` to the dialog's root `Column`, mirroring the established pattern in `BitwardenTwoButtonDialog`/`BitwardenScaffold`. No `@OptIn` needed (the API is stable in this Compose version, consistent with existing usages).

## ✅ Verification

- Change is a one-line addition + two imports that exactly mirror existing usages in the same repo.
- Diff reviewed manually: imports alphabetically ordered, no lines exceed the 100-char limit.
- Note: full Gradle build/detekt could not be executed in the sandboxed environment (no Maven network access → TLS/PKIX failures). After merge/CI, confirm the field appears with `resource-id` `BlockedUriEntry` in an Appium inspector session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
