### PR TITLE
[PM-39840] fix: Scope cookie bootstrap to the request's environment

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerImpl.kt
@@ -87,27 +87,18 @@ class NetworkCookieManagerImpl(
     }
 
     private fun isCookieBootstrapConfigured(hostname: String): Boolean {
-        val isSsoCookieVendor = configDiskSource
+        val bootstrap = configDiskSource
             .serverConfig
             ?.serverData
             ?.communication
             ?.bootstrap
-            ?.type == BOOTSTRAP_TYPE_SSO_COOKIE_VENDOR
-        val result = isSsoCookieVendor && hostnameMatchesCookieDomain(hostname = hostname)
-        Timber.d("isCookieBootstrapConfigured($hostname): $result (cookieDomain=$cookieDomain)")
+            ?.takeIf { it.type == BOOTSTRAP_TYPE_SSO_COOKIE_VENDOR }
+            ?: return false
+        val domain = bootstrap.cookieDomain
+        // No cookie domain configured: cannot scope to an environment, preserve default behavior.
+        val result = domain == null || hostname == domain || hostname.endsWith(".$domain")
+        Timber.d("isCookieBootstrapConfigured($hostname): $result (cookieDomain=$domain)")
         return result
-    }
-
-    /**
-     * Returns `true` when [hostname] is covered by the configured [cookieDomain] — i.e. it is the
-     * cookie domain itself or a subdomain of it.
-     *
-     * When no cookie domain is configured the request cannot be scoped to a specific environment,
-     * so this returns `true` to preserve the default bootstrap behavior.
-     */
-    private fun hostnameMatchesCookieDomain(hostname: String): Boolean {
-        val domain = cookieDomain ?: return true
-        return hostname == domain || hostname.endsWith(".$domain")
     }
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerImpl.kt
@@ -42,27 +42,12 @@ class NetworkCookieManagerImpl(
         )
 
     override fun needsBootstrap(hostname: String): Boolean {
-        val result = configDiskSource
-            .serverConfig
-            ?.serverData
-            ?.communication
-            ?.bootstrap
-            ?.type
-            ?.let { bootstrapType ->
-                when (bootstrapType) {
-                    BOOTSTRAP_TYPE_SSO_COOKIE_VENDOR -> {
-                        val resolved = resolveHostname(hostname)
-                        cookieDiskSource
-                            .getCookieConfig(hostname = resolved)
-                            ?.cookies
-                            ?.none() != false
-                    }
-
-                    else -> false
-                }
-            }
-            ?: false
-        Timber.d("needsBootstrap($hostname): $result (cookieDomain=$cookieDomain)")
+        val result = isCookieBootstrapConfigured(hostname = hostname) &&
+            cookieDiskSource
+                .getCookieConfig(hostname = resolveHostname(hostname))
+                ?.cookies
+                ?.none() != false
+        Timber.d("needsBootstrap($hostname): $result")
         return result
     }
 
@@ -99,6 +84,30 @@ class NetworkCookieManagerImpl(
                 },
             ),
         )
+    }
+
+    private fun isCookieBootstrapConfigured(hostname: String): Boolean {
+        val isSsoCookieVendor = configDiskSource
+            .serverConfig
+            ?.serverData
+            ?.communication
+            ?.bootstrap
+            ?.type == BOOTSTRAP_TYPE_SSO_COOKIE_VENDOR
+        val result = isSsoCookieVendor && hostnameMatchesCookieDomain(hostname = hostname)
+        Timber.d("isCookieBootstrapConfigured($hostname): $result (cookieDomain=$cookieDomain)")
+        return result
+    }
+
+    /**
+     * Returns `true` when [hostname] is covered by the configured [cookieDomain] — i.e. it is the
+     * cookie domain itself or a subdomain of it.
+     *
+     * When no cookie domain is configured the request cannot be scoped to a specific environment,
+     * so this returns `true` to preserve the default bootstrap behavior.
+     */
+    private fun hostnameMatchesCookieDomain(hostname: String): Boolean {
+        val domain = cookieDomain ?: return true
+        return hostname == domain || hostname.endsWith(".$domain")
     }
 
     /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerTest.kt
@@ -200,6 +200,20 @@ class NetworkCookieManagerTest {
         assertTrue(result)
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `needsBootstrap should return true when hostname equals the cookie domain and no cookies`() {
+        fakeConfigDiskSource.serverConfig = createServerConfig(
+            bootstrapType = BOOTSTRAP_TYPE_SSO,
+            cookieDomain = COOKIE_DOMAIN,
+        )
+        every { mockCookieDiskSource.getCookieConfig(any()) } returns null
+
+        val result = manager.needsBootstrap(COOKIE_DOMAIN)
+
+        assertTrue(result)
+    }
+
     @Test
     fun `needsBootstrap should return false when hostname is outside the cookie domain`() {
         fakeConfigDiskSource.serverConfig = createServerConfig(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerTest.kt
@@ -201,6 +201,19 @@ class NetworkCookieManagerTest {
     }
 
     @Test
+    fun `needsBootstrap should return false when hostname is outside the cookie domain`() {
+        fakeConfigDiskSource.serverConfig = createServerConfig(
+            bootstrapType = BOOTSTRAP_TYPE_SSO,
+            cookieDomain = COOKIE_DOMAIN,
+        )
+
+        val result = manager.needsBootstrap(OTHER_ENVIRONMENT_HOSTNAME)
+
+        assertFalse(result)
+        verify(exactly = 0) { mockCookieDiskSource.getCookieConfig(any()) }
+    }
+
+    @Test
     fun `storeCookies should store under cookieDomain when present`() {
         fakeConfigDiskSource.serverConfig = createServerConfig(
             bootstrapType = BOOTSTRAP_TYPE_SSO,
@@ -259,6 +272,7 @@ class NetworkCookieManagerTest {
 private const val HOSTNAME = "vault.bitwarden.com"
 private const val COOKIE_DOMAIN = "bitwarden.com"
 private const val SUBDOMAIN_HOSTNAME = "api.bitwarden.com"
+private const val OTHER_ENVIRONMENT_HOSTNAME = "vault.example.org"
 private const val BOOTSTRAP_TYPE_SSO = "ssoCookieVendor"
 
 private val DEFAULT_COOKIES = listOf(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39840

## 📔 Objective

The SSO cookie-vendor "Sync with Browser" prompt was appearing in the wrong environment. With multiple authenticated accounts and the load-balancer (LB) environment active, switching to a non-LB environment account (or otherwise issuing a request to a different environment) triggered the cookie acquisition prompt even though that environment does not use the load balancer.

Root cause: `NetworkCookieManagerImpl.needsBootstrap(hostname)` decided whether to trigger acquisition using only the *global* server config's bootstrap type (`ssoCookieVendor`) plus whether cookies existed for the host. The server config is stored globally and reflects whichever environment last synced, so a request to a different environment's host matched the LB bootstrap and — finding no cookies stored for that host — wrongly triggered acquisition.

Fix: scope the bootstrap decision to the request's hostname. `needsBootstrap` now only triggers when the host is within the configured `cookieDomain` (the domain the SSO cookie applies to), via a new `hostnameMatchesCookieDomain` check. Requests to hosts outside that domain no longer trigger the prompt, matching the expected behavior: the prompt shows only for the environment that has the load balancer configured.