### PR TITLE
[QA-2177] Enabling testTagsAsResourceId flag to make BlockedURI testTag visible…

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/AddEditBlockedUriDialog.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/AddEditBlockedUriDialog.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -50,6 +52,7 @@ fun AddEditBlockedUriDialog(
         val scrollState = rememberScrollState()
         Column(
             modifier = Modifier
+                .semantics { testTagsAsResourceId = true }
                 .requiredHeightIn(
                     max = configuration.maxDialogHeight,
                 )


### PR DESCRIPTION
… to our e2e tests

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/QA-2177

## 📔 Objective

We confirmed the `testTag` we added in https://github.com/bitwarden/android/pull/7149 was not being found by our e2e tests. This PR enables the `testTagAsResourceId` flag in `AddEditBlockedUriDialog.kt` to make it visible.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
