### PR TITLE
[PM-41059] fix: CXF import crash when credential timestamps contain negative values (e.g., Windows FILETIME epoch -11644473600 from Google Password Manager exports).

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerImpl.kt
@@ -57,7 +57,7 @@ class CredentialExchangeImportManagerImpl(
     ): ImportCxfPayloadResult {
         val allCiphers = accountsJsonList.flatMap { accountJson ->
             vaultSdkSource
-                .importCxf(userId = userId, payload = accountJson)
+                .importCxf(userId = userId, payload = sanitizeTimestamps(accountJson))
                 .getOrElse { return ImportCxfPayloadResult.Error(error = it) }
         }
 
@@ -116,3 +116,20 @@ class CredentialExchangeImportManagerImpl(
             }
         }
 }
+
+private val NEGATIVE_TIMESTAMP_REGEX = Regex(
+    """("(?:creationAt|modifiedAt)"\s*:\s*)-\d+""",
+)
+
+/**
+ * Replace negative Unix timestamps in CXF account JSON with 0.
+ *
+ * Some credential managers (e.g., Google Password Manager on Windows) export
+ * timestamps as the Windows FILETIME epoch (-11644473600) when no real date
+ * exists. The Bitwarden SDK deserializes these fields as u64 and cannot
+ * handle negative values.
+ */
+internal fun sanitizeTimestamps(json: String): String =
+    NEGATIVE_TIMESTAMP_REGEX.replace(json) { match ->
+        "${match.groupValues[1]}0"
+    }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerTest.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkCipher
 import com.x8bit.bitwarden.data.vault.manager.model.ImportCxfPayloadResult
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
+import com.x8bit.bitwarden.data.vault.manager.sanitizeTimestamps
 import io.mockk.awaits
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -509,6 +510,68 @@ class CredentialExchangeImportManagerTest {
                     ciphersService.importCiphers(any())
                 }
             }
