### PR TITLE
PM-40699: feat: Add FedRamp base urls to EnvironmentScreen autocomplete

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
@@ -43,11 +43,9 @@ import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
-import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenClientCertificateDialog
 import com.x8bit.bitwarden.ui.platform.composition.LocalKeyChainManager
 import com.x8bit.bitwarden.ui.platform.manager.keychain.KeyChainManager
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 
 /**
@@ -206,15 +204,7 @@ fun EnvironmentScreen(
                     id = BitwardenString.self_hosted_environment_footer,
                 ),
                 onValueChange = { viewModel.trySendAction(EnvironmentAction.ServerUrlChange(it)) },
-                autoCompleteOptions = if (BuildConfig.BUILD_TYPE != "release") {
-                    persistentListOf(
-                        "https://vault.qa.bitwarden.pw",
-                        "https://qa-team.sh.bitwarden.pw",
-                        "https://vault.usdev.bitwarden.pw",
-                    )
-                } else {
-                    persistentListOf()
-                },
+                autoCompleteOptions = state.autocompleteEnvironments,
                 keyboardType = KeyboardType.Uri,
                 textFieldTestTag = "ServerUrlEntry",
                 cardStyle = CardStyle.Full,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
 import com.bitwarden.data.manager.file.FileManager
 import com.bitwarden.data.repository.model.Environment
@@ -25,6 +26,9 @@ import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.ui.platform.manager.keychain.model.PrivateKeyAliasSelectionResult
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -45,6 +49,7 @@ class EnvironmentViewModel @Inject constructor(
     private val certificateManager: CertificateManager,
     private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     private val savedStateHandle: SavedStateHandle,
+    buildInfoManager: BuildInfoManager,
 ) : BaseViewModel<EnvironmentState, EnvironmentEvent, EnvironmentAction>(
     initialState = savedStateHandle[KEY_STATE] ?: run {
         val environmentUrlData = when (val environment = environmentRepository.environment) {
@@ -63,6 +68,7 @@ class EnvironmentViewModel @Inject constructor(
             keyAlias = keyAlias,
             keyHost = keyHost,
             dialog = null,
+            isRelease = buildInfoManager.isReleaseBuild,
         )
     },
 ) {
@@ -445,7 +451,17 @@ data class EnvironmentState(
     val dialog: DialogState?,
     // internal
     private val keyHost: MutualTlsKeyHost?,
+    private val isRelease: Boolean,
 ) : Parcelable {
+    /**
+     * The environments that should be available via the UI's autocomplete.
+     */
+    val autocompleteEnvironments: ImmutableList<String>
+        get() = if (isRelease) {
+            persistentListOf()
+        } else {
+            Environment.DEFAULT_INTERNAL_ENVIRONMENTS.toImmutableList()
+        }
 
     val keyUri: String?
         get() = "cert://$keyHost/$keyAlias"

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/BitwardenBuildInfoManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/BitwardenBuildInfoManagerImpl.kt
@@ -20,6 +20,9 @@ class BitwardenBuildInfoManagerImpl : BuildInfoManager {
     override val isDevBuild: Boolean
         get() = BuildConfig.BUILD_TYPE == "debug"
 
+    override val isReleaseBuild: Boolean
+        get() = BuildConfig.BUILD_TYPE == "release"
+
     override val versionData: String
         get() = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
@@ -427,17 +427,16 @@ class EnvironmentScreenTest : BitwardenComposeTest() {
             )
         }
     }
-
-    companion object {
-        val DEFAULT_STATE = EnvironmentState(
-            serverUrl = "",
-            keyAlias = "",
-            webVaultServerUrl = "",
-            apiServerUrl = "",
-            identityServerUrl = "",
-            iconsServerUrl = "",
-            keyHost = null,
-            dialog = null,
-        )
-    }
 }
