### PR TITLE
PM-40657: feat: Add support for disableUserRegistration boolean

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
@@ -4,6 +4,8 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.manager.model.FlagKey
+import com.bitwarden.data.datasource.disk.model.ServerConfig
+import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
@@ -37,12 +39,13 @@ private const val KEY_STATE = "state"
 /**
  * Manages application state for the initial landing screen.
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class LandingViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val vaultRepository: VaultRepository,
     private val environmentRepository: EnvironmentRepository,
+    serverConfigRepository: ServerConfigRepository,
     snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     savedStateHandle: SavedStateHandle,
     featureFlagManager: FeatureFlagManager,
@@ -62,6 +65,12 @@ class LandingViewModel @Inject constructor(
                 .orEmpty()
                 .toImmutableList(),
             isFedRampEnabled = featureFlagManager.getFeatureFlag(FlagKey.FedRamp),
+            disableCreateAccount = serverConfigRepository
+                .serverConfigStateFlow
+                .value
+                ?.serverData
+                ?.settings
+                ?.disableUserRegistration == true,
         ),
 ) {
 
@@ -118,6 +127,12 @@ class LandingViewModel @Inject constructor(
             .map { LandingAction.Internal.FedRampFeatureUpdated(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
+
+        serverConfigRepository
+            .serverConfigStateFlow
+            .map { LandingAction.Internal.ServerConfigReceived(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
     }
 
     override fun handleAction(action: LandingAction) {
@@ -149,6 +164,7 @@ class LandingViewModel @Inject constructor(
 
             is LandingAction.Internal.SnackbarDataReceived -> handleSnackbarDataReceived(action)
             is LandingAction.Internal.FedRampFeatureUpdated -> handleFedRampFeatureUpdated(action)
+            is LandingAction.Internal.ServerConfigReceived -> handleServerConfigReceived(action)
         }
     }
 
@@ -276,6 +292,18 @@ class LandingViewModel @Inject constructor(
         mutableStateFlow.update { it.copy(isFedRampEnabled = action.isEnabled) }
     }
 
+    private fun handleServerConfigReceived(action: LandingAction.Internal.ServerConfigReceived) {
+        mutableStateFlow.update {
+            it.copy(
+                disableCreateAccount = action
+                    .serverConfig
+                    ?.serverData
+                    ?.settings
+                    ?.disableUserRegistration == true,
+            )
+        }
+    }
+
     /**
      * If the user state account is changed to an active but not "logged in" account we can
      * pre-populate the email field with this account.
@@ -303,6 +331,7 @@ data class LandingState(
     val dialog: DialogState?,
     val accountSummaries: ImmutableList<AccountSummary>,
     val isFedRampEnabled: Boolean,
+    val disableCreateAccount: Boolean,
 ) : Parcelable {
     /**
      * The selectable environments.
@@ -317,7 +346,7 @@ data class LandingState(
      * Determines if the user should be allowed to create a new account.
      */
     val allowCreateAccount: Boolean
-        get() = selectedEnvironmentType != Environment.Type.FED_RAMP
+        get() = !disableCreateAccount && selectedEnvironmentType != Environment.Type.FED_RAMP
 
     /**
      * Determines whether the app bar should be visible based on the presence of account summaries.
@@ -481,6 +510,13 @@ sealed class LandingAction {
          * Internal action to update the email input state from a non-user action
          */
         data class UpdateEmailState(val emailInput: String) : Internal()
