### PR TITLE
PM-41423: chore: Separate ForcePasswordResetReason from MasterPasswordUnlockData

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -111,6 +111,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.toDeviceInfo
 import com.x8bit.bitwarden.data.auth.repository.util.toOrganizations
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.toUserState
+import com.x8bit.bitwarden.data.auth.repository.util.updateForcePasswordReset
 import com.x8bit.bitwarden.data.auth.repository.util.updateMasterPasswordUnlock
 import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
 import com.x8bit.bitwarden.data.auth.util.KdfParamsConstants.DEFAULT_PBKDF2_ITERATIONS
@@ -379,7 +380,7 @@ class AuthRepositoryImpl(
 
                 // Otherwise check the user's password against the policies and set or
                 // clear the force reset reason accordingly.
-                storeUserResetPasswordReason(
+                authDiskSource.userState = authDiskSource.userState?.updateForcePasswordReset(
                     userId = userId,
                     reason = ForcePasswordResetReason
                         .WEAK_MASTER_PASSWORD_ON_LOGIN
@@ -1182,14 +1183,17 @@ class AuthRepositoryImpl(
                     .map { response }
             }
             .onSuccess { response ->
-                authDiskSource.userState = authDiskSource.userState?.updateMasterPasswordUnlock(
-                    userId = userId,
-                    masterPasswordUnlock = MasterPasswordUnlockData(
-                        kdf = profile.toSdkParams(),
-                        masterKeyWrappedUserKey = response.newKey,
-                        salt = profile.email,
-                    ),
-                )
+                authDiskSource.userState = authDiskSource
+                    .userState
+                    ?.updateMasterPasswordUnlock(
+                        userId = userId,
+                        masterPasswordUnlock = MasterPasswordUnlockData(
+                            kdf = profile.toSdkParams(),
+                            masterKeyWrappedUserKey = response.newKey,
+                            salt = profile.email,
+                        ),
+                    )
+                    ?.updateForcePasswordReset(userId = userId, reason = null)
                 this.organizationIdentifier = null
             }
             .flatMap { response ->
@@ -1244,10 +1248,13 @@ class AuthRepositoryImpl(
                     userId = userId,
                     accountCryptographicState = response.accountCryptographicState,
                 )
-                authDiskSource.userState = authDiskSource.userState?.updateMasterPasswordUnlock(
-                    userId = userId,
-                    masterPasswordUnlock = response.masterPasswordUnlock,
-                )
+                authDiskSource.userState = authDiskSource
+                    .userState
+                    ?.updateMasterPasswordUnlock(
+                        userId = userId,
+                        masterPasswordUnlock = response.masterPasswordUnlock,
+                    )
+                    ?.updateForcePasswordReset(userId = userId, reason = null)
                 this.organizationIdentifier = null
             }
             .flatMap { response ->
@@ -1316,6 +1323,7 @@ class AuthRepositoryImpl(
                                     salt = profile.email,
                                 ),
                             )
+                            ?.updateForcePasswordReset(userId = userId, reason = null)
                         this.organizationIdentifier = null
                     }
                     .map { response }
@@ -1711,25 +1719,6 @@ class AuthRepositoryImpl(
                 remember = false,
             )
         }
-
-    /**
-     * Update the saved state with the force password reset reason.
-     */
-    private fun storeUserResetPasswordReason(userId: String, reason: ForcePasswordResetReason?) {
-        val accounts = authDiskSource
-            .userState
-            ?.accounts
-            ?.toMutableMap()
-            ?: return
-        val account = accounts[userId] ?: return
-        val updatedProfile = account
-            .profile
-            .copy(forcePasswordResetReason = reason)
-        accounts[userId] = account.copy(profile = updatedProfile)
-        authDiskSource.userState = authDiskSource
-            .userState
-            ?.copy(accounts = accounts)
-    }
 
     //region LoginCommon
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
@@ -104,6 +104,25 @@ private fun SyncResponseJson.Profile.getForcePasswordResetReason(
 }
 
 /**
+ * Updates the [UserStateJson] by setting the `forcePasswordResetReason` value for the given
+ * [userId]. If the user is not present in the `UserStateJson`, nothing is updated.
+ */
+fun UserStateJson.updateForcePasswordReset(
+    userId: String,
+    reason: ForcePasswordResetReason?,
+): UserStateJson {
+    val account = accounts[userId] ?: return this
+    val profile = account.profile
+    val updatedProfile = profile.copy(forcePasswordResetReason = reason)
+    val updatedAccount = account.copy(profile = updatedProfile)
+    return this.copy(
+        accounts = accounts
+            .toMutableMap()
+            .apply { replace(userId, updatedAccount) },
+    )
+}
+
+/**
  * Updates the [UserStateJson] by setting the `hasMasterPassword` and `masterPasswordUnlock` values
  * for the given [userId]. If the user is not present in the `UserStateJson`, nothing is updated.
  */
@@ -122,7 +141,6 @@ fun UserStateJson.updateMasterPasswordUnlock(
         )
     }
     val updatedProfile = profile.copy(
-        forcePasswordResetReason = null,
         userDecryptionOptions = userDecryptionOptions
             ?.copy(
                 hasMasterPassword = masterPasswordUnlockJson != null,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
@@ -193,6 +193,141 @@ class UserStateJsonExtensionsTest {
     }
 
     @Test
+    fun `updateForcePasswordReset should do nothing for a non-matching account`() {
+        val originalUserState = UserStateJson(
+            activeUserId = "activeUserId",
+            accounts = mapOf("activeUserId" to mockk()),
+        )
+        assertEquals(
+            originalUserState,
+            originalUserState.updateForcePasswordReset(
+                userId = "nonActiveUserId",
+                reason = ForcePasswordResetReason.ADMIN_FORCE_PASSWORD_RESET,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `updateForcePasswordReset should update the force password reset reason for a matching account`() {
+        val originalUserState = createUserStateWithDecryptionOptions(
+            userDecryptionOptions = null,
+        )
+
+        assertEquals(
+            createUserStateWithDecryptionOptions(
+                userDecryptionOptions = null,
+                forcePasswordResetReason = ForcePasswordResetReason.ADMIN_FORCE_PASSWORD_RESET,
+            ),
+            originalUserState.updateForcePasswordReset(
+                userId = "activeUserId",
+                reason = ForcePasswordResetReason.ADMIN_FORCE_PASSWORD_RESET,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `updateForcePasswordReset should clear the force password reset reason when given a null reason`() {
+        val originalUserState = createUserStateWithDecryptionOptions(
+            userDecryptionOptions = null,
+            forcePasswordResetReason = ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN,
+        )
+
+        assertEquals(
+            createUserStateWithDecryptionOptions(
+                userDecryptionOptions = null,
+                forcePasswordResetReason = null,
+            ),
+            originalUserState.updateForcePasswordReset(
+                userId = "activeUserId",
+                reason = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `updateForcePasswordReset should only update the specified account`() {
+        val activeProfile = AccountJson.Profile(
+            userId = "activeUserId",
+            email = "active@example.com",
+            isEmailVerified = true,
+            name = "Active User",
+            stamp = null,
+            organizationId = null,
+            avatarColorHex = null,
+            hasPremiumPersonally = true,
+            hasPremiumFromOrganization = null,
+            forcePasswordResetReason = null,
+            kdfType = KdfTypeJson.ARGON2_ID,
+            kdfIterations = 600000,
+            kdfMemory = 16,
+            kdfParallelism = 4,
+            userDecryptionOptions = null,
+            isTwoFactorEnabled = false,
+            creationDate = Instant.parse("2024-09-13T01:00:00.00Z"),
+        )
+        val inactiveProfile = AccountJson.Profile(
+            userId = "inactiveUserId",
+            email = "inactive@example.com",
+            isEmailVerified = true,
+            name = "Inactive User",
+            stamp = null,
+            organizationId = null,
+            avatarColorHex = null,
+            hasPremiumPersonally = false,
+            hasPremiumFromOrganization = null,
+            forcePasswordResetReason = null,
+            kdfType = KdfTypeJson.ARGON2_ID,
+            kdfIterations = 500000,
+            kdfMemory = 8,
+            kdfParallelism = 2,
+            userDecryptionOptions = null,
+            isTwoFactorEnabled = false,
+            creationDate = Instant.parse("2024-08-13T01:00:00.00Z"),
+        )
+        val activeAccount = AccountJson(
+            profile = activeProfile,
+            tokens = null,
+            settings = AccountJson.Settings(environmentUrlData = null),
+        )
+        val inactiveAccount = AccountJson(
+            profile = inactiveProfile,
+            tokens = null,
+            settings = AccountJson.Settings(environmentUrlData = null),
+        )
+        val originalUserState = UserStateJson(
+            activeUserId = "activeUserId",
+            accounts = mapOf(
+                "activeUserId" to activeAccount,
+                "inactiveUserId" to inactiveAccount,
+            ),
+        )
+
+        val result = originalUserState.updateForcePasswordReset(
+            userId = "inactiveUserId",
+            reason = ForcePasswordResetReason.ADMIN_FORCE_PASSWORD_RESET,
+        )
+
+        // Should remain unchanged
+        assertEquals(
+            UserStateJson(
+                activeUserId = "activeUserId",
+                accounts = mapOf(
+                    "activeUserId" to activeAccount,
+                    "inactiveUserId" to inactiveAccount.copy(
+                        profile = inactiveProfile.copy(
+                            forcePasswordResetReason =
+                                ForcePasswordResetReason.ADMIN_FORCE_PASSWORD_RESET,
+                        ),
+                    ),
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
     fun `toUpdatedUserStateJson should do nothing for a non-matching account`() {
         val originalUserState = UserStateJson(
             activeUserId = "activeUserId",
@@ -469,7 +604,6 @@ class UserStateJsonExtensionsTest {
                 accounts = mapOf(
                     "activeUserId" to originalAccount.copy(
                         profile = originalProfile.copy(
-                            forcePasswordResetReason = null,
                             userDecryptionOptions = UserDecryptionOptionsJson(
                                 hasMasterPassword = true,
                                 keyConnectorUserDecryptionOptions = null,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41423](https://bitwarden.atlassian.net/browse/PM-41423)

## 📔 Objective

This PR separates the setting of the `ForcePasswordResetReason` from `MasterPasswordUnlockData`. This was fine before but once the SDK starts interacting with the data being stored, we do not want the additional side-affects to occur.


[PM-41423]: https://bitwarden.atlassian.net/browse/PM-41423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