### PR TITLE
[PM-41240] Exclude archived items from folder item count

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
@@ -188,8 +188,8 @@ fun VaultData.toViewState(
                     count = decryptCipherListResult
                         .successes
                         .count {
-                            it.deletedDate == null &&
-                                !it.id.isNullOrBlank() &&
+                            !it.id.isNullOrBlank() &&
+                                it.isActive &&
                                 folderView.id == it.folderId
                         },
                 )
@@ -201,7 +201,7 @@ fun VaultData.toViewState(
                     count = allFilteredCipherViewList
                         .count {
                             !it.id.isNullOrBlank() &&
-                                it.deletedDate == null &&
+                                it.isActive &&
                                 collectionView.id in it.collectionIds
                         },
                 )


### PR DESCRIPTION
## 📔 Objective

Currently archived items are included in the folder item count on VaultItemListingScreen but excluded on the VaultScreen. With this PR archived items are excluded on the VaultItemListingScreen as well.

⚠️ WARNING: This is untested because I don't want to play around with my real account. Is there a way to turn on premium features in a development environment?