+
+        /**
+         * Indicates that an updated [serverConfig] has been received.
+         */
+        data class ServerConfigReceived(
+            val serverConfig: ServerConfig?,
+        ) : Internal()
 
         /**
          * Indicates that FedRamp feature has been enabled or disabled.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
@@ -3,6 +3,8 @@ package com.x8bit.bitwarden.ui.auth.feature.startregistration
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.data.datasource.disk.model.ServerConfig
+import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
@@ -38,6 +40,7 @@ private const val KEY_STATE = "state"
 class StartRegistrationViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
+    serverConfigRepository: ServerConfigRepository,
     private val authRepository: AuthRepository,
     private val environmentRepository: EnvironmentRepository,
 ) : BaseViewModel<StartRegistrationState, StartRegistrationEvent, StartRegistrationAction>(
@@ -69,6 +72,11 @@ class StartRegistrationViewModel @Inject constructor(
         snackbarRelayManager
             .getSnackbarDataFlow(SnackbarRelay.ENVIRONMENT_SAVED)
             .map { StartRegistrationAction.Internal.SnackbarDataReceived(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+        serverConfigRepository
+            .serverConfigStateFlow
+            .map { StartRegistrationAction.Internal.ServerConfigReceived(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
     }
@@ -108,6 +116,10 @@ class StartRegistrationViewModel @Inject constructor(
 
             is StartRegistrationAction.Internal.UpdatedEnvironmentReceive -> {
                 handleUpdatedEnvironmentReceive(action)
+            }
+
+            is StartRegistrationAction.Internal.ServerConfigReceived -> {
+                handleServerConfigReceived(action)
             }
         }
     }
@@ -150,6 +162,25 @@ class StartRegistrationViewModel @Inject constructor(
             it.copy(
                 selectedEnvironmentType = action.environment.type,
             )
+        }
+    }
+
+    private fun handleServerConfigReceived(
+        action: StartRegistrationAction.Internal.ServerConfigReceived,
+    ) {
+        val serverData = action.serverConfig?.serverData ?: return
+        if (serverData.settings?.disableUserRegistration == true) {
+            // Show the dialog informing the user that they cannot create an account.
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = StartRegistrationDialog.Error(
+                        title = BitwardenString.account_creation_restricted.asText(),
+                        message = BitwardenString
+                            .only_allows_invited_users_to_create_accounts
+                            .asText(serverData.environment?.vaultUrl.orEmpty()),
+                    ),
+                )
+            }
         }
     }
 
@@ -470,6 +501,13 @@ sealed class StartRegistrationAction {
          */
         data class UpdatedEnvironmentReceive(
             val environment: Environment,
+        ) : Internal()
+
+        /**
+         * Indicates that an updated [serverConfig] has been received.
+         */
+        data class ServerConfigReceived(
+            val serverConfig: ServerConfig?,
         ) : Internal()
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.auth.feature.welcome
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -153,14 +154,19 @@ private fun WelcomeScreenContent(
                 .height(44.dp),
         )
 
