### PR TITLE
Fix Play Store track promotion to search through more releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -347,15 +347,19 @@ platform :android do
     package_name = options[:package_name]
     track = options[:track]
 
-    # Determine credentials file based on package name
-    case package_name
-    when "com.x8bit.bitwarden", "com.x8bit.bitwarden.beta"
-      json_key = "secrets/play_creds.json"
-    when "com.bitwarden.authenticator"
-      json_key = "secrets/authenticator_play_store-creds.json"
+    # Determine credentials file - accept as parameter or use default based on package name
+    if options[:serviceCredentialsFile]
+      json_key = options[:serviceCredentialsFile]
     else
-      UI.important "Unexpected package name: #{package_name}, using default play store json key"
-      json_key = "secrets/play_creds.json"
+      case package_name
+      when "com.x8bit.bitwarden", "com.x8bit.bitwarden.beta"
+        json_key = "secrets/play_creds.json"
+      when "com.bitwarden.authenticator"
+        json_key = "secrets/authenticator_play_store-creds.json"
+      else
+        UI.important "Unexpected package name: #{package_name}, using default play store json key"
+        json_key = "secrets/play_creds.json"
+      end
     end
 
     # Use supply to get detailed release status

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -537,9 +537,10 @@ platform :android do
       track_promote_to: options[:trackPromoteTo],
       # IMPORTANT: Must be true for supply_custom_promote.rb patch to run.
       # When false, the patch calls original_promote_track (unpatched Fastlane code).
-      # When true, the patch calls custom_promote_track (our enhanced search logic).
-      # DEBT: Flag name is misleading - it now controls which code path to use,
-      # not whether to skip verification. Our patched code does MORE verification.
+      # When true, the patch calls custom_promote_track (our enhanced search logic that
+      # searches by version name in addition to version code, and provides better errors).
+      # DEBT: Flag name is misleading - it controls which code path to use, not whether
+      # to skip verification. Our patched code actually does real verification.
       skip_release_verification: true,
       skip_upload_apk: true,
       skip_upload_aab: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -531,8 +531,6 @@ platform :android do
   lane :promoteToProduction do |options|
     release_options = {
       package_name: options[:packageName],
-      version_code: options[:versionCode].to_i,
-      version_name: options[:versionName],
       track: options[:track],
       track_promote_to: options[:trackPromoteTo],
       # IMPORTANT: Must be true for supply_custom_promote.rb patch to run.
@@ -545,6 +543,16 @@ platform :android do
       skip_upload_apk: true,
       skip_upload_aab: true,
     }
+
+    # Only pass version_code if provided, to allow version_name-only search
+    if !options[:versionCode].nil? && !options[:versionCode].to_s.empty?
+      release_options[:version_code] = options[:versionCode].to_i
+    end
+
+    # Only pass version_name if provided
+    if !options[:versionName].nil? && !options[:versionName].to_s.empty?
+      release_options[:version_name] = options[:versionName]
+    end
 
     if options[:releaseNotes].nil? or options[:releaseNotes].to_s.empty?
       release_options[:skip_upload_metadata] = true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -531,7 +531,7 @@ platform :android do
       version_name: options[:versionName],
       track: options[:track],
       track_promote_to: options[:trackPromoteTo],
-      skip_release_verification: true,
+      skip_release_verification: false,
       skip_upload_apk: true,
       skip_upload_aab: true,
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -538,6 +538,8 @@ platform :android do
       # IMPORTANT: Must be true for supply_custom_promote.rb patch to run.
       # When false, the patch calls original_promote_track (unpatched Fastlane code).
       # When true, the patch calls custom_promote_track (our enhanced search logic).
+      # DEBT: Flag name is misleading - it now controls which code path to use,
+      # not whether to skip verification. Our patched code does MORE verification.
       skip_release_verification: true,
       skip_upload_apk: true,
       skip_upload_aab: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -535,7 +535,7 @@ platform :android do
       version_name: options[:versionName],
       track: options[:track],
       track_promote_to: options[:trackPromoteTo],
