### PR TITLE
[PM-41103] feat: Add identity autofill feature flag

### DIFF
--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -48,6 +48,7 @@ sealed class FlagKey<out T : Any> {
                 FedRamp,
                 SendControls,
                 SendControlsExistingSends,
+                IdentityAutofill,
             )
         }
     }
@@ -205,6 +206,15 @@ sealed class FlagKey<out T : Any> {
      */
     data object SendControlsExistingSends : FlagKey<Boolean>() {
         override val keyName: String = "pm-31885-send-controls-existing-sends"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key for gating identity autofill (offering saved
+     * Identity items as autofill suggestions).
+     */
+    data object IdentityAutofill : FlagKey<Boolean>() {
+        override val keyName: String = "pm-38138-mobile-identity-autofill"
         override val defaultValue: Boolean = false
     }
 

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
@@ -72,6 +72,10 @@ class FlagKeyTest {
             FlagKey.SendControlsExistingSends.keyName,
             "pm-31885-send-controls-existing-sends",
         )
+        assertEquals(
+            FlagKey.IdentityAutofill.keyName,
+            "pm-38138-mobile-identity-autofill",
+        )
     }
 
     @Test
@@ -94,6 +98,7 @@ class FlagKeyTest {
                 FlagKey.FedRamp,
                 FlagKey.SendControls,
                 FlagKey.SendControlsExistingSends,
+                FlagKey.IdentityAutofill,
             ).all {
                 !it.defaultValue
             },

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
@@ -42,6 +42,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.FedRamp,
     FlagKey.SendControls,
     FlagKey.SendControlsExistingSends,
+    FlagKey.IdentityAutofill,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -110,4 +111,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.SendControlsExistingSends -> {
         stringResource(BitwardenString.send_controls_existing_sends)
     }
+
+    FlagKey.IdentityAutofill -> stringResource(BitwardenString.identity_autofill)
 }

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -59,6 +59,7 @@
     <string name="fed_ramp">FedRAMP</string>
     <string name="send_controls">Send Controls</string>
     <string name="send_controls_existing_sends">Send Controls - Existing Sends</string>
+    <string name="identity_autofill">Identity Autofill</string>
 
     <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41103

## 📔 Objective

Adds `FlagKey.IdentityAutofill` (`pm-38138-mobile-identity-autofill`), defaulted off, so the in-progress identity autofill feature (PM-38138) can be gated before it reaches production. This PR is definition-only — no gating logic is added yet, so behavior is unchanged. Also wires the flag into the debug menu (`FeatureFlagListItems.kt` + `identity_autofill` string) so it can be toggled locally for testing.

A follow-up PR will add the actual gating check in the autofill parser.

## 📸 Screenshots

N/A — debug menu label follows the same list-item pattern as existing flags.