-        BitwardenFilledButton(
-            label = stringResource(id = BitwardenString.create_account),
-            onClick = onCreateAccountClick,
-            modifier = Modifier
-                .standardHorizontalMargin(medium = HORIZONTAL_MARGIN_MEDIUM)
-                .fillMaxWidth()
-                .testTag("ChooseAccountCreationButton"),
-        )
+        AnimatedVisibility(
+            visible = state.allowCreateAccount,
+            label = "CreateAccountAnimatedVisibility",
+        ) {
+            BitwardenFilledButton(
+                label = stringResource(id = BitwardenString.create_account),
+                onClick = onCreateAccountClick,
+                modifier = Modifier
+                    .standardHorizontalMargin(medium = HORIZONTAL_MARGIN_MEDIUM)
+                    .fillMaxWidth()
+                    .testTag("ChooseAccountCreationButton"),
+            )
+        }
 
         BitwardenOutlinedButton(
             label = stringResource(id = BitwardenString.log_in_verb),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeViewModel.kt
@@ -1,10 +1,16 @@
 package com.x8bit.bitwarden.ui.auth.feature.welcome
 
 import android.os.Parcelable
+import androidx.lifecycle.viewModelScope
+import com.bitwarden.data.datasource.disk.model.ServerConfig
+import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -13,24 +19,47 @@ import javax.inject.Inject
  * Manages application state for the welcome screen.
  */
 @HiltViewModel
-class WelcomeViewModel @Inject constructor() :
-    BaseViewModel<WelcomeState, WelcomeEvent, WelcomeAction>(
-        initialState = WelcomeState(
-            index = 0,
-            pages = listOf(
-                WelcomeState.WelcomeCard.CardOne,
-                WelcomeState.WelcomeCard.CardTwo,
-                WelcomeState.WelcomeCard.CardThree,
-                WelcomeState.WelcomeCard.CardFour,
-            ),
+class WelcomeViewModel @Inject constructor(
+    serverConfigRepository: ServerConfigRepository,
+) : BaseViewModel<WelcomeState, WelcomeEvent, WelcomeAction>(
+    initialState = WelcomeState(
+        index = 0,
+        pages = listOf(
+            WelcomeState.WelcomeCard.CardOne,
+            WelcomeState.WelcomeCard.CardTwo,
+            WelcomeState.WelcomeCard.CardThree,
+            WelcomeState.WelcomeCard.CardFour,
         ),
-    ) {
+        disableCreateAccount = serverConfigRepository
+            .serverConfigStateFlow
+            .value
+            ?.serverData
+            ?.settings
+            ?.disableUserRegistration == true,
+    ),
+) {
+
+    init {
+        serverConfigRepository
+            .serverConfigStateFlow
+            .map { WelcomeAction.Internal.ServerConfigReceived(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+    }
+
     override fun handleAction(action: WelcomeAction) {
         when (action) {
             is WelcomeAction.PagerSwipe -> handlePagerSwipe(action)
             is WelcomeAction.DotClick -> handleDotClick(action)
             WelcomeAction.CreateAccountClick -> handleCreateAccountClick()
             WelcomeAction.LoginClick -> handleLoginClick()
+            is WelcomeAction.Internal -> handleInternalAction(action)
+        }
+    }
+
+    private fun handleInternalAction(action: WelcomeAction.Internal) {
+        when (action) {
+            is WelcomeAction.Internal.ServerConfigReceived -> handleServerConfigReceived(action)
         }
     }
 
@@ -50,6 +79,18 @@ class WelcomeViewModel @Inject constructor() :
     private fun handleLoginClick() {
         sendEvent(WelcomeEvent.NavigateToLogin)
     }
+
+    private fun handleServerConfigReceived(action: WelcomeAction.Internal.ServerConfigReceived) {
+        mutableStateFlow.update {
+            it.copy(
+                disableCreateAccount = action
+                    .serverConfig
+                    ?.serverData
+                    ?.settings
+                    ?.disableUserRegistration == true,
+            )
+        }
+    }
 }
 
 /**
@@ -59,7 +100,13 @@ class WelcomeViewModel @Inject constructor() :
 data class WelcomeState(
     val index: Int,
     val pages: List<WelcomeCard>,
+    val disableCreateAccount: Boolean,
 ) : Parcelable {
+    /**
+     * Determines if the user should be allowed to create a new account.
+     */
+    val allowCreateAccount: Boolean get() = !disableCreateAccount
+
     /**
      * A sealed class to represent the different cards the user can view on the welcome screen.
      */
@@ -159,4 +206,16 @@ sealed class WelcomeAction {
      * Click the login button.
      */
     data object LoginClick : WelcomeAction()
+
+    /**
+     * Actions for internal use by the ViewModel.
+     */
+    sealed class Internal : WelcomeAction() {
+        /**
+         * Indicates that an updated [serverConfig] has been received.
+         */
+        data class ServerConfigReceived(
+            val serverConfig: ServerConfig?,
+        ) : Internal()
+    }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -7586,6 +7586,7 @@ class AuthRepositoryTest {
                 ),
                 featureStates = emptyMap(),
                 communication = null,
+                settings = null,
             ),
         )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/FillAssistManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/FillAssistManagerTest.kt
@@ -791,5 +791,6 @@ private val SERVER_CONFIG = ServerConfig(
         ),
         featureStates = null,
         communication = null,
+        settings = null,
     ),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/sdk/ServerCommunicationConfigRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/sdk/ServerCommunicationConfigRepositoryTest.kt
@@ -73,6 +73,7 @@ class ServerCommunicationConfigRepositoryTest {
                         cookieDomain = cookieDomain,
                     ),
                 ),
+                settings = null,
             ),
         )
         val cookieData = CookieConfigurationData(
@@ -126,6 +127,7 @@ class ServerCommunicationConfigRepositoryTest {
                         cookieDomain = null,
                     ),
                 ),