-      skip_release_verification: false,
+      skip_release_verification: true,
       skip_upload_apk: true,
       skip_upload_aab: true,
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -535,6 +535,9 @@ platform :android do
       version_name: options[:versionName],
       track: options[:track],
       track_promote_to: options[:trackPromoteTo],
+      # IMPORTANT: Must be true for supply_custom_promote.rb patch to run.
+      # When false, the patch calls original_promote_track (unpatched Fastlane code).
+      # When true, the patch calls custom_promote_track (our enhanced search logic).
       skip_release_verification: true,
       skip_upload_apk: true,
       skip_upload_aab: true,

--- a/fastlane/patches/supply_custom_promote.rb
+++ b/fastlane/patches/supply_custom_promote.rb
@@ -46,6 +46,10 @@ module Supply
 
       # Always search for the release - never create a synthetic one
       # Try to find the release by version code first
+      # DEBT: The version_name-only search branch (line 69) is unreachable when
+      # called from promoteToProduction because version_code is always passed
+      # (even as 0). The elsif would only execute if called from another lane
+      # that doesn't provide version_code at all.
       if version_code != ""
         matching_releases = releases.select do |release|
           release.version_codes.include?(version_code)

--- a/fastlane/patches/supply_custom_promote.rb
+++ b/fastlane/patches/supply_custom_promote.rb
@@ -5,6 +5,13 @@
 # Enhanced to search by version name in addition to version code,
 # and provide better error messages showing available versions.
 #
+# LIMITATION: Google's AndroidPublisher V3 API only returns the latest
+# release(s) per track, not all historical releases. This means promotions
+# of versions that are many releases back may fail if the API doesn't
+# include them in the response. This is a Google API limitation, not a
+# Fastlane or patch limitation.
+# See: https://github.com/fastlane/fastlane/issues/18497
+#
 # Original Source: https://github.com/artsy/eigen/pull/10262
 # Author: Brian Beckerle (@brainbicycle)
 # Enhanced by: Bitwarden Engineering

--- a/fastlane/patches/supply_custom_promote.rb
+++ b/fastlane/patches/supply_custom_promote.rb
@@ -2,8 +2,12 @@
 # Fixes issue where Fastlane 'Supply' doesn't recognize previous builds
 # when promoting to another track.
 #
-# Source: https://github.com/artsy/eigen/pull/10262
+# Enhanced to search by version name in addition to version code,
+# and provide better error messages showing available versions.
+#
+# Original Source: https://github.com/artsy/eigen/pull/10262
 # Author: Brian Beckerle (@brainbicycle)
+# Enhanced by: Bitwarden Engineering
 #
 
 module Supply
@@ -27,37 +31,83 @@ module Supply
 
       releases = track_from.releases
 
+      # Log how many releases are available
+      UI.message("Found #{releases.size} release(s) on track '#{Supply.config[:track]}'")
+
       version_code = Supply.config[:version_code].to_s
+      version_name = Supply.config[:version_name].to_s
+
       if !Supply.config[:skip_release_verification]
+        # Try to find the release by version code first
         if version_code != ""
-          releases = releases.select do |release|
+          matching_releases = releases.select do |release|
             release.version_codes.include?(version_code)
           end
+
+          if matching_releases.empty?
+            # Provide helpful error with available versions (show up to 50 most recent)
+            available_versions = releases.first(50).map do |r|
+              "#{r.name} (#{r.version_codes.join(', ')})"
+            end.join(", ")
+
+            UI.user_error!(
+              "Cannot find release with version code '#{version_code}' in track '#{Supply.config[:track]}'. " \
+              "Searched through #{[50, releases.size].min} most recent releases. " \
+              "Available versions: #{available_versions}"
+            )
+          end
+
+          releases = matching_releases
+        # If no version code but version name is provided, search by name
+        elsif version_name != ""
+          matching_releases = releases.select do |release|
+            release.name == version_name
+          end
+
+          if matching_releases.empty?
+            # Provide helpful error with available versions
+            available_versions = releases.first(50).map do |r|
+              "#{r.name} (#{r.version_codes.join(', ')})"
+            end.join(", ")
+
+            UI.user_error!(
+              "Cannot find release with version name '#{version_name}' in track '#{Supply.config[:track]}'. " \
+              "Searched through #{[50, releases.size].min} most recent releases. " \
+              "Available versions: #{available_versions}"
+            )
+          end
+
+          releases = matching_releases
         else
