### PR TITLE
[PM-40631] feat: Display personal vault as "My vault" instead of email address

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
@@ -203,7 +203,7 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
             val collections = state.common.selectedOwner?.collections.orEmpty()
             item {
                 BitwardenTextSelectionButton(
-                    label = stringResource(id = BitwardenString.owner),
+                    label = stringResource(id = BitwardenString.vault),
                     selectedOption = state.common.selectedOwner?.name,
                     onClick = commonTypeHandlers.onPresentOwnerOptions,
                     cardStyle = if (collections.isNotEmpty()) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
@@ -204,7 +204,7 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
             item {
                 BitwardenTextSelectionButton(
                     label = stringResource(id = BitwardenString.vault),
-                    selectedOption = state.common.selectedOwner?.name,
+                    selectedOption = state.common.selectedOwner?.name?.invoke(),
                     onClick = commonTypeHandlers.onPresentOwnerOptions,
                     cardStyle = if (collections.isNotEmpty()) {
                         CardStyle.Middle()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -805,8 +805,8 @@ private fun OwnerSelectionBottomSheet(
     modifier: Modifier = Modifier,
 ) {
 
-    var selectedOwnerId by rememberSaveable {
-        mutableStateOf(state.selectedOwner?.id)
+    var selectedOwner by rememberSaveable {
+        mutableStateOf(state.selectedOwner)
     }
     BitwardenModalBottomSheet(
         sheetTitle = stringResource(BitwardenString.select_vault),
@@ -816,17 +816,10 @@ private fun OwnerSelectionBottomSheet(
                 label = stringResource(BitwardenString.save),
                 onClick = {
                     handlers.onDismissBottomSheet()
-                    state
-                        .availableOwners
-                        .firstOrNull {
-                            it.id == selectedOwnerId
-                        }
-                        ?.run {
-                            handlers.onOwnerSelected(this.id)
-                        }
+                    selectedOwner?.let { handlers.onOwnerSelected(it.id) }
                     animatedOnDismiss()
                 },
-                isEnabled = state.availableOwners.any { it.id == selectedOwnerId },
+                isEnabled = selectedOwner != null,
             )
         },
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -834,9 +827,9 @@ private fun OwnerSelectionBottomSheet(
     ) {
         OwnerSelectionBottomSheetContent(
             options = state.availableOwners.toImmutableList(),
-            selectedOwnerId = selectedOwnerId,
+            selectedOwner = selectedOwner,
             onOptionSelected = {
-                selectedOwnerId = it
+                selectedOwner = it
             },
         )
     }
@@ -845,8 +838,8 @@ private fun OwnerSelectionBottomSheet(
 @Composable
 private fun OwnerSelectionBottomSheetContent(
     options: ImmutableList<VaultAddEditState.Owner>,
-    selectedOwnerId: String?,
-    onOptionSelected: (String?) -> Unit,
+    selectedOwner: VaultAddEditState.Owner?,
+    onOptionSelected: (VaultAddEditState.Owner) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -863,7 +856,7 @@ private fun OwnerSelectionBottomSheetContent(
                     .cardStyle(
                         cardStyle = options.toListItemCardStyle(index = index),
                         onClick = {
-                            onOptionSelected(option.id)
+                            onOptionSelected(option)
                         },
                     ),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -878,9 +871,9 @@ private fun OwnerSelectionBottomSheetContent(
                         .padding(horizontal = 16.dp),
                 )
                 BitwardenRadioButton(
-                    isSelected = selectedOwnerId == option.id,
+                    isSelected = selectedOwner == option,
                     onClick = {
-                        onOptionSelected(option.id)
+                        onOptionSelected(option)
                     },
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -809,7 +809,7 @@ private fun OwnerSelectionBottomSheet(
         mutableStateOf(state.selectedOwner?.name.orEmpty())
     }
     BitwardenModalBottomSheet(
-        sheetTitle = stringResource(BitwardenString.owner),
+        sheetTitle = stringResource(BitwardenString.select_vault),
         onDismiss = handlers.onDismissBottomSheet,
         topBarActions = { animatedOnDismiss ->
             BitwardenTextButton(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -805,8 +805,8 @@ private fun OwnerSelectionBottomSheet(
     modifier: Modifier = Modifier,
 ) {
 
-    var selectedOptionState by rememberSaveable {
-        mutableStateOf(state.selectedOwner?.name.orEmpty())
+    var selectedOwnerId by rememberSaveable {
+        mutableStateOf(state.selectedOwner?.id)
     }
     BitwardenModalBottomSheet(
         sheetTitle = stringResource(BitwardenString.select_vault),
@@ -819,24 +819,24 @@ private fun OwnerSelectionBottomSheet(
                     state
                         .availableOwners
                         .firstOrNull {
-                            it.name == selectedOptionState
+                            it.id == selectedOwnerId
                         }
                         ?.run {
                             handlers.onOwnerSelected(this.id)
                         }
                     animatedOnDismiss()
                 },
-                isEnabled = selectedOptionState.isNotBlank(),
+                isEnabled = state.availableOwners.any { it.id == selectedOwnerId },
             )
         },
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         modifier = modifier.statusBarsPadding(),
     ) {
         OwnerSelectionBottomSheetContent(
-            options = state.availableOwners.map { it.name }.toImmutableList(),
-            selectedOption = selectedOptionState,
+            options = state.availableOwners.toImmutableList(),
+            selectedOwnerId = selectedOwnerId,
             onOptionSelected = {
-                selectedOptionState = it
+                selectedOwnerId = it
             },
         )
     }
@@ -844,9 +844,9 @@ private fun OwnerSelectionBottomSheet(
 
 @Composable
 private fun OwnerSelectionBottomSheetContent(
-    options: ImmutableList<String>,
-    selectedOption: String,
-    onOptionSelected: (String) -> Unit,
+    options: ImmutableList<VaultAddEditState.Owner>,
+    selectedOwnerId: String?,
+    onOptionSelected: (String?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -863,14 +863,14 @@ private fun OwnerSelectionBottomSheetContent(
                     .cardStyle(
                         cardStyle = options.toListItemCardStyle(index = index),
                         onClick = {
-                            onOptionSelected(option)
+                            onOptionSelected(option.id)
                         },
                     ),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = option,
+                    text = option.name,
                     color = BitwardenTheme.colorScheme.text.primary,
                     style = BitwardenTheme.typography.bodyLarge,
                     modifier = Modifier
@@ -878,9 +878,9 @@ private fun OwnerSelectionBottomSheetContent(
                         .padding(horizontal = 16.dp),
                 )
                 BitwardenRadioButton(
-                    isSelected = selectedOption == option,
+                    isSelected = selectedOwnerId == option.id,
                     onClick = {
-                        onOptionSelected(option)
+                        onOptionSelected(option.id)
                     },
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -826,7 +826,7 @@ private fun OwnerSelectionBottomSheet(
         modifier = modifier.statusBarsPadding(),
     ) {
         OwnerSelectionBottomSheetContent(
-            options = state.availableOwners.toImmutableList(),
+            options = state.availableOwners,
             selectedOwner = selectedOwner,
             onOptionSelected = {
                 selectedOwner = it
@@ -863,7 +863,7 @@ private fun OwnerSelectionBottomSheetContent(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = option.name,
+                    text = option.name(),
                     color = BitwardenTheme.colorScheme.text.primary,
                     style = BitwardenTheme.typography.bodyLarge,
                     modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -97,6 +97,7 @@ import com.x8bit.bitwarden.ui.vault.util.detectCardBrand
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -2669,7 +2670,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun List<VaultAddEditState.Owner>.toUpdatedOwners(
         selectedOwnerId: String?,
         selectedCollectionId: String,
-    ): List<VaultAddEditState.Owner> =
+    ): ImmutableList<VaultAddEditState.Owner> =
         map { owner ->
             if (owner.id != selectedOwnerId) return@map owner
             owner.copy(
@@ -2678,6 +2679,7 @@ class VaultAddEditViewModel @Inject constructor(
                     .toUpdatedCollections(selectedCollectionId = selectedCollectionId),
             )
         }
+            .toImmutableList()
 
     private fun List<VaultCollection>.toUpdatedCollections(
         selectedCollectionId: String,
@@ -2929,7 +2931,7 @@ data class VaultAddEditState(
                 val selectedFolderId: String? = null,
                 val availableFolders: List<Folder> = emptyList(),
                 val selectedOwnerId: String? = null,
-                val availableOwners: List<Owner> = emptyList(),
+                val availableOwners: ImmutableList<Owner> = persistentListOf(),
                 val hasOrganizations: Boolean = false,
                 val canDelete: Boolean = true,
                 val canAssignToCollections: Boolean = true,
@@ -3315,7 +3317,7 @@ data class VaultAddEditState(
     @Parcelize
     data class Owner(
         val id: String?,
-        val name: String,
+        val name: Text,
         val collections: List<VaultCollection>,
     ) : Parcelable
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
@@ -5,6 +5,7 @@ package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 import com.bitwarden.collections.CollectionType
 import com.bitwarden.collections.CollectionView
 import com.bitwarden.core.data.util.toFormattedDateTimeStyle
+import com.bitwarden.core.util.persistentListOfNotNull
 import com.bitwarden.ui.platform.model.TotpData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
@@ -35,7 +36,6 @@ import java.time.format.FormatStyle
 import java.util.UUID
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 
 /**
  * Transforms [CipherView] into [VaultAddEditState.ViewState].
@@ -306,7 +306,7 @@ private fun UserState.Account.toAvailableOwners(
     isIndividualVaultDisabled: Boolean,
     selectedCollectionId: String? = null,
 ): ImmutableList<VaultAddEditState.Owner> =
-    listOfNotNull(
+    persistentListOfNotNull(
         VaultAddEditState
             .Owner(
                 name = BitwardenString.my_vault.asText(),
@@ -341,7 +341,6 @@ private fun UserState.Account.toAvailableOwners(
             }
             .toTypedArray(),
     )
-        .toImmutableList()
 
 private fun FieldView.toCustomField() =
     when (this.type) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
@@ -214,6 +214,7 @@ fun VaultAddEditState.ViewState.appendFolderAndOwnerData(
                     collectionViewList = collectionViewList,
                     cipherView = currentContentState.common.originalCipher,
                     isIndividualVaultDisabled = isIndividualVaultDisabled,
+                    resourceManager = resourceManager,
                     selectedCollectionId = currentContentState.common.selectedCollectionId
                         ?: collectionViewList
                             .getDefaultCollectionViewOrNull(
@@ -301,12 +302,13 @@ private fun UserState.Account.toAvailableOwners(
     collectionViewList: List<CollectionView>,
     cipherView: CipherView?,
     isIndividualVaultDisabled: Boolean,
+    resourceManager: ResourceManager,
     selectedCollectionId: String? = null,
 ): List<VaultAddEditState.Owner> =
     listOfNotNull(
         VaultAddEditState
             .Owner(
-                name = email,
+                name = resourceManager.getString(BitwardenString.my_vault),
                 id = null,
                 collections = emptyList(),
             )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
@@ -33,6 +33,9 @@ import java.time.LocalDate
 import java.time.format.DateTimeParseException
 import java.time.format.FormatStyle
 import java.util.UUID
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 /**
  * Transforms [CipherView] into [VaultAddEditState.ViewState].
@@ -156,7 +159,7 @@ fun CipherView.toViewState(
             favorite = this.favorite,
             masterPasswordReprompt = this.reprompt == CipherRepromptType.PASSWORD,
             notes = this.notes.orEmpty(),
-            availableOwners = emptyList(),
+            availableOwners = persistentListOf(),
             hasOrganizations = false,
             customFieldData = this.fields.orEmpty().map { it.toCustomField() },
             canDelete = canDelete,
@@ -214,7 +217,6 @@ fun VaultAddEditState.ViewState.appendFolderAndOwnerData(
                     collectionViewList = collectionViewList,
                     cipherView = currentContentState.common.originalCipher,
                     isIndividualVaultDisabled = isIndividualVaultDisabled,
-                    resourceManager = resourceManager,
                     selectedCollectionId = currentContentState.common.selectedCollectionId
                         ?: collectionViewList
                             .getDefaultCollectionViewOrNull(
@@ -302,13 +304,12 @@ private fun UserState.Account.toAvailableOwners(
     collectionViewList: List<CollectionView>,
     cipherView: CipherView?,
     isIndividualVaultDisabled: Boolean,
-    resourceManager: ResourceManager,
     selectedCollectionId: String? = null,
-): List<VaultAddEditState.Owner> =
+): ImmutableList<VaultAddEditState.Owner> =
     listOfNotNull(
         VaultAddEditState
             .Owner(
-                name = resourceManager.getString(BitwardenString.my_vault),
+                name = BitwardenString.my_vault.asText(),
                 id = null,
                 collections = emptyList(),
             )
@@ -316,7 +317,7 @@ private fun UserState.Account.toAvailableOwners(
         *organizations
             .map {
                 VaultAddEditState.Owner(
-                    name = it.name,
+                    name = it.name.asText(),
                     id = it.id,
                     collections = collectionViewList
                         .filter { collection ->
@@ -340,6 +341,7 @@ private fun UserState.Account.toAvailableOwners(
             }
             .toTypedArray(),
     )
+        .toImmutableList()
 
 private fun FieldView.toCustomField() =
     when (this.type) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -3354,7 +3354,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         // Opens the menu
         composeTestRule
             .onNodeWithContentDescriptionAfterScroll(
-                label = "placeholder@email.com. Owner",
+                label = "My vault. Vault",
             )
             .performClick()
 
@@ -3372,7 +3372,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithText("Owner")
+            .onNodeWithText("Select vault")
             .assertIsDisplayed()
     }
 
@@ -3383,7 +3383,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithText("Owner")
+            .onNodeWithText("Select vault")
             .assertIsDisplayed()
 
         composeTestRule
@@ -3438,7 +3438,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         updateStateWithOwners()
         composeTestRule
             .onNodeWithContentDescriptionAfterScroll(
-                label = "placeholder@email.com. Owner",
+                label = "My vault. Vault",
             )
             .assertIsDisplayed()
 
@@ -3447,7 +3447,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "mockOwnerName-2. Owner")
+            .onNodeWithContentDescriptionAfterScroll(label = "mockOwnerName-2. Vault")
             .assertIsDisplayed()
     }
 
@@ -3486,7 +3486,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             availableOwners = listOf(
                 VaultAddEditState.Owner(
                     id = null,
-                    name = "placeholder@email.com",
+                    name = "My vault",
                     collections = DEFAULT_COLLECTIONS,
                 ),
             ),
@@ -3876,7 +3876,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
         composeTestRule
             .onNodeWithContentDescriptionAfterScroll(
-                label = "placeholder@email.com. Owner",
+                label = "My vault. Vault",
             )
             .assertIsDisplayed()
 
@@ -3886,7 +3886,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
         composeTestRule
             .onNodeWithContentDescriptionAfterScroll(
-                label = "mockOwnerName-2. Owner",
+                label = "mockOwnerName-2. Vault",
             )
             .assertIsDisplayed()
     }
@@ -5564,7 +5564,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         private val ALTERED_OWNERS = listOf(
             VaultAddEditState.Owner(
                 id = null,
-                name = "placeholder@email.com",
+                name = "My vault",
                 collections = emptyList(),
             ),
             VaultAddEditState.Owner(
@@ -5591,7 +5591,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         private val DEFAULT_OWNERS = listOf(
             VaultAddEditState.Owner(
                 id = null,
-                name = "placeholder@email.com",
+                name = "My vault",
                 collections = emptyList(),
             ),
             VaultAddEditState.Owner(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -46,6 +46,7 @@ import com.bitwarden.core.data.util.advanceTimeByAndRunCurrent
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.manager.exit.ExitManager
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.assertNoDialogExists
 import com.bitwarden.ui.util.assertScrollableNodeDoesNotExist
@@ -80,6 +81,9 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
@@ -3409,10 +3413,11 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
                     availableOwners = listOf(
                         VaultAddEditState.Owner(
                             id = ownerId,
-                            name = ownerName,
+                            name = ownerName.asText(),
                             collections = DEFAULT_COLLECTIONS,
                         ),
-                    ),
+                    )
+                        .toImmutableList(),
                 )
             }
                 .copy(bottomSheetState = VaultAddEditState.BottomSheetState.OwnerSelection)
@@ -3486,10 +3491,11 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             availableOwners = listOf(
                 VaultAddEditState.Owner(
                     id = null,
-                    name = "My vault",
+                    name = BitwardenString.my_vault.asText(),
                     collections = DEFAULT_COLLECTIONS,
                 ),
-            ),
+            )
+                .toImmutableList(),
             hasOrganizations = false,
         )
 
@@ -5130,7 +5136,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
     private fun updateStateWithOwners(
         selectedOwnerId: String? = null,
-        availableOwners: List<VaultAddEditState.Owner> = DEFAULT_OWNERS,
+        availableOwners: ImmutableList<VaultAddEditState.Owner> = DEFAULT_OWNERS,
         hasOrganizations: Boolean = true,
     ) {
         mutableStateFlow.update { currentState ->
@@ -5561,20 +5567,20 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             ),
         )
 
-        private val ALTERED_OWNERS = listOf(
+        private val ALTERED_OWNERS = persistentListOf(
             VaultAddEditState.Owner(
                 id = null,
-                name = "My vault",
+                name = BitwardenString.my_vault.asText(),
                 collections = emptyList(),
             ),
             VaultAddEditState.Owner(
                 id = "mockOwnerId-1",
-                name = "mockOwnerName-1",
+                name = "mockOwnerName-1".asText(),
                 collections = emptyList(),
             ),
             VaultAddEditState.Owner(
                 id = "mockOwnerId-2",
-                name = "mockOwnerName-2",
+                name = "mockOwnerName-2".asText(),
                 collections = ALTERED_COLLECTIONS,
             ),
         )
@@ -5588,20 +5594,20 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             ),
         )
 
-        private val DEFAULT_OWNERS = listOf(
+        private val DEFAULT_OWNERS = persistentListOf(
             VaultAddEditState.Owner(
                 id = null,
-                name = "My vault",
+                name = BitwardenString.my_vault.asText(),
                 collections = emptyList(),
             ),
             VaultAddEditState.Owner(
                 id = "mockOwnerId-1",
-                name = "mockOwnerName-1",
+                name = "mockOwnerName-1".asText(),
                 collections = emptyList(),
             ),
             VaultAddEditState.Owner(
                 id = "mockOwnerId-2",
-                name = "mockOwnerName-2",
+                name = "mockOwnerName-2".asText(),
                 collections = DEFAULT_COLLECTIONS,
             ),
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -170,6 +170,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     )
     private val resourceManager: ResourceManager = mockk {
         every { getString(BitwardenString.folder_none) } returns "No Folder"
+        every { getString(BitwardenString.my_vault) } returns "My vault"
     }
     private val clipboardManager: BitwardenClipboardManager = mockk {
         every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
@@ -6519,7 +6520,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         listOf(
             VaultAddEditState.Owner(
                 id = null,
-                name = "activeEmail",
+                name = "My vault",
                 collections = emptyList(),
             ),
             VaultAddEditState.Owner(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -114,6 +114,7 @@ import io.mockk.runs
 import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -170,7 +171,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     )
     private val resourceManager: ResourceManager = mockk {
         every { getString(BitwardenString.folder_none) } returns "No Folder"
-        every { getString(BitwardenString.my_vault) } returns "My vault"
     }
     private val clipboardManager: BitwardenClipboardManager = mockk {
         every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
@@ -361,7 +361,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                         availableOwners = listOf(
                             VaultAddEditState.Owner(
                                 id = "organizationId",
-                                name = "organizationName",
+                                name = "organizationName".asText(),
                                 collections = emptyList(),
                             ),
                         ),
@@ -5282,7 +5282,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                             availableOwners = listOf(
                                 VaultAddEditState.Owner(
                                     id = "organizationId",
-                                    name = "organizationName",
+                                    name = "organizationName".asText(),
                                     collections = emptyList(),
                                 ),
                             ),
@@ -6388,7 +6388,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             selectedOwnerId = selectedOwnerId,
             originalCipher = originalCipher,
             availableFolders = availableFolders,
-            availableOwners = availableOwners,
+            availableOwners = availableOwners.toImmutableList(),
             hasOrganizations = hasOrganizations,
             canDelete = canDelete,
             canAssignToCollections = canAssociateToCollections,
@@ -6520,12 +6520,12 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         listOf(
             VaultAddEditState.Owner(
                 id = null,
-                name = "My vault",
+                name = BitwardenString.my_vault.asText(),
                 collections = emptyList(),
             ),
             VaultAddEditState.Owner(
                 id = "organizationId",
-                name = "organizationName",
+                name = "organizationName".asText(),
                 collections = if (hasCollection) {
                     listOf(
                         VaultCollection(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
@@ -39,6 +39,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -55,7 +57,6 @@ class CipherViewExtensionsTest {
     private val resourceManager: ResourceManager = mockk {
         every { getString(BitwardenString.clone) } returns "Clone"
         every { getString(BitwardenString.folder_none) } returns "No Folder"
-        every { getString(BitwardenString.my_vault) } returns "My vault"
     }
 
     @BeforeEach
@@ -103,7 +104,7 @@ class CipherViewExtensionsTest {
                         ),
                     ),
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                 ),
                 isIndividualVaultDisabled = false,
                 type = VaultAddEditState.ViewState.Content.ItemType.Card(
@@ -152,7 +153,7 @@ class CipherViewExtensionsTest {
                         ),
                     ),
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                 ),
                 isIndividualVaultDisabled = true,
                 type = VaultAddEditState.ViewState.Content.ItemType.Identity(
@@ -197,7 +198,7 @@ class CipherViewExtensionsTest {
                     masterPasswordReprompt = true,
                     notes = "Lots of notes",
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                     customFieldData = listOf(
                         VaultAddEditState.Custom.BooleanField(TEST_ID, "TestBoolean", false),
                         VaultAddEditState.Custom.TextField(TEST_ID, "TestText", "TestText"),
@@ -259,7 +260,7 @@ class CipherViewExtensionsTest {
                     masterPasswordReprompt = true,
                     notes = "Lots of notes",
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                     customFieldData = listOf(
                         VaultAddEditState.Custom.BooleanField(TEST_ID, "TestBoolean", false),
                         VaultAddEditState.Custom.TextField(TEST_ID, "TestText", "TestText"),
@@ -323,7 +324,7 @@ class CipherViewExtensionsTest {
                         VaultAddEditState.Custom.HiddenField(TEST_ID, "TestHidden", "TestHidden"),
                     ),
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                 ),
                 isIndividualVaultDisabled = true,
                 type = VaultAddEditState.ViewState.Content.ItemType.SecureNotes,
@@ -366,7 +367,7 @@ class CipherViewExtensionsTest {
                         ),
                     ),
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                 ),
                 isIndividualVaultDisabled = false,
                 type = VaultAddEditState.ViewState.Content.ItemType.SshKey(
@@ -408,7 +409,7 @@ class CipherViewExtensionsTest {
                         VaultAddEditState.Custom.HiddenField(TEST_ID, "TestHidden", "TestHidden"),
                     ),
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                 ),
                 isIndividualVaultDisabled = false,
                 type = VaultAddEditState.ViewState.Content.ItemType.Passport(
@@ -460,7 +461,7 @@ class CipherViewExtensionsTest {
                         VaultAddEditState.Custom.HiddenField(TEST_ID, "TestHidden", "TestHidden"),
                     ),
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                 ),
                 isIndividualVaultDisabled = false,
                 type = VaultAddEditState.ViewState.Content.ItemType.SecureNotes,
@@ -498,7 +499,7 @@ class CipherViewExtensionsTest {
                         VaultAddEditState.Custom.HiddenField(TEST_ID, "TestHidden", "TestHidden"),
                     ),
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                     archiveCalloutText = BitwardenString.this_item_is_archived.asText(),
                 ),
                 isIndividualVaultDisabled = false,
@@ -540,7 +541,7 @@ class CipherViewExtensionsTest {
                         VaultAddEditState.Custom.HiddenField(TEST_ID, "TestHidden", "TestHidden"),
                     ),
                     availableFolders = emptyList(),
-                    availableOwners = emptyList(),
+                    availableOwners = persistentListOf(),
                     archiveCalloutText = BitwardenString
                         .this_item_is_archived_saving_changes_will_restore_it_to_your_vault
                         .asText(),
@@ -717,14 +718,14 @@ class CipherViewExtensionsTest {
                     ),
                 ),
                 availableFolders = emptyList(),
-                availableOwners = emptyList(),
+                availableOwners = persistentListOf(),
             )
                 .let {
                     if (availableOwners.isNotEmpty()) {
                         it.copy(
                             selectedOwnerId = selectedOwnerId,
                             hasOrganizations = true,
-                            availableOwners = availableOwners,
+                            availableOwners = availableOwners.toImmutableList(),
                         )
                     } else {
                         it
@@ -985,7 +986,7 @@ private val MOCK_FOLDER_ITEM = VaultAddEditState.Folder(
 )
 private val ORGANIZATION_OWNER = VaultAddEditState.Owner(
     id = "mockOrganizationId-1",
-    name = "organizationName",
+    name = "organizationName".asText(),
     collections = listOf(
         VaultCollection(
             id = "mockId-1",
@@ -998,7 +999,7 @@ private val ORGANIZATION_OWNER = VaultAddEditState.Owner(
 
 private val ORGANIZATION_OWNER_DEFAULT_COLLECTION = VaultAddEditState.Owner(
     id = "mockOrganizationId-1",
-    name = "organizationName",
+    name = "organizationName".asText(),
     collections = listOf(
         VaultCollection(
             id = "mockId-1",
@@ -1010,6 +1011,6 @@ private val ORGANIZATION_OWNER_DEFAULT_COLLECTION = VaultAddEditState.Owner(
 )
 private val USER_OWNER = VaultAddEditState.Owner(
     id = null,
-    name = "My vault",
+    name = BitwardenString.my_vault.asText(),
     collections = emptyList(),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
@@ -55,6 +55,7 @@ class CipherViewExtensionsTest {
     private val resourceManager: ResourceManager = mockk {
         every { getString(BitwardenString.clone) } returns "Clone"
         every { getString(BitwardenString.folder_none) } returns "No Folder"
+        every { getString(BitwardenString.my_vault) } returns "My vault"
     }
 
     @BeforeEach
@@ -1009,6 +1010,6 @@ private val ORGANIZATION_OWNER_DEFAULT_COLLECTION = VaultAddEditState.Owner(
 )
 private val USER_OWNER = VaultAddEditState.Owner(
     id = null,
-    name = "activeEmail",
+    name = "My vault",
     collections = emptyList(),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
@@ -15,6 +15,7 @@ import com.bitwarden.vault.PasswordHistoryView
 import com.bitwarden.vault.SecureNoteType
 import com.bitwarden.vault.SecureNoteView
 import com.bitwarden.vault.SshKeyView
+import com.bitwarden.ui.util.asText
 import com.bitwarden.vault.UriMatchType
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFido2CredentialList
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
@@ -24,13 +25,14 @@ import com.x8bit.bitwarden.ui.vault.model.VaultCardExpirationMonth
 import com.x8bit.bitwarden.ui.vault.model.VaultCollection
 import com.x8bit.bitwarden.ui.vault.model.VaultIdentityTitle
 import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 @Suppress("LargeClass")
 class VaultAddItemStateExtensionsTest {
@@ -1151,10 +1153,10 @@ class VaultAddItemStateExtensionsTest {
             common = VaultAddEditState.ViewState.Content.Common(
                 name = "mockName-1",
                 selectedOwnerId = "mockOwnerId-1",
-                availableOwners = listOf(
+                availableOwners = persistentListOf(
                     VaultAddEditState.Owner(
                         id = "mockOwnerId-1",
-                        name = "Mock Organization",
+                        name = "Mock Organization".asText(),
                         collections = listOf(
                             VaultCollection(
                                 id = "collection-1",
@@ -1243,10 +1245,10 @@ class VaultAddItemStateExtensionsTest {
                 originalCipher = cipherView,
                 name = "mockName-1",
                 selectedOwnerId = "mockOwnerId-1",
-                availableOwners = listOf(
+                availableOwners = persistentListOf(
                     VaultAddEditState.Owner(
                         id = "mockOwnerId-1",
-                        name = "Mock Organization",
+                        name = "Mock Organization".asText(),
                         collections = listOf(
                             VaultCollection(
                                 id = "collection-1",

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -687,6 +687,7 @@ Do you want to switch to this account?</string>
     <string name="logging_in_on">Logging in on</string>
     <string name="logging_in_on_with_colon">Logging in on:</string>
     <string name="vault">Vault</string>
+    <string name="select_vault">Select vault</string>
     <string name="appearance">Appearance</string>
     <string name="account_security">Account security</string>
     <string name="bitwarden_help_center">Bitwarden help center</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40631](https://bitwarden.atlassian.net/browse/PM-40631)
[PM-40633](https://bitwarden.atlassian.net/browse/PM-40633)

## 📔 Objective

In the Add/Edit Item flow, renames the "Owner" field to "Vault" and its selection sheet title from "Owner" to "Select vault". The personal-vault option in that picker now reads "My vault" instead of the user's email address, resolved via `ResourceManager` (mirroring the existing `toAvailableFolders` pattern) rather than hardcoded. Applies uniformly across all item types since the field lives in the shared `Common` section of `VaultAddEditItemContent`.

Existing `owner` string entries are left in place (unreferenced) rather than edited/removed, per team convention of not mutating shared string values in place.

## 📸 Screenshots
"Vault" field reading "My vault" on the Add Login screen
<img width="300" alt="01-add-login-vault-field" src="https://github.com/user-attachments/assets/14e296f6-0ba1-44af-b7d8-a3a05415df33" />

"Select vault" bottom sheet listing "My vault" + orgs
<img width="300"  alt="02-select-vault-sheet" src="https://github.com/user-attachments/assets/4c4478b8-ceee-4dfc-98b2-4651b37ef4d4" />

Same field on the Add Card screen, confirming shared behavior across item types
<img width="300" alt="03-add-card-vault-field-cross-type" src="https://github.com/user-attachments/assets/79c478c4-3720-4f1f-b0ba-60017ae1e231" />


[PM-40631]: https://bitwarden.atlassian.net/browse/PM-40631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-40633]: https://bitwarden.atlassian.net/browse/PM-40633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