+                settings = null,
             ),
         )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
@@ -326,5 +326,6 @@ private val SERVER_CONFIG = ServerConfig(
             "flexible-collections-v-1" to JsonPrimitive(false),
         ),
         communication = null,
+        settings = null,
     ),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerTest.kt
@@ -293,6 +293,7 @@ private fun createServerConfig(
                 ),
             )
         },
+        settings = null,
     ),
 )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/util/FakeServerConfigRepository.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/util/FakeServerConfigRepository.kt
@@ -56,5 +56,6 @@ private val SERVER_CONFIG = ServerConfig(
             "dummy-boolean" to JsonPrimitive(true),
         ),
         communication = null,
+        settings = null,
     ),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
@@ -358,6 +358,15 @@ class LandingScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "Create an account")
             .performScrollTo()
             .assertIsDisplayed()
+
+        mutableStateFlow.update { it.copy(disableCreateAccount = true) }
+        composeTestRule.onNodeWithText(text = "Create an account").assertDoesNotExist()
+
+        mutableStateFlow.update { it.copy(disableCreateAccount = false) }
+        composeTestRule
+            .onNodeWithText(text = "Create an account")
+            .performScrollTo()
+            .assertIsDisplayed()
     }
 
     @Test
@@ -525,4 +534,5 @@ private val DEFAULT_STATE = LandingState(
     dialog = null,
     accountSummaries = persistentListOf(),
     isFedRampEnabled = true,
+    disableCreateAccount = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
@@ -4,7 +4,10 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.data.datasource.disk.model.ServerConfig
+import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.data.repository.model.Environment
+import com.bitwarden.network.model.ConfigResponseJson
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.account.model.AccountSummary
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
@@ -44,6 +47,10 @@ class LandingViewModelTest : BaseViewModelTest() {
         every { lockVault(any(), any()) } just runs
     }
     private val fakeEnvironmentRepository = FakeEnvironmentRepository()
+    private val mutableServerConfigFlow = MutableStateFlow<ServerConfig?>(null)
+    private val serverConfigRepository: ServerConfigRepository = mockk {
+        every { serverConfigStateFlow } returns mutableServerConfigFlow
+    }
     private val mutableSnackbarSharedFlow = bufferedMutableSharedFlow<BitwardenSnackbarData>()
     private val snackbarRelayManager = mockk<SnackbarRelayManager<SnackbarRelay>> {
         every {
@@ -131,6 +138,32 @@ class LandingViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel(savedStateHandle = handle)
         viewModel.stateFlow.test {
             assertEquals(expectedState, awaitItem())
+        }
+    }
+
+    @Test
+    fun `initial state should be correct when user registration is disabled`() = runTest {
+        mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = true)
+        val viewModel = createViewModel()
+        viewModel.stateFlow.test {
+            assertEquals(DEFAULT_STATE.copy(disableCreateAccount = true), awaitItem())
+        }
+    }
+
+    @Test
+    fun `server config changes should update state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(DEFAULT_STATE, awaitItem())
+            mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = true)
+            assertEquals(DEFAULT_STATE.copy(disableCreateAccount = true), awaitItem())
+            mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = false)
+            assertEquals(DEFAULT_STATE.copy(disableCreateAccount = false), awaitItem())
+            mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = true)
+            assertEquals(DEFAULT_STATE.copy(disableCreateAccount = true), awaitItem())
+            mutableServerConfigFlow.value = null
+            assertEquals(DEFAULT_STATE.copy(disableCreateAccount = false), awaitItem())
         }
     }
 
@@ -647,6 +680,7 @@ class LandingViewModelTest : BaseViewModelTest() {
         },
         vaultRepository = vaultRepository,
         environmentRepository = fakeEnvironmentRepository,
+        serverConfigRepository = serverConfigRepository,
         snackbarRelayManager = snackbarRelayManager,
         featureFlagManager = featureFlagManager,
         savedStateHandle = savedStateHandle,
@@ -664,4 +698,23 @@ private val DEFAULT_STATE = LandingState(
     dialog = null,
     accountSummaries = persistentListOf(),
     isFedRampEnabled = true,
+    disableCreateAccount = false,
+)
+
+private fun createServerConfig(
+    disableUserRegistration: Boolean,
+): ServerConfig = ServerConfig(
+    lastSync = 0L,
+    serverData = ConfigResponseJson(
+        type = null,
+        version = null,
+        gitHash = null,
+        server = null,
+        environment = null,
+        featureStates = null,
+        communication = null,
+        settings = ConfigResponseJson.SettingJson(
+            disableUserRegistration = disableUserRegistration,
+        ),
+    ),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
@@ -3,7 +3,10 @@ package com.x8bit.bitwarden.ui.auth.feature.startregistration
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.data.datasource.disk.model.ServerConfig
+import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.data.repository.model.Environment
+import com.bitwarden.network.model.ConfigResponseJson
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
@@ -31,6 +34,7 @@ import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -45,6 +49,10 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
         } returns mutableSnackbarSharedFlow
     }
     private val fakeEnvironmentRepository = FakeEnvironmentRepository()
+    private val mutableServerConfigFlow = MutableStateFlow<ServerConfig?>(null)
+    private val serverConfigRepository: ServerConfigRepository = mockk {
+        every { serverConfigStateFlow } returns mutableServerConfigFlow
+    }
 
     @Test
     fun `initial state should be correct`() {
@@ -350,12 +358,45 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Test
+    fun `ServerConfigReceive with user registration disabled should show error dialog`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_STATE, awaitItem())
+                mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = true)
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        dialog = StartRegistrationDialog.Error(
+                            title = BitwardenString.account_creation_restricted.asText(),
+                            message = BitwardenString
+                                .only_allows_invited_users_to_create_accounts
+                                .asText("https://bitwarden.com"),
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `ServerConfigReceive with user registration enabled should not update state`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_STATE, awaitItem())
+                mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = false)
+                expectNoEvents()
+            }
+        }
+
     private fun createViewModel(
         state: StartRegistrationState? = null,
     ): StartRegistrationViewModel =
         StartRegistrationViewModel(
             authRepository = mockAuthRepository,
             environmentRepository = fakeEnvironmentRepository,
+            serverConfigRepository = serverConfigRepository,
             snackbarRelayManager = snackbarRelayManager,
             savedStateHandle = SavedStateHandle().apply {
                 set(key = "state", value = state)
@@ -380,4 +421,30 @@ private val VALID_INPUT_STATE: StartRegistrationState = StartRegistrationState(
     isContinueButtonEnabled = true,
     selectedEnvironmentType = Environment.Type.US,
     dialog = null,
+)
+
+private fun createServerConfig(
+    disableUserRegistration: Boolean,
+): ServerConfig = ServerConfig(
+    lastSync = 0L,
+    serverData = ConfigResponseJson(
+        type = null,
+        version = null,
+        gitHash = null,
+        server = null,
+        environment = ConfigResponseJson.EnvironmentJson(
+            cloudRegion = "US",
+            vaultUrl = "https://bitwarden.com",
+            apiUrl = "https://api.bitwarden.com",
+            identityUrl = "https://identity.bitwarden.com",
+            notificationsUrl = "https://notifications.bitwarden.com",
+            ssoUrl = null,
+            fillAssistRulesUrl = null,
+        ),
+        featureStates = null,
+        communication = null,
+        settings = ConfigResponseJson.SettingJson(
+            disableUserRegistration = disableUserRegistration,
+        ),
+    ),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreenTest.kt
@@ -98,6 +98,25 @@ class WelcomeScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `create account button should update according to state`() {
+        composeTestRule
+            .onNodeWithText("Create account")
+            .assertExists()
+            .assertIsDisplayed()
+
+        mutableStateFlow.update { it.copy(disableCreateAccount = true) }
+        composeTestRule
+            .onNodeWithText("Create account")
+            .assertDoesNotExist()
+
+        mutableStateFlow.update { it.copy(disableCreateAccount = false) }
+        composeTestRule
+            .onNodeWithText("Create account")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun `login button click should send LoginClick action`() {
         // Use an empty list of pages to guarantee that the login button
         // will be in view on the UI testing viewport.
@@ -121,4 +140,5 @@ private val DEFAULT_STATE = WelcomeState(
         WelcomeState.WelcomeCard.CardOne,
         WelcomeState.WelcomeCard.CardTwo,
     ),
+    disableCreateAccount = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeViewModelTest.kt
@@ -1,12 +1,23 @@
 package com.x8bit.bitwarden.ui.auth.feature.welcome
 
 import app.cash.turbine.test
+import com.bitwarden.data.datasource.disk.model.ServerConfig
+import com.bitwarden.data.repository.ServerConfigRepository
+import com.bitwarden.network.model.ConfigResponseJson
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class WelcomeViewModelTest : BaseViewModelTest() {
+
+    private val mutableServerConfigFlow = MutableStateFlow<ServerConfig?>(null)
+    private val serverConfigRepository: ServerConfigRepository = mockk {
+        every { serverConfigStateFlow } returns mutableServerConfigFlow
+    }
 
     @Test
     fun `initial state should be correct`() = runTest {
@@ -17,6 +28,36 @@ class WelcomeViewModelTest : BaseViewModelTest() {
                 DEFAULT_STATE,
                 awaitItem(),
             )
+        }
+    }
+
+    @Test
+    fun `initial state should be correct when user registration is disabled`() = runTest {
+        mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = true)
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(
+                DEFAULT_STATE.copy(disableCreateAccount = true),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `server config changes should update state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(DEFAULT_STATE, awaitItem())
+            mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = true)
+            assertEquals(DEFAULT_STATE.copy(disableCreateAccount = true), awaitItem())
+            mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = false)
+            assertEquals(DEFAULT_STATE.copy(disableCreateAccount = false), awaitItem())
+            mutableServerConfigFlow.value = createServerConfig(disableUserRegistration = true)
+            assertEquals(DEFAULT_STATE.copy(disableCreateAccount = true), awaitItem())
+            mutableServerConfigFlow.value = null
+            assertEquals(DEFAULT_STATE.copy(disableCreateAccount = false), awaitItem())
         }
     }
 
