### PR TITLE
[PM-40529] feat: Add 14-day option to Send deletion date dropdown

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendCustomDateChooser.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendCustomDateChooser.kt
@@ -55,6 +55,8 @@ fun AddEditSendCustomDateChooser(
         CustomDeletionOption.TwoDays to CustomDeletionOption.TwoDays.getText(clock = clock)(),
         CustomDeletionOption.ThreeDays to CustomDeletionOption.ThreeDays.getText(clock = clock)(),
         CustomDeletionOption.SevenDays to CustomDeletionOption.SevenDays.getText(clock = clock)(),
+        CustomDeletionOption.FourteenDays to
+            CustomDeletionOption.FourteenDays.getText(clock = clock)(),
         CustomDeletionOption.ThirtyDays to CustomDeletionOption.ThirtyDays.getText(clock = clock)(),
     )
     var currentSelectionOption: CustomDeletionOption by rememberSaveable(originalSelectionOption) {
@@ -132,6 +134,12 @@ private sealed class CustomDeletionOption : Parcelable {
     data object SevenDays : CustomDeletionOption() {
         override val offsetMillis: Long get() = 7.days.inWholeMilliseconds
         override fun getText(clock: Clock): Text = BitwardenString.seven_days.asText()
+    }
+
+    @Parcelize
+    data object FourteenDays : CustomDeletionOption() {
+        override val offsetMillis: Long get() = 14.days.inWholeMilliseconds
+        override fun getText(clock: Clock): Text = BitwardenString.fourteen_days.asText()
     }
 
     @Parcelize

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendDeletionDateChooser.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendDeletionDateChooser.kt
@@ -78,6 +78,10 @@ private enum class DeletionOption(
         text = BitwardenString.seven_days.asText(),
         offsetMillis = 7.days.inWholeMilliseconds,
     ),
+    FOURTEEN_DAYS(
+        text = BitwardenString.fourteen_days.asText(),
+        offsetMillis = 14.days.inWholeMilliseconds,
+    ),
     THIRTY_DAYS(
         text = BitwardenString.thirty_days.asText(),
         offsetMillis = 30.days.inWholeMilliseconds,

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -502,6 +502,7 @@ Scanning will happen automatically.</string>
     <string name="two_days">2 days</string>
     <string name="three_days">3 days</string>
     <string name="seven_days">7 days</string>
+    <string name="fourteen_days">14 days</string>
     <string name="thirty_days">30 days</string>
     <string name="custom">Custom</string>
     <string name="custom_timeout">Custom timeout</string>


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-40529

## 📔 Objective
Adds a "14 days" choice to the Send deletion date dropdown, sitting between the existing "7 days" and "30 days" options.

Worth calling out: the presets are defined twice, once for each flow. `AddEditSendDeletionDateChooser` handles creating a Send, and `AddEditSendCustomDateChooser` handles editing one (that dropdown also carries the Send's current deletion date at the top of the list). The ticket only mentioned the first file, but both needed the new entry — otherwise "14 days" would show up when creating a Send and quietly go missing when editing one.

Nothing changes on the network side. Picking an option immediately converts it to an absolute timestamp, and that's what gets sent, so the server never sees the preset itself.

## 📸 Screenshots

https://github.com/user-attachments/assets/b0f9f1f8-4481-41c4-9adf-1c3349bee847