+
+private val DEFAULT_STATE: EnvironmentState = EnvironmentState(
+    serverUrl = "",
+    keyAlias = "",
+    webVaultServerUrl = "",
+    apiServerUrl = "",
+    identityServerUrl = "",
+    iconsServerUrl = "",
+    keyHost = null,
+    dialog = null,
+    isRelease = true,
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModelTest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.auth.feature.environment
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
 import com.bitwarden.data.manager.file.FileManager
@@ -40,6 +41,9 @@ class EnvironmentViewModelTest : BaseViewModelTest() {
     private val mockFileManager = mockk<FileManager>()
     private val snackbarRelayManager = mockk<SnackbarRelayManager<SnackbarRelay>> {
         every { sendSnackbarData(data = any(), relay = any()) } just runs
+    }
+    private val buildInfoManager: BuildInfoManager = mockk {
+        every { isReleaseBuild } returns true
     }
 
     @Suppress("MaxLineLength")
@@ -817,21 +821,21 @@ class EnvironmentViewModelTest : BaseViewModelTest() {
             certificateManager = mockCertificateManager,
             fileManager = mockFileManager,
             snackbarRelayManager = snackbarRelayManager,
+            buildInfoManager = buildInfoManager,
             savedStateHandle = savedStateHandle,
         )
 
     //endregion Helper methods
-
-    companion object {
-        private val DEFAULT_STATE = EnvironmentState(
-            serverUrl = "",
-            keyAlias = "",
-            webVaultServerUrl = "",
-            apiServerUrl = "",
-            identityServerUrl = "",
-            iconsServerUrl = "",
-            keyHost = null,
-            dialog = null,
-        )
-    }
 }
+
+private val DEFAULT_STATE: EnvironmentState = EnvironmentState(
+    serverUrl = "",
+    keyAlias = "",
+    webVaultServerUrl = "",
+    apiServerUrl = "",
+    identityServerUrl = "",
+    iconsServerUrl = "",
+    keyHost = null,
+    dialog = null,
+    isRelease = true,
+)

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/AuthenticatorBuildInfoManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/AuthenticatorBuildInfoManagerImpl.kt
@@ -24,6 +24,9 @@ class AuthenticatorBuildInfoManagerImpl : BuildInfoManager {
     override val isDevBuild: Boolean
         get() = BuildConfig.BUILD_TYPE == "debug"
 
+    override val isReleaseBuild: Boolean
+        get() = BuildConfig.BUILD_TYPE == "release"
+
     override val versionData: String
         get() = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
 

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/BuildInfoManager.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/BuildInfoManager.kt
@@ -30,6 +30,11 @@ interface BuildInfoManager {
     val isDevBuild: Boolean
 
     /**
+     * A boolean property that indicates whether the current build is a release build.
+     */
+    val isReleaseBuild: Boolean
+
+    /**
      * A string that represents a displayable app version.
      */
     val versionData: String

--- a/data/src/main/kotlin/com/bitwarden/data/repository/model/Environment.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/repository/model/Environment.kt
@@ -87,4 +87,19 @@ sealed class Environment {
         FED_RAMP,
         SELF_HOSTED,
     }
+
+    @Suppress("UndocumentedPublicClass")
+    companion object {
+        /**
+         * List of all primary development environment base URLs.
+         */
+        val DEFAULT_INTERNAL_ENVIRONMENTS: List<String> = listOf(
+            "https://vault.qa.bitwarden.pw",
+            "https://qa-team.sh.bitwarden.pw",
+            "https://vault.usdev.bitwarden.pw",
+            "https://fedramp.usdev.bitwarden.pw",
+            "https://gw.dev.bitwarden.pw",
+            "https://gw.stg.bitwarden.pw",
+        )
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40699](https://bitwarden.atlassian.net/browse/PM-40699)

## 📔 Objective

This PR adds the 3 FedRamp test environment domains to the Autocomplete dropdown.


[PM-40699]: https://bitwarden.atlassian.net/browse/PM-40699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