@@ -83,7 +124,9 @@ class WelcomeViewModelTest : BaseViewModelTest() {
         }
     }
 
-    private fun createViewModel(): WelcomeViewModel = WelcomeViewModel()
+    private fun createViewModel(): WelcomeViewModel = WelcomeViewModel(
+        serverConfigRepository = serverConfigRepository,
+    )
 }
 
 private val DEFAULT_STATE = WelcomeState(
@@ -93,5 +136,24 @@ private val DEFAULT_STATE = WelcomeState(
         WelcomeState.WelcomeCard.CardTwo,
         WelcomeState.WelcomeCard.CardThree,
         WelcomeState.WelcomeCard.CardFour,
+    ),
+    disableCreateAccount = false,
+)
+
+private fun createServerConfig(
+    disableUserRegistration: Boolean,
+): ServerConfig = ServerConfig(
+    lastSync = 0L,
+    serverData = ConfigResponseJson(
+        type = null,
+        version = null,
+        gitHash = null,
+        server = null,
+        environment = null,
+        featureStates = null,
+        communication = null,
+        settings = ConfigResponseJson.SettingJson(
+            disableUserRegistration = disableUserRegistration,
+        ),
     ),
 )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
@@ -269,5 +269,6 @@ private val SERVER_CONFIG = ServerConfig(
             "flexible-collections-v-1" to JsonPrimitive(false),
         ),
         communication = null,
