### PR TITLE
PM-41466: feat: Filter out unknown Send types

### DIFF
--- a/core/src/main/kotlin/com/bitwarden/core/data/serializer/SafeListSerializer.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/serializer/SafeListSerializer.kt
@@ -1,6 +1,6 @@
 package com.bitwarden.core.data.serializer
 
-import com.bitwarden.core.data.util.decodeFromJsonElementOrNull
+import com.bitwarden.core.data.util.decodeFromJsonElementForResult
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -8,6 +8,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonArray
+import timber.log.Timber
 
 /**
  * A [KSerializer] for parsing lists of items and allows for the individual items in the array
@@ -30,6 +31,16 @@ class SafeListSerializer<T>(
     ): List<T> = with(decoder as JsonDecoder) {
         decodeJsonElement()
             .jsonArray
-            .mapNotNull { json.decodeFromJsonElementOrNull(innerSerializer, it) }
+            .mapNotNull { element ->
+                json
+                    .decodeFromJsonElementForResult(
+                        deserializer = innerSerializer,
+                        element = element,
+                    )
+                    .getOrElse {
+                        Timber.w(it, "Failed to deserialize element in list")
+                        null
+                    }
+            }
     }
 }

--- a/core/src/main/kotlin/com/bitwarden/core/data/util/JsonExtensions.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/util/JsonExtensions.kt
@@ -7,19 +7,28 @@ import kotlinx.serialization.json.JsonElement
 
 /**
  * Attempts to decode the given JSON [element] into the given type [T]. If there is an error in
+ * processing the JSON or deserializing it to an instance of [T], the error result will be returned.
+ */
+fun <T> Json.decodeFromJsonElementForResult(
+    deserializer: DeserializationStrategy<T>,
+    element: JsonElement,
+): Result<T> =
+    try {
+        decodeFromJsonElement(deserializer = deserializer, element = element).asSuccess()
+    } catch (se: SerializationException) {
+        se.asFailure()
+    } catch (iae: IllegalArgumentException) {
+        iae.asFailure()
+    }
+
+/**
+ * Attempts to decode the given JSON [element] into the given type [T]. If there is an error in
  * processing the JSON or deserializing it to an instance of [T], `null` will be returned.
  */
 fun <T> Json.decodeFromJsonElementOrNull(
     deserializer: DeserializationStrategy<T>,
     element: JsonElement,
-): T? =
-    try {
-        decodeFromJsonElement(deserializer = deserializer, element = element)
-    } catch (_: SerializationException) {
-        null
-    } catch (_: IllegalArgumentException) {
-        null
-    }
+): T? = decodeFromJsonElementForResult(deserializer = deserializer, element = element).getOrNull()
 
 /**
  * Attempts to decode the given JSON [string] into the given type [T]. If there is an error in

--- a/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
@@ -26,9 +26,11 @@ private const val DEFAULT_FIDO_2_KEY_CURVE = "P-256"
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SyncResponseJson(
+    @Contextual
     @SerialName("folders")
     val folders: List<Folder>?,
 
+    @Contextual
     @SerialName("collections")
     val collections: List<Collection>?,
 
@@ -52,6 +54,7 @@ data class SyncResponseJson(
     @JsonNames("Domains")
     val domains: Domains?,
 
+    @Contextual
     @SerialName("sends")
     val sends: List<Send>?,
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41466](https://bitwarden.atlassian.net/browse/PM-41466)

## 📔 Objective

This PR updates the `SyncResponseJson` model to safely handle the list of `Sends`, `Collections`, and `Folders`. if a single item in those lists fail to parse, the item is removed from the list but the rest of the data is still parsed. 

Additionally, a new warning log statement is made when this occurs.


[PM-41466]: https://bitwarden.atlassian.net/browse/PM-41466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