### PR TITLE
[PM-40805] feat: Rename "Move to vault" to "Move"

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -372,7 +372,7 @@ fun VaultAddEditScreen(
                                     .takeUnless { state.isAddItemMode },
                                 OverflowMenuItemData(
                                     text = stringResource(
-                                        id = BitwardenString.move_to_vault,
+                                        id = BitwardenString.move,
                                     ),
                                     onClick = {
                                         viewModel.trySendAction(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -202,7 +202,7 @@ fun VaultItemScreen(
                             )
                                 .takeUnless { state.isCipherInCollection },
                             OverflowMenuItemData(
-                                text = stringResource(id = BitwardenString.move_to_vault),
+                                text = stringResource(id = BitwardenString.move),
                                 onClick = {
                                     viewModel.trySendAction(
                                         VaultItemAction.Common.MoveToOrganizationClick,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationContent.kt
@@ -40,6 +40,7 @@ fun VaultMoveToOrganizationContent(
             item {
                 BitwardenMultiSelectButton(
                     label = stringResource(id = BitwardenString.vault),
+                    dialogTitle = stringResource(id = BitwardenString.filter_by_vault),
                     options = state
                         .organizations
                         .map { it.name }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModel.kt
@@ -351,7 +351,7 @@ data class VaultMoveToOrganizationState(
         get() = if (onlyShowCollections) {
             BitwardenString.shared_folders.asText()
         } else {
-            BitwardenString.move_to_vault.asText()
+            BitwardenString.move.asText()
         }
 
     val appBarButtonText: Text

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -4422,7 +4422,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertDoesNotExist()
 
@@ -4510,7 +4510,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertIsDisplayed()
 
@@ -5181,7 +5181,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
         // Confirm dropdown version of item is absent
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
@@ -5191,7 +5191,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
         // Confirm it does not exist
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertIsNotDisplayed()
     }
@@ -5216,7 +5216,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
         // Confirm dropdown version of item is absent
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
 
@@ -5225,7 +5225,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .performClick()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertIsDisplayed()
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -1547,14 +1547,14 @@ class VaultItemScreenTest : BitwardenComposeTest() {
 
         // Confirm dropdown version of item is absent
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
         composeTestRule.onNodeWithContentDescription("More options").performClick()
         // Click on the move to organization hint item in the dropdown
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filterToOne(hasAnyAncestor(isPopup()))
             .performClick()
         verify {
@@ -1574,14 +1574,14 @@ class VaultItemScreenTest : BitwardenComposeTest() {
 
         // Confirm dropdown version of item is absent
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
         composeTestRule.onNodeWithContentDescription("More options").performClick()
         // Confirm it does not exist
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertDoesNotExist()
     }
@@ -1696,7 +1696,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertDoesNotExist()
 
@@ -1724,7 +1724,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertIsDisplayed()
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onLast
@@ -60,7 +61,8 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "Shared folders")
             .assertIsNotDisplayed()
         composeTestRule
-            .onNodeWithText(text = "Move to vault")
+            .onAllNodesWithText(text = "Move")
+            .filterToOne(!hasClickAction())
             .assertIsDisplayed()
 
         mutableStateFlow.update { currentState ->
@@ -68,7 +70,7 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithText(text = "Move to vault")
+            .onNodeWithText(text = "Move")
             .assertIsNotDisplayed()
         composeTestRule
             .onNodeWithText(text = "Shared folders")
@@ -85,7 +87,8 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "Save")
             .assertIsNotDisplayed()
         composeTestRule
-            .onNodeWithText(text = "Move")
+            .onAllNodesWithText(text = "Move")
+            .filterToOne(hasClickAction())
             .assertIsDisplayed()
 
         mutableStateFlow.update { currentState ->
@@ -155,7 +158,8 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
     @Test
     fun `clicking move button should send MoveClick action`() {
         composeTestRule
-            .onNodeWithText(text = "Move")
+            .onAllNodesWithText(text = "Move")
+            .filterToOne(hasClickAction())
             .performClick()
 
         verify {

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
@@ -49,6 +49,7 @@ import kotlinx.collections.immutable.toImmutableList
  * @param isEnabled Whether the button is enabled.
  * @param cardStyle Indicates the type of card style to be applied.
  * @param modifier A [Modifier] that you can use to apply custom modifications to the composable.
+ * @param dialogTitle The title to apply to the dialog (defaults to [label] when `null`).
  * @param dialogSubtitle The subtitle to apply to the dialog.
  * @param supportingText An optional supporting text that will appear below the text field.
  * @param helpData An optional [BitwardenHelpButtonData], representing the help button.
@@ -67,6 +68,7 @@ fun BitwardenMultiSelectButton(
     onOptionSelected: (String) -> Unit,
     cardStyle: CardStyle?,
     modifier: Modifier = Modifier,
+    dialogTitle: String? = null,
     dialogSubtitle: String? = null,
     isEnabled: Boolean = true,
     supportingText: String? = null,
@@ -78,6 +80,7 @@ fun BitwardenMultiSelectButton(
 ) {
     BitwardenMultiSelectButton(
         label = label,
+        dialogTitle = dialogTitle,
         dialogSubtitle = dialogSubtitle,
         options = options.map { MultiSelectOption.Row(it) }.toImmutableList(),
         selectedOption = selectedOption?.let { MultiSelectOption.Row(it) },
@@ -119,6 +122,7 @@ fun BitwardenMultiSelectButton(
  * @param supportingContent An optional supporting content that will appear below the button.
  * @param cardStyle Indicates the type of card style to be applied.
  * @param modifier A [Modifier] that you can use to apply custom modifications to the composable.
+ * @param dialogTitle The title to apply to the dialog (defaults to [label] when `null`).
  * @param helpData An optional [BitwardenHelpButtonData], representing the help button.
  * @param insets Inner padding to be applied withing the card.
  * @param textFieldTestTag The optional test tag associated with the inner text field.
@@ -135,6 +139,7 @@ fun BitwardenMultiSelectButton(
     onOptionSelected: (MultiSelectOption.Row) -> Unit,
     cardStyle: CardStyle?,
     modifier: Modifier = Modifier,
+    dialogTitle: String? = null,
     dialogSubtitle: String? = null,
     isEnabled: Boolean = true,
     supportingContent: @Composable (ColumnScope.() -> Unit)?,
@@ -166,7 +171,7 @@ fun BitwardenMultiSelectButton(
 
     if (shouldShowDialog) {
         BitwardenSelectionDialog(
-            title = label,
+            title = dialogTitle ?: label,
             subTitle = dialogSubtitle,
             onDismissRequest = { shouldShowDialog = false },
         ) {

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -341,7 +341,6 @@ Scanning will happen automatically.</string>
     <string name="moved_item_to_org">%1$s moved to %2$s.</string>
     <string name="you_must_select_at_least_one_shared_folder">You must select at least one shared folder.</string>
     <string name="share">Share</string>
-    <string name="move_to_vault">Move to vault</string>
     <string name="no_vaults_to_list">No vaults to list.</string>
     <string name="move_to_vault_desc">Choose a vault that you wish to move this item to. Moving to another vault transfers ownership of the item to that organization. You will no longer be the direct owner of this item once it has been moved.</string>
     <string name="number_of_words">Number of words</string>


### PR DESCRIPTION
## ⚠️ Note
Stacked on #7196 (VFO-1 naming re-add)

## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-40805

## 📔 Objective
Renames "Move to vault" to "Move" in the overflow menu item and the destination screen's app-bar title, per updated requirements on the VFO-1 epic (PM-40638 is now on hold; this text supersedes it). The confirm button already reads "Move" and needed no change.

Also updates the "Vault" field's selection dialog on the Move screen so its title reads "Filter items by vault" (per Figma), instead of reusing the field's own "Vault" label. `BitwardenMultiSelectButton` now accepts an optional `dialogTitle` param for this, defaulting to the existing label-reuse behavior for every other call site.

## 📸 Screenshots
Move in cipher options:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/09b5e8e3-a37d-4540-b6d8-ad796e935fd3" />

Move title and button:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/3a0e598d-2375-4f90-951f-61ca31f22594" />

Vault selection dialog ("Filter items by vault" title):
<img width="350" alt="image" src="https://github.com/user-attachments/assets/c9e994ec-7eae-4a8c-b1a1-0a84adfd91a9" />


<!-- screenshot pending -->