+        settings = null,
     ),
 )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/repository/util/FakeServerConfigRepository.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/repository/util/FakeServerConfigRepository.kt
@@ -56,5 +56,6 @@ private val SERVER_CONFIG = ServerConfig(
             "dummy-boolean" to JsonPrimitive(true),
         ),
         communication = null,
+        settings = null,
     ),
 )

--- a/data/src/test/kotlin/com/bitwarden/data/datasource/disk/ConfigDiskSourceTest.kt
+++ b/data/src/test/kotlin/com/bitwarden/data/datasource/disk/ConfigDiskSourceTest.kt
@@ -114,5 +114,6 @@ private val SERVER_CONFIG = ServerConfig(
             "flexible-collections-v-1" to JsonPrimitive(false),
         ),
         communication = null,
+        settings = null,
     ),
 )

--- a/data/src/test/kotlin/com/bitwarden/data/repository/ServerConfigRepositoryTest.kt
+++ b/data/src/test/kotlin/com/bitwarden/data/repository/ServerConfigRepositoryTest.kt
@@ -168,6 +168,7 @@ private val SERVER_CONFIG = ServerConfig(
             "flexible-collections-v-1" to JsonPrimitive(false),
         ),
         communication = null,
+        settings = null,
     ),
 )
 
@@ -193,4 +194,5 @@ private val CONFIG_RESPONSE_JSON = ConfigResponseJson(
         "flexible-collections-v-1" to JsonPrimitive(false),
     ),
     communication = null,