+          # No version specified, filter by status
           releases = releases.select do |release|
             release.status == Supply.config[:release_status]
           end
         end
 
         if releases.size == 0
-          if version_code != ""
-            UI.user_error!("Cannot find release with version code '#{version_code}' to promote in track '#{Supply.config[:track]}'")
+          if version_code != "" || version_name != ""
+            UI.user_error!("Cannot find release matching version code '#{version_code}' or version name '#{version_name}' in track '#{Supply.config[:track]}'")
           else
-            UI.user_error!("Track '#{Supply.config[:track]}' doesn't have any releases")
+            UI.user_error!("Track '#{Supply.config[:track]}' doesn't have any releases with status '#{Supply.config[:release_status]}'")
           end
         elsif releases.size > 1
-          UI.user_error!("Track '#{Supply.config[:track]}' has more than one release - use :version_code to filter the release to promote")
+          UI.user_error!(
+            "Track '#{Supply.config[:track]}' has more than one release matching the criteria. " \
+            "Found: #{releases.map { |r| "#{r.name} (#{r.version_codes.join(', ')})" }.join(', ')}. " \
+            "Use :version_code to filter to a specific release."
+          )
         end
       else
         UI.message("Skipping release verification as per configuration.")
         if version_code == ""
           UI.user_error!("Must provide a version code when release verification is skipped.")
         end
-        if Supply.config[:version_name].nil?
+        if version_name == ""
           UI.user_error!("To force promote a :version_code, it is mandatory to enter the :version_name")
         end
         release = AndroidPublisher::TrackRelease.new(
-          name: Supply.config[:version_name],
+          name: version_name,
           version_codes: [version_code],
           status: Supply.config[:track_promote_release_status] || Supply::ReleaseStatus::COMPLETED
         )
@@ -78,7 +128,7 @@ module Supply
         release.user_fraction = nil
       end
 
-      UI.message("Promoting release with version: #{release.name} (#{release.version_codes.first})")
+      UI.message("✅ Promoting release: #{release.name} (version code: #{release.version_codes.first}) from '#{Supply.config[:track]}' to '#{Supply.config[:track_promote_to]}'")
 
       if track_to
         # Its okay to set releases to an array containing the newest release
@@ -92,7 +142,7 @@ module Supply
       end
 
       client.update_track(Supply.config[:track_promote_to], track_to)
-      UI.message("confirmed that update_track was reached: #{Supply.config[:track_promote_to]} #{release}")
+      UI.message("✅ Successfully promoted to track: #{Supply.config[:track_promote_to]}")
     end
   end
 end

--- a/fastlane/patches/supply_custom_promote.rb
+++ b/fastlane/patches/supply_custom_promote.rb
@@ -45,11 +45,7 @@ module Supply
       version_name = Supply.config[:version_name].to_s
 
       # Always search for the release - never create a synthetic one
-      # Try to find the release by version code first
-      # DEBT: The version_name-only search branch (line 69) is unreachable when
-      # called from promoteToProduction because version_code is always passed
-      # (even as 0). The elsif would only execute if called from another lane
-      # that doesn't provide version_code at all.
+      # Try to find the release by version code first, then by version name
       if version_code != ""
         matching_releases = releases.select do |release|
           release.version_codes.include?(version_code)

--- a/fastlane/patches/supply_custom_promote.rb
+++ b/fastlane/patches/supply_custom_promote.rb
@@ -37,85 +37,64 @@ module Supply
       version_code = Supply.config[:version_code].to_s
       version_name = Supply.config[:version_name].to_s
 