+    }
+}
+
+class SanitizeTimestampsTest {
+    @Test
+    fun `import flow sanitizes negative timestamps before SDK call`() = runTest {
+        val negativeTimestampJson = DEFAULT_ACCOUNT_JSON.replace(
+            "1759783057",
+            "-11644473600",
+        )
+        val sanitizedJson = sanitizeTimestamps(negativeTimestampJson)
+
+        val importManager = CredentialExchangeImportManagerImpl(
+            vaultSdkSource = mockk {
+                coEvery { importCxf(any(), any()) } returns DEFAULT_CIPHER_LIST.asSuccess()
+            },
+            ciphersService = mockk {
+                coEvery { importCiphers(any()) } returns
+                    ImportCiphersResponseJson.Success.asSuccess()
+            },
+            vaultSyncManager = mockk {
+                coEvery { syncForResult(forced = true) } returns SyncVaultDataResult.Success
+            },
+            policyManager = mockk { every { getActivePolicies(any()) } returns emptyList() },
+            credentialExchangePayloadParser = mockk {
+                every { parse(any()) } returns CredentialExchangePayload.Importable(
+                    accountsJsonList = listOf(negativeTimestampJson),
+                )
+            },
+        )
+
+        val result = importManager.importCxfPayload(DEFAULT_USER_ID, "payload")
+
+        assertTrue(result is ImportCxfPayloadResult.Success)
+    }
+
+
+    @Test
+    fun `sanitizeTimestamps replaces negative creationAt with 0`() {
+        val input = """{"creationAt": -11644473600, "modifiedAt": 1759783057}"""
+        val expected = """{"creationAt": 0, "modifiedAt": 1759783057}"""
+        assertEquals(expected, sanitizeTimestamps(input))
+    }
+
+    @Test
+    fun `sanitizeTimestamps replaces negative modifiedAt with 0`() {
+        val input = """{"creationAt": 1759783057, "modifiedAt": -11644473600}"""
+        val expected = """{"creationAt": 1759783057, "modifiedAt": 0}"""
+        assertEquals(expected, sanitizeTimestamps(input))
+    }
+
+    @Test
+    fun `sanitizeTimestamps replaces both negative timestamps`() {
+        val input = """{"creationAt": -11644473600, "modifiedAt": -11644473600}"""
+        val expected = """{"creationAt": 0, "modifiedAt": 0}"""
+        assertEquals(expected, sanitizeTimestamps(input))
+    }
+
+    @Test
+    fun `sanitizeTimestamps does not modify valid timestamps`() {
+        val input = """{"creationAt": 1759783057, "modifiedAt": 1759783057}"""
+        assertEquals(input, sanitizeTimestamps(input))
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

[<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->](https://github.com/bitwarden/android/issues/7175)

https://github.com/bitwarden/android/issues/7140

https://github.com/bitwarden/android/issues/7215

https://bitwarden.atlassian.net/browse/PM-40542

## 📔 Objective

Fixes bug:

Stacktrace:
com.bitwarden.sdk.BitwardenException$Export: v1=com.bitwarden.exporters.ExportException$Cxf: Credential Exchange error: JSON error: invalid value: integer `-11644473600`, expected u64 at line 1 column 61701
	com.bitwarden.sdk.FfiConverterTypeBitwardenError.read(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:174)
	com.bitwarden.sdk.FfiConverterTypeBitwardenError.read(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:515)
	com.bitwarden.sdk.FfiConverter$DefaultImpls.liftFromRustBuffer(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:11)
	com.bitwarden.sdk.FfiConverterRustBuffer$DefaultImpls.liftFromRustBuffer(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:4)
	com.bitwarden.sdk.FfiConverterTypeBitwardenError.liftFromRustBuffer(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:1)
	com.bitwarden.sdk.FfiConverterTypeBitwardenError.liftFromRustBuffer(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:8)
	com.bitwarden.sdk.FfiConverterRustBuffer$DefaultImpls.lift(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:4)
	com.bitwarden.sdk.FfiConverterTypeBitwardenError.lift(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:1)
	com.bitwarden.sdk.FfiConverterTypeBitwardenError.lift(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:8)
	com.bitwarden.sdk.BitwardenException$ErrorHandler.lift(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:6)
	com.bitwarden.sdk.BitwardenException$ErrorHandler.lift(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:13)
	com.bitwarden.sdk.Bitwarden_uniffiKt.uniffiCheckCallStatus(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:79)
	com.bitwarden.sdk.Bitwarden_uniffiKt.access$uniffiCheckCallStatus(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:1)
	com.bitwarden.sdk.ExporterClient.importCxf(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:66)
	rpb.Z(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:75)
	db2.a(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:133)
	hnb.T(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:91)
	br4.invokeSuspend(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:51)
	vo0.resumeWith(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:8)
	qw2.run(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:114)
	qb3.t0(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:24)
	ng1.o(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:93)
	ng1.s(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:3)
	l41.a(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:7)
	j41.R(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:69)
	j41.d(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:53)
	j41.b(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:104)
	com.bitwarden.ui.platform.base.BaseViewModel.trySendAction(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:3)
	ip.invokeSuspend(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:1362)
	vo0.resumeWith(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:8)
	qw2.run(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:114)
	xr.p0(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:24)
	wr.run(r8-map-id-3711f003cf7d2a46fb8ec7e8ada71c46655423e03b475b325f07a00886353258:3)
	android.os.Handler.handleCallback(Handler.java:1095)
	android.os.Handler.dispatchMessageImpl(Handler.java:135)
	android.os.Handler.dispatchMessage(Handler.java:125)
	android.os.Looper.loopOnce(Looper.java:296)
	android.os.Looper.loop(Looper.java:397)
	android.app.ActivityThread.main(ActivityThread.java:9523)
	java.lang.reflect.Method.invoke(Native Method)
	com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:575)
	com.android.internal.os.ZygoteInit.main(ZygoteInit.java:939)

Version: 2026.6.1 (21713)
Device: 📱 google Pixel 9 🤖 17@37 📦 prod
CI: 🧱 commit: bitwarden/android/release/2026.6-rc57@e5ee43f68773f9fe20bec3dd664781d65b804967
💻 build source: bitwarden/android/actions/runs/28253991408/attempts/1