+    settings = null,
 )

--- a/network/src/main/kotlin/com/bitwarden/network/model/ConfigResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/ConfigResponseJson.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.JsonPrimitive
  * @property environment The environment information containing URLs (vault, api, identity, etc.).
  * @property featureStates A map containing various feature states.
  * @property communication The communication configuration for server bootstrap (nullable).
+ * @property settings The settings configuration for the environment (nullable).
  */
 @Serializable
 data class ConfigResponseJson(
@@ -37,6 +38,9 @@ data class ConfigResponseJson(
 
     @SerialName("communication")
     val communication: CommunicationJson?,
+
+    @SerialName("settings")
+    val settings: SettingJson?,
 ) {
     /**
      * Represents a server in the configuration response.
@@ -122,4 +126,16 @@ data class ConfigResponseJson(
             val cookieDomain: String?,
         )
     }
+
+    /**
+     * Represents the settings configuration in the configuration response.
+     *
+     * @param disableUserRegistration If `true`, the environment does not allow for new user
+     * registration.
+     */
+    @Serializable
+    data class SettingJson(
+        @SerialName("disableUserRegistration")
+        val disableUserRegistration: Boolean,
+    )
 }

--- a/network/src/test/kotlin/com/bitwarden/network/service/ConfigServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/ConfigServiceTest.kt
@@ -50,6 +50,9 @@ private const val CONFIG_RESPONSE_JSON = """
       "cookieName": "sso-cookie",
       "cookieDomain": ".example.com"
     }
+  },
+  "settings":{
+    "disableUserRegistration":false
   }
 }
 """
@@ -80,5 +83,8 @@ private val CONFIG_RESPONSE = ConfigResponseJson(
             cookieName = "sso-cookie",
             cookieDomain = ".example.com",
         ),
+    ),
+    settings = ConfigResponseJson.SettingJson(
+        disableUserRegistration = false,
     ),
 )

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1414,4 +1414,6 @@ Do you want to switch to this account?</string>
     <string name="keep_documents_safe_and_encrypted">Keep documents safe and encrypted</string>
     <string name="share_files_securely_with_anyone_using_send">Share files securely with anyone using Send</string>
     <string name="receive_24_7_priority_support">Receive 24/7 priority support</string>
+    <string name="account_creation_restricted">Account creation restricted</string>
+    <string name="only_allows_invited_users_to_create_accounts">%1$s only allows invited users to create accounts.</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35124](https://bitwarden.atlassian.net/browse/PM-35124)
[PM-40675](https://bitwarden.atlassian.net/browse/PM-40675)
[PM-40657](https://bitwarden.atlassian.net/browse/PM-40677)

## 📔 Objective

This PR adds the `setting` to the `ConfigResponseJson` and uses that data to hide the `Create account` button on the Landing screen and the Welcome screen.


[PM-40657]: https://bitwarden.atlassian.net/browse/PM-40657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-40675]: https://bitwarden.atlassian.net/browse/PM-40675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-35124]: https://bitwarden.atlassian.net/browse/PM-35124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