### PR TITLE
PM-39902: feat: Add data field for updating a cipher with Blob encryption

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
@@ -74,6 +74,7 @@ fun Cipher.toEncryptedNetworkCipher(
         driversLicense = driversLicense?.toEncryptedNetworkDriversLicense(),
         passport = passport?.toEncryptedNetworkPassport(),
         archivedDate = archivedDate,
+        data = data,
         encryptedFor = encryptedFor,
     )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
@@ -631,6 +631,7 @@ private const val CIPHER_JSON = """
     "issueDate": "mockIssueDate-1",
     "expirationDate": "mockExpirationDate-1",
   },
+  "data": "mockData-1",
   "encryptedFor": "mockEncryptedFor-1"
 }
 """

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/VaultSdkCipherUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/VaultSdkCipherUtil.kt
@@ -70,7 +70,7 @@ fun createMockSdkCipher(
         organizationUseTotp = false,
         viewPassword = false,
         localData = null,
-        data = null,
+        data = "mockData-$number",
     )
 
 /**

--- a/network/src/main/kotlin/com/bitwarden/network/model/CipherJsonRequest.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/CipherJsonRequest.kt
@@ -93,6 +93,9 @@ data class CipherJsonRequest(
     @Contextual
     val archivedDate: Instant?,
 
+    @SerialName("data")
+    val data: String?,
+
     @SerialName("encryptedFor")
     val encryptedFor: String?,
 )

--- a/network/src/main/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequest.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequest.kt
@@ -69,6 +69,9 @@ data class CipherWithIdJsonRequest(
     @SerialName("key")
     val key: String?,
 
+    @SerialName("data")
+    val data: String?,
+
     @SerialName("encryptedFor")
     val encryptedFor: String?,
 )
@@ -96,5 +99,6 @@ fun CipherJsonRequest.toCipherWithIdJsonRequest(id: String): CipherWithIdJsonReq
         isFavorite = isFavorite,
         card = card,
         key = key,
+        data = data,
         encryptedFor = encryptedFor,
     )

--- a/network/src/test/kotlin/com/bitwarden/network/service/CiphersServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/CiphersServiceTest.kt
@@ -684,6 +684,7 @@ private const val CREATE_ATTACHMENT_SUCCESS_JSON = """
       "issueDate": "mockIssueDate-1",
       "expirationDate": "mockExpirationDate-1"
     },
+    "data": "mockData-1",
     "encryptedFor": "mockEncryptedFor-1",
     "archivedDate": "2023-10-27T12:00:00.00Z"
   }
@@ -853,6 +854,7 @@ private const val CREATE_RESTORE_UPDATE_CIPHER_SUCCESS_JSON = """
     "issueDate": "mockIssueDate-1",
     "expirationDate": "mockExpirationDate-1"
   },
+  "data": "mockData-1",
   "encryptedFor": "mockEncryptedFor-1",
   "archivedDate": "2023-10-27T12:00:00.00Z"
 }
@@ -1039,6 +1041,7 @@ private const val UPDATE_CIPHER_COLLECTION_SUCCESS_JSON = """
       "issueDate": "mockIssueDate-1",
       "expirationDate": "mockExpirationDate-1"
     },
+    "data": "mockData-1",
     "encryptedFor": "mockEncryptedFor-1",
     "archivedDate": "2023-10-27T12:00:00.00Z"
   }

--- a/network/src/test/kotlin/com/bitwarden/network/service/SyncServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/SyncServiceTest.kt
@@ -522,6 +522,7 @@ private const val SYNC_SUCCESS_JSON = """
         "expirationDate": "mockExpirationDate-1",
       },
       "encryptedFor": "mockEncryptedFor-1",
+      "data": "mockData-1",
       "archivedDate": "2023-10-27T12:00:00.00Z"
     }
   ],

--- a/network/src/testFixtures/kotlin/com/bitwarden/network/model/CipherJsonRequestUtil.kt
+++ b/network/src/testFixtures/kotlin/com/bitwarden/network/model/CipherJsonRequestUtil.kt
@@ -35,6 +35,7 @@ fun createMockCipherJsonRequest(
     lastKnownRevisionDate: Instant? = Instant.parse("2023-10-27T12:00:00Z"),
     key: String? = "mockKey-$number",
     archivedDate: Instant? = Instant.parse("2023-10-27T12:00:00Z"),
+    data: String? = "mockData-$number",
     encryptedFor: String? = "mockEncryptedFor-$number",
 ): CipherJsonRequest =
     CipherJsonRequest(
@@ -59,5 +60,6 @@ fun createMockCipherJsonRequest(
         lastKnownRevisionDate = lastKnownRevisionDate,
         key = key,
         archivedDate = archivedDate,
+        data = data,
         encryptedFor = encryptedFor,
     )

--- a/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseCipherUtil.kt
+++ b/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseCipherUtil.kt
@@ -50,7 +50,7 @@ fun createMockCipher(
     shouldViewPassword: Boolean = false,
     key: String? = "mockKey-$number",
     encryptedFor: String? = "mockEncryptedFor-$number",
-    data: String? = null,
+    data: String? = "mockData-$number",
 ): SyncResponseJson.Cipher =
     SyncResponseJson.Cipher(
         id = id,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39902](https://bitwarden.atlassian.net/browse/PM-39902)

## 📔 Objective

This PT adds the `data` payload to the network request payloads responsible to for updating ciphers. This is required to ensure continued functionality with Blob encryption.


[PM-39902]: https://bitwarden.atlassian.net/browse/PM-39902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