### PR TITLE
Auth/ PM-41503 & PM-41533 - Add openOrgInvite param to SDK registration finish call

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceImpl.kt
@@ -124,6 +124,7 @@ class AuthSdkSourceImpl(
                         providerInviteToken = null,
                         providerUserId = null,
                         salesAssistedToken = null,
+                        openOrgInvite = null,
                     ),
                 )
             }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceTest.kt
@@ -238,6 +238,7 @@ class AuthSdkSourceTest {
                         providerInviteToken = null,
                         providerUserId = null,
                         salesAssistedToken = null,
+                        openOrgInvite = null,
                     ),
                 )
             } returns expectedResult
@@ -267,6 +268,7 @@ class AuthSdkSourceTest {
                         providerInviteToken = null,
                         providerUserId = null,
                         salesAssistedToken = null,
+                        openOrgInvite = null,
                     ),
                 )
             }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41503
https://bitwarden.atlassian.net/browse/PM-41533

Server PR: https://github.com/bitwarden/server/pull/8159
Server SDK Bindings Update PR: https://github.com/bitwarden/sdk-internal/pull/1372
SDK PR which wires up breaking changes: https://github.com/bitwarden/sdk-internal/pull/1363 


## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The SDK's `UserMasterPasswordRegistrationRequest` gains a new `openOrgInvite` field (`Option<RegistrationFinishOpenOrgInviteData>`) to support finishing registration via an open organization invite link once https://github.com/bitwarden/sdk-internal/pull/1363 merges. Android does not use open-org-invite (that flow is web-only), so this passes `null` at the production call site and the two matching test expectations to satisfy the new required constructor parameter.


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
n/a