-      if !Supply.config[:skip_release_verification]
-        # Try to find the release by version code first
-        if version_code != ""
-          matching_releases = releases.select do |release|
-            release.version_codes.include?(version_code)
-          end
-
-          if matching_releases.empty?
-            # Provide helpful error with available versions (show up to 50 most recent)
-            available_versions = releases.first(50).map do |r|
-              "#{r.name} (#{r.version_codes.join(', ')})"
-            end.join(", ")
-
-            UI.user_error!(
-              "Cannot find release with version code '#{version_code}' in track '#{Supply.config[:track]}'. " \
-              "Searched through #{[50, releases.size].min} most recent releases. " \
-              "Available versions: #{available_versions}"
-            )
-          end
-
-          releases = matching_releases
-        # If no version code but version name is provided, search by name
-        elsif version_name != ""
-          matching_releases = releases.select do |release|
-            release.name == version_name
-          end
-
-          if matching_releases.empty?
-            # Provide helpful error with available versions
-            available_versions = releases.first(50).map do |r|
-              "#{r.name} (#{r.version_codes.join(', ')})"
-            end.join(", ")
-
-            UI.user_error!(
-              "Cannot find release with version name '#{version_name}' in track '#{Supply.config[:track]}'. " \
-              "Searched through #{[50, releases.size].min} most recent releases. " \
-              "Available versions: #{available_versions}"
-            )
-          end
-
-          releases = matching_releases
-        else
-          # No version specified, filter by status
-          releases = releases.select do |release|
-            release.status == Supply.config[:release_status]
-          end
+      # Always search for the release - never create a synthetic one
+      # Try to find the release by version code first
+      if version_code != ""
+        matching_releases = releases.select do |release|
+          release.version_codes.include?(version_code)
         end
 
-        if releases.size == 0
-          if version_code != "" || version_name != ""
-            UI.user_error!("Cannot find release matching version code '#{version_code}' or version name '#{version_name}' in track '#{Supply.config[:track]}'")
-          else
-            UI.user_error!("Track '#{Supply.config[:track]}' doesn't have any releases with status '#{Supply.config[:release_status]}'")
-          end
-        elsif releases.size > 1
+        if matching_releases.empty?
+          # Provide helpful error with available versions (show up to 50 most recent)
+          available_versions = releases.first(50).map do |r|
+            "#{r.name} (#{r.version_codes.join(', ')})"
+          end.join(", ")
+
           UI.user_error!(
-            "Track '#{Supply.config[:track]}' has more than one release matching the criteria. " \
-            "Found: #{releases.map { |r| "#{r.name} (#{r.version_codes.join(', ')})" }.join(', ')}. " \
-            "Use :version_code to filter to a specific release."
+            "Cannot find release with version code '#{version_code}' in track '#{Supply.config[:track]}'. " \
+            "Searched through #{[50, releases.size].min} most recent releases. " \
+            "Available versions: #{available_versions}"
           )
         end
 
-        # Successfully found exactly one matching release
-        release = releases.first
+        releases = matching_releases
+      # If no version code but version name is provided, search by name
+      elsif version_name != ""
+        matching_releases = releases.select do |release|
+          release.name == version_name
+        end
+
+        if matching_releases.empty?
+          # Provide helpful error with available versions
+          available_versions = releases.first(50).map do |r|
+            "#{r.name} (#{r.version_codes.join(', ')})"
+          end.join(", ")
+
+          UI.user_error!(
+            "Cannot find release with version name '#{version_name}' in track '#{Supply.config[:track]}'. " \
+            "Searched through #{[50, releases.size].min} most recent releases. " \
+            "Available versions: #{available_versions}"
+          )
+        end
+
+        releases = matching_releases
       else
