### PR TITLE
[PM-41100] fix: Complete the VFO-1 organization-to-vault revert

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -372,7 +372,7 @@ fun VaultAddEditScreen(
                                     .takeUnless { state.isAddItemMode },
                                 OverflowMenuItemData(
                                     text = stringResource(
-                                        id = BitwardenString.move_to_vault,
+                                        id = BitwardenString.move_to_organization,
                                     ),
                                     onClick = {
                                         viewModel.trySendAction(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -202,7 +202,7 @@ fun VaultItemScreen(
                             )
                                 .takeUnless { state.isCipherInCollection },
                             OverflowMenuItemData(
-                                text = stringResource(id = BitwardenString.move_to_vault),
+                                text = stringResource(id = BitwardenString.move_to_organization),
                                 onClick = {
                                     viewModel.trySendAction(
                                         VaultItemAction.Common.MoveToOrganizationClick,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationContent.kt
@@ -39,7 +39,7 @@ fun VaultMoveToOrganizationContent(
         if (!showOnlyCollections) {
             item {
                 BitwardenMultiSelectButton(
-                    label = stringResource(id = BitwardenString.vault),
+                    label = stringResource(id = BitwardenString.organization),
                     options = state
                         .organizations
                         .map { it.name }
@@ -52,7 +52,7 @@ fun VaultMoveToOrganizationContent(
                                 .first { it.name == selectedString },
                         )
                     },
-                    supportingText = stringResource(id = BitwardenString.move_to_vault_desc),
+                    supportingText = stringResource(id = BitwardenString.move_to_org_desc),
                     cardStyle = CardStyle.Full,
                     modifier = Modifier
                         .testTag("OrganizationListDropdown")

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationEmpty.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationEmpty.kt
@@ -26,7 +26,7 @@ fun VaultMoveToOrganizationEmpty(modifier: Modifier = Modifier) {
     ) {
         Spacer(modifier = Modifier.height(8.dp))
         Text(
-            text = stringResource(id = BitwardenString.no_vaults_to_list),
+            text = stringResource(id = BitwardenString.no_orgs_to_list),
             style = BitwardenTheme.typography.bodyMedium,
             color = BitwardenTheme.colorScheme.text.secondary,
             textAlign = TextAlign.Center,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModel.kt
@@ -351,7 +351,7 @@ data class VaultMoveToOrganizationState(
         get() = if (onlyShowCollections) {
             BitwardenString.collections.asText()
         } else {
-            BitwardenString.move_to_vault.asText()
+            BitwardenString.move_to_organization.asText()
         }
 
     val appBarButtonText: Text

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -4416,7 +4416,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertDoesNotExist()
 
@@ -4504,7 +4504,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertIsDisplayed()
 
@@ -5175,7 +5175,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
         // Confirm dropdown version of item is absent
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
@@ -5185,7 +5185,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
         // Confirm it does not exist
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertIsNotDisplayed()
     }
@@ -5210,7 +5210,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
         // Confirm dropdown version of item is absent
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
 
@@ -5219,7 +5219,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .performClick()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertIsDisplayed()
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -1547,14 +1547,14 @@ class VaultItemScreenTest : BitwardenComposeTest() {
 
         // Confirm dropdown version of item is absent
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
         composeTestRule.onNodeWithContentDescription("More options").performClick()
         // Click on the move to organization hint item in the dropdown
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filterToOne(hasAnyAncestor(isPopup()))
             .performClick()
         verify {
@@ -1574,14 +1574,14 @@ class VaultItemScreenTest : BitwardenComposeTest() {
 
         // Confirm dropdown version of item is absent
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
         composeTestRule.onNodeWithContentDescription("More options").performClick()
         // Confirm it does not exist
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertDoesNotExist()
     }
@@ -1696,7 +1696,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertDoesNotExist()
 
@@ -1724,7 +1724,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithText("Move to vault")
+            .onAllNodesWithText("Move to Organization")
             .filterToOne(hasAnyAncestor(isPopup()))
             .assertIsDisplayed()
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationScreenTest.kt
@@ -60,7 +60,7 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "Collections")
             .assertIsNotDisplayed()
         composeTestRule
-            .onNodeWithText(text = "Move to vault")
+            .onNodeWithText(text = "Move to Organization")
             .assertIsDisplayed()
 
         mutableStateFlow.update { currentState ->
@@ -68,7 +68,7 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithText(text = "Move to vault")
+            .onNodeWithText(text = "Move to Organization")
             .assertIsNotDisplayed()
         composeTestRule
             .onNodeWithText(text = "Collections")
@@ -104,7 +104,7 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
     fun `the organization option field should update according to state`() {
         composeTestRule
             .onNodeWithContentDescription(
-                label = "mockOrganizationName-1. Vault",
+                label = "mockOrganizationName-1. Organization",
                 substring = true,
             )
             .assertIsDisplayed()
@@ -114,14 +114,14 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription(label = "mockOrganizationName-1. Vault")
+            .onNodeWithContentDescription(label = "mockOrganizationName-1. Organization")
             .assertIsNotDisplayed()
     }
 
     @Test
     fun `the organization option field description should update according to state`() {
         composeTestRule
-            .onNodeWithText(text = "Choose a vault that", substring = true)
+            .onNodeWithText(text = "Choose an organization that", substring = true)
             .assertIsDisplayed()
 
         mutableStateFlow.update { currentState ->
@@ -129,7 +129,7 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithText(text = "Choose a vault that", substring = true)
+            .onNodeWithText(text = "Choose an organization that", substring = true)
             .assertIsNotDisplayed()
     }
 
@@ -168,7 +168,7 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
     @Test
     fun `selecting an organization should send OrganizationSelect action`() {
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "mockOrganizationName-1. Vault")
+            .onNodeWithContentDescriptionAfterScroll(label = "mockOrganizationName-1. Organization")
             .performClick()
         // Choose the option from the menu
         composeTestRule
@@ -200,7 +200,7 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
     @Test
     fun `the organization option field should display according to state`() {
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "mockOrganizationName-1. Vault")
+            .onNodeWithContentDescriptionAfterScroll(label = "mockOrganizationName-1. Organization")
             .assertIsDisplayed()
 
         mutableStateFlow.update { currentState ->
@@ -213,7 +213,7 @@ class VaultMoveToOrganizationScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "mockOrganizationName-2. Vault")
+            .onNodeWithContentDescriptionAfterScroll(label = "mockOrganizationName-2. Organization")
             .assertIsDisplayed()
     }
 

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -341,9 +341,9 @@ Scanning will happen automatically.</string>
     <string name="moved_item_to_org">%1$s moved to %2$s.</string>
     <string name="select_one_collection">You must select at least one collection.</string>
     <string name="share">Share</string>
-    <string name="move_to_vault">Move to vault</string>
-    <string name="no_vaults_to_list">No vaults to list.</string>
-    <string name="move_to_vault_desc">Choose a vault that you wish to move this item to. Moving to another vault transfers ownership of the item to that organization. You will no longer be the direct owner of this item once it has been moved.</string>
+    <string name="move_to_organization">Move to Organization</string>
+    <string name="no_orgs_to_list">No organizations to list.</string>
+    <string name="move_to_org_desc">Choose an organization that you wish to move this item to. Moving to an organization transfers ownership of the item to that organization. You will no longer be the direct owner of this item once it has been moved.</string>
     <string name="number_of_words">Number of words</string>
     <string name="passphrase">Passphrase</string>
     <string name="word_separator">Word separator</string>


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-41100

## 📔 Objective
The revert of the VFO-1 naming changes (#7195) squashed three separate PRs (#7183 Owner, #7189 Collections, #7192 Organization→Vault) into one commit. It correctly reverted the Owner and Collections wording everywhere, but missed every hunk belonging to the Organization→Vault rename — including two files (`VaultMoveToOrganizationContent.kt`, `VaultMoveToOrganizationEmpty.kt`) that PR #7192 was the *only* one of the three to touch, so they never surfaced while resolving the other two.

As a result, `main` was still unconditionally showing "Move to vault" (menu item, app-bar title, dropdown label, description, empty-state) regardless of any feature flag — exactly what QA caught in this ticket.

This PR completes the revert: restores `move_to_organization`, `move_to_org_desc`, and `no_orgs_to_list`, points the affected screens/ViewModel back at them, and removes the leftover `move_to_vault`/`move_to_vault_desc`/`no_vaults_to_list` strings — so the app matches its pre-VFO1 baseline again until the flag-gated version (already stacked behind `vfo1-foundation` in #7219) lands.

## 📸 Screenshots
<img width="350" alt="image" src="https://github.com/user-attachments/assets/4228f6ca-af5e-4a79-9f76-dfbda86d294d" />
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/3d2a82ba-8683-4f06-86ec-855a6dfaf396" />