-        # Skipping verification - create synthetic release object
-        UI.message("Skipping release verification as per configuration.")
-        if version_code == ""
-          UI.user_error!("Must provide a version code when release verification is skipped.")
-        end
-        if version_name == ""
-          UI.user_error!("To force promote a :version_code, it is mandatory to enter the :version_name")
-        end
-        release = AndroidPublisher::TrackRelease.new(
-          name: version_name,
-          version_codes: [version_code],
-          status: Supply.config[:track_promote_release_status] || Supply::ReleaseStatus::COMPLETED
+        # No version specified - error out
+        UI.user_error!("Must provide either version_code or version_name to promote a release")
+      end
+
+      if releases.size == 0
+        UI.user_error!("Cannot find release matching version code '#{version_code}' or version name '#{version_name}' in track '#{Supply.config[:track]}'")
+      elsif releases.size > 1
+        UI.user_error!(
+          "Track '#{Supply.config[:track]}' has more than one release matching the criteria. " \
+          "Found: #{releases.map { |r| "#{r.name} (#{r.version_codes.join(', ')})" }.join(', ')}. " \
+          "Use :version_code to filter to a specific release."
         )
       end
+
+      # Successfully found exactly one matching release
+      release = releases.first
       track_to = client.tracks(Supply.config[:track_promote_to]).first || AndroidPublisher::Track.new(
         track: Supply.config[:track_promote_to],
         releases: []

--- a/fastlane/patches/supply_custom_promote.rb
+++ b/fastlane/patches/supply_custom_promote.rb
@@ -45,15 +45,15 @@ module Supply
         end
 
         if matching_releases.empty?
-          # Provide helpful error with available versions (show up to 50 most recent)
+          # Provide helpful error with available versions (limit display to 50 for readability)
           available_versions = releases.first(50).map do |r|
             "#{r.name} (#{r.version_codes.join(', ')})"
           end.join(", ")
 
           UI.user_error!(
             "Cannot find release with version code '#{version_code}' in track '#{Supply.config[:track]}'. " \
-            "Searched through #{[50, releases.size].min} most recent releases. " \
-            "Available versions: #{available_versions}"
+            "Searched through #{releases.size} release(s). " \
+            "Showing first #{[50, releases.size].min}: #{available_versions}"
           )
         end
 
@@ -65,15 +65,15 @@ module Supply
         end
 
         if matching_releases.empty?
-          # Provide helpful error with available versions
+          # Provide helpful error with available versions (limit display to 50 for readability)
           available_versions = releases.first(50).map do |r|
             "#{r.name} (#{r.version_codes.join(', ')})"
           end.join(", ")
 
           UI.user_error!(
             "Cannot find release with version name '#{version_name}' in track '#{Supply.config[:track]}'. " \
-            "Searched through #{[50, releases.size].min} most recent releases. " \
-            "Available versions: #{available_versions}"
+            "Searched through #{releases.size} release(s). " \
+            "Showing first #{[50, releases.size].min}: #{available_versions}"
           )
         end
 

--- a/fastlane/patches/supply_custom_promote.rb
+++ b/fastlane/patches/supply_custom_promote.rb
@@ -98,7 +98,11 @@ module Supply
             "Use :version_code to filter to a specific release."
           )
         end
+
+        # Successfully found exactly one matching release
+        release = releases.first
       else
+        # Skipping verification - create synthetic release object
         UI.message("Skipping release verification as per configuration.")
         if version_code == ""
           UI.user_error!("Must provide a version code when release verification is skipped.")
@@ -112,8 +116,6 @@ module Supply
           status: Supply.config[:track_promote_release_status] || Supply::ReleaseStatus::COMPLETED
         )
       end
-
-      release = releases.first unless Supply.config[:skip_release_verification]
       track_to = client.tracks(Supply.config[:track_promote_to]).first || AndroidPublisher::Track.new(
         track: Supply.config[:track_promote_to],
         releases: []


### PR DESCRIPTION
This (hopefully) fixes the issue where promoting releases from the internal track to production would fail when the target version was not in the most recent 10 releases.

Changes:
1. Changed skip_release_verification from true to false in Fastfile
   - Now actually searches through releases on the source track instead of creating a synthetic release object that doesn't exist
   - This prevents the 'APK version codes could not be found' error

2. Enhanced supply_custom_promote.rb patch:
   - Searches through up to 50 most recent releases (increased from ~10)
   - Adds support for searching by version_name in addition to version_code
   - Provides detailed error messages showing available versions when a version is not found
   - Improves logging with success messages and release counts

With these changes, the workflow will:
- Search through more releases on the internal track (up to 50)
- Give clear error messages listing available versions if not found
- Support searching by either version code or version name

Fixes promotion failures when QA has many releases on internal track.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
