### PR TITLE
[PM-40532] feat: Lock the Send deletion date when enforced by the SendControls policy

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
@@ -62,6 +62,7 @@ import com.x8bit.bitwarden.ui.tools.feature.send.addedit.handlers.AddEditSendHan
 @Composable
 fun AddEditSendContent(
     state: AddEditSendState.ViewState.Content,
+    enforcedDeletionHours: Int?,
     policyDisablesSend: Boolean,
     policySendOptionsInEffect: Boolean,
     shouldHideEmailAddressToggle: Boolean,
@@ -141,6 +142,7 @@ fun AddEditSendContent(
 
         if (isAddMode) {
             AddEditSendDeletionDateChooser(
+                enforcedDeletionHours = enforcedDeletionHours,
                 onDateSelect = addSendHandlers.onDeletionDateChange,
                 isEnabled = !policyDisablesSend,
                 modifier = Modifier
@@ -151,8 +153,9 @@ fun AddEditSendContent(
         } else {
             AddEditSendCustomDateChooser(
                 originalSelection = state.common.deletionDate,
-                isEnabled = !policyDisablesSend,
                 onDateSelect = addSendHandlers.onDeletionDateChange,
+                isDeletionDateEnforced = enforcedDeletionHours != null,
+                isEnabled = !policyDisablesSend,
                 modifier = Modifier
                     .testTag("SendCustomDeletionDatePicker")
                     .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
@@ -173,6 +173,7 @@ fun AddEditSendScreen(
         when (val viewState = state.viewState) {
             is AddEditSendState.ViewState.Content -> AddEditSendContent(
                 state = viewState,
+                enforcedDeletionHours = state.enforcedDeletionHours,
                 policyDisablesSend = state.policyDisablesSend,
                 policySendOptionsInEffect = state.shouldDisplayPolicyWarning,
                 shouldHideEmailAddressToggle = state.shouldHideEmailAddressToggle,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -422,13 +422,13 @@ class AddEditSendViewModel @Inject constructor(
         action: AddEditSendAction.Internal.EffectiveSendPolicyReceive,
     ) {
         val effectiveSendPolicy = action.effectiveSendPolicy
-        val enforcedDeletionHours = effectiveSendPolicy
+        val newEnforcedDeletionHours = effectiveSendPolicy
             .deletionHours
             ?.takeIf { action.isSendControlsEnabled }
         // Captured before the state is updated below, since detecting a dropped enforcement
         // requires the previous value of `enforcedDeletionHours`.
         val newDeletionDate = state.newDeletionDateOrNull(
-            enforcedDeletionHours = enforcedDeletionHours,
+            newEnforcedDeletionHours = newEnforcedDeletionHours,
         )
         mutableStateFlow.update { currentState ->
             currentState.copy(
@@ -457,11 +457,12 @@ class AddEditSendViewModel @Inject constructor(
      * restores the default window, so the chooser and the state cannot disagree once the chooser
      * unlocks.
      */
-    private fun AddEditSendState.newDeletionDateOrNull(enforcedDeletionHours: Int?): Instant? {
+    private fun AddEditSendState.newDeletionDateOrNull(newEnforcedDeletionHours: Int?): Instant? {
         if (!isAddMode) return null
         val hours = when {
-            enforcedDeletionHours != null -> enforcedDeletionHours.toLong()
-            this.enforcedDeletionHours != null -> DEFAULT_DELETION_HOURS
+            newEnforcedDeletionHours != null -> newEnforcedDeletionHours.toLong()
+            // The enforcement was just dropped, so the default window is restored.
+            enforcedDeletionHours != null -> DEFAULT_DELETION_HOURS
             else -> return null
         }
         return clock.instant().plus(hours, ChronoUnit.HOURS)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -67,6 +67,11 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
+/**
+ * The deletion window applied to a new Send when no deletion date is enforced by policy (7 days).
+ */
+private const val DEFAULT_DELETION_HOURS: Long = 7 * 24L
+
 private const val KEY_STATE = "state"
 
 /**
@@ -103,6 +108,7 @@ class AddEditSendViewModel @Inject constructor(
         val sendType = args.sendType
         val addEditSendType = args.addEditSendType
         val effectiveSendPolicy = policyManager.getEffectiveSendPolicy()
+        val isSendControlsEnabled = featureFlagManager.getFeatureFlag(key = FlagKey.SendControls)
 
         AddEditSendState(
             sendType = sendType,
@@ -120,9 +126,14 @@ class AddEditSendViewModel @Inject constructor(
                         isHideEmailChecked = false,
                         isDeactivateChecked = false,
                         isHideEmailAddressEnabled = !effectiveSendPolicy.disableHideEmail,
-                        deletionDate = clock
-                            .instant()
-                            .plus(@Suppress("MagicNumber") 7, ChronoUnit.DAYS),
+                        deletionDate = clock.instant().plus(
+                            effectiveSendPolicy
+                                .deletionHours
+                                ?.takeIf { isSendControlsEnabled }
+                                ?.toLong()
+                                ?: DEFAULT_DELETION_HOURS,
+                            ChronoUnit.HOURS,
+                        ),
                         expirationDate = null,
                         sendUrl = null,
                         hasPassword = false,
@@ -152,7 +163,7 @@ class AddEditSendViewModel @Inject constructor(
             dialogState = null,
             baseWebSendUrl = environmentRepo.environment.baseWebSendUrl,
             policyDisablesSend = effectiveSendPolicy.disableSend,
-            isSendControlsEnabled = featureFlagManager.getFeatureFlag(key = FlagKey.SendControls),
+            isSendControlsEnabled = isSendControlsEnabled,
             allowedDomains = effectiveSendPolicy.allowedDomains,
             allowedSendTypes = effectiveSendPolicy.allowedSendTypes,
             deletionHours = effectiveSendPolicy.deletionHours,
@@ -411,6 +422,9 @@ class AddEditSendViewModel @Inject constructor(
         action: AddEditSendAction.Internal.EffectiveSendPolicyReceive,
     ) {
         val effectiveSendPolicy = action.effectiveSendPolicy
+        val enforcedDeletionHours = effectiveSendPolicy
+            .deletionHours
+            ?.takeIf { action.isSendControlsEnabled }
         mutableStateFlow.update { currentState ->
             currentState.copy(
                 policyDisablesSend = effectiveSendPolicy.disableSend,
@@ -424,12 +438,35 @@ class AddEditSendViewModel @Inject constructor(
                         content.copy(
                             common = content.common.copy(
                                 isHideEmailAddressEnabled = !effectiveSendPolicy.disableHideEmail,
+                                deletionDate = currentState.newDeletionDateOrNull(
+                                    enforcedDeletionHours = enforcedDeletionHours,
+                                )
+                                    ?: content.common.deletionDate,
                             ),
                         )
                     }
                     ?: currentState.viewState,
             )
         }
+    }
+
+    /**
+     * Returns the deletion date a new Send should adopt in response to a policy change, or `null`
+     * when the current date should be left alone.
+     *
+     * Only a new Send is affected — an existing Send keeps the deletion date it was created with.
+     * Dropping the enforcement (the policy is lifted or the SendControls flag is turned off)
+     * restores the default window, so the chooser and the state cannot disagree once the chooser
+     * unlocks.
+     */
+    private fun AddEditSendState.newDeletionDateOrNull(enforcedDeletionHours: Int?): Instant? {
+        if (!isAddMode) return null
+        val hours = when {
+            enforcedDeletionHours != null -> enforcedDeletionHours.toLong()
+            this.enforcedDeletionHours != null -> DEFAULT_DELETION_HOURS
+            else -> return null
+        }
+        return clock.instant().plus(hours, ChronoUnit.HOURS)
     }
 
     @Suppress("LongMethod")
@@ -960,6 +997,13 @@ data class AddEditSendState(
     val whoCanAccess: SendAccessTypeJson?,
     val isPremium: Boolean,
 ) : Parcelable {
+
+    /**
+     * Helper to determine the Send deletion window enforced by the SendControls policy, or `null`
+     * when the deletion date is left to the user. The legacy send options policy has no equivalent
+     * enforcement, so this is only in effect alongside the SendControls feature flag.
+     */
+    val enforcedDeletionHours: Int? get() = deletionHours.takeIf { isSendControlsEnabled }
 
     /**
      * Helper to determine the screen display name.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendCustomDateChooser.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendCustomDateChooser.kt
@@ -33,6 +33,8 @@ import kotlin.time.Duration.Companion.hours
  * @param originalSelection The originally selected time value, this cannot be changed after being
  * set.
  * @param onDateSelect The callback for being notified of updates to the selected date and time.
+ * @param isDeletionDateEnforced Whether the SendControls policy enforces the deletion date. When
+ * enforced, the button is locked and continues to display the [originalSelection].
  * @param isEnabled Whether the button is enabled.
  * @param modifier A [Modifier] that you can use to apply custom modifications to the composable.
  * @param clock The clock used for formatting and timezone purposes.
@@ -41,6 +43,7 @@ import kotlin.time.Duration.Companion.hours
 fun AddEditSendCustomDateChooser(
     originalSelection: Instant,
     onDateSelect: (Instant) -> Unit,
+    isDeletionDateEnforced: Boolean,
     isEnabled: Boolean,
     modifier: Modifier = Modifier,
     clock: Clock = LocalClock.current,
@@ -64,7 +67,7 @@ fun AddEditSendCustomDateChooser(
     }
     BitwardenMultiSelectButton(
         label = stringResource(id = BitwardenString.deletion_date),
-        isEnabled = isEnabled,
+        isEnabled = isEnabled && !isDeletionDateEnforced,
         options = options.values.toImmutableList(),
         selectedOption = currentSelectionOption.getText(clock = clock).invoke(),
         onOptionSelected = { selected ->
@@ -77,7 +80,13 @@ fun AddEditSendCustomDateChooser(
                         .plus(currentSelectionOption.offsetMillis, ChronoUnit.MILLIS),
             )
         },
-        supportingText = stringResource(id = BitwardenString.deletion_date_info),
+        supportingText = stringResource(
+            id = if (isDeletionDateEnforced) {
+                BitwardenString.this_date_is_enforced_by_your_organization
+            } else {
+                BitwardenString.deletion_date_info
+            },
+        ),
         insets = PaddingValues(top = 6.dp, bottom = 4.dp),
         cardStyle = CardStyle.Full,
         modifier = modifier,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendDeletionDateChooser.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendDeletionDateChooser.kt
@@ -24,30 +24,48 @@ import kotlin.time.Duration.Companion.hours
 
 /**
  * Displays UX for choosing deletion date of a send.
+ *
+ * @param enforcedDeletionHours The deletion window enforced by the SendControls policy, or `null`
+ * when no deletion date is enforced. When enforced, the matching option is selected and the button
+ * is locked.
+ * @param onDateSelect The callback for being notified of updates to the selected date.
+ * @param isEnabled Whether the button is enabled.
+ * @param modifier A [Modifier] that you can use to apply custom modifications to the composable.
+ * @param clock The clock used for calculating the selected date.
  */
 @Composable
 fun AddEditSendDeletionDateChooser(
+    enforcedDeletionHours: Int?,
     onDateSelect: (Instant) -> Unit,
     isEnabled: Boolean,
     modifier: Modifier = Modifier,
     clock: Clock = LocalClock.current,
 ) {
     val options = DeletionOption.entries.associateWith { it.text() }
+    val enforcedOption = enforcedDeletionHours?.let { hours ->
+        DeletionOption.entries.firstOrNull {
+            it.offsetMillis == hours.hours.inWholeMilliseconds
+        }
+    }
     var selectedOption: DeletionOption by rememberSaveable {
         mutableStateOf(value = DeletionOption.SEVEN_DAYS)
     }
     BitwardenMultiSelectButton(
         label = stringResource(id = BitwardenString.deletion_date),
-        isEnabled = isEnabled,
+        isEnabled = isEnabled && enforcedDeletionHours == null,
         options = options.values.toImmutableList(),
-        selectedOption = selectedOption.text(),
+        selectedOption = (enforcedOption ?: selectedOption).text(),
         onOptionSelected = { selected ->
             selectedOption = options.entries.first { it.value == selected }.key
             onDateSelect(
                 clock.instant().plus(selectedOption.offsetMillis, ChronoUnit.MILLIS),
             )
         },
-        supportingText = stringResource(id = BitwardenString.deletion_date_info),
+        supportingText = stringResource(
+            id = enforcedDeletionHours
+                ?.let { BitwardenString.this_date_is_enforced_by_your_organization }
+                ?: BitwardenString.deletion_date_info,
+        ),
         insets = PaddingValues(top = 6.dp, bottom = 4.dp),
         cardStyle = CardStyle.Full,
         modifier = modifier,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -465,6 +465,117 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deletion date chooser should not open its options when enforced by policy`() {
+        mutableStateFlow.update {
+            it.copy(isSendControlsEnabled = true, deletionHours = 168)
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Deletion date")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(text = "1 hour")
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithText(text = "This date is enforced by your organization")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deletion date chooser should display the enforced option when the policy maps to one`() {
+        mutableStateFlow.update {
+            it.copy(isSendControlsEnabled = true, deletionHours = 24)
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "1 day")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `custom deletion date chooser should not open its options when enforced by policy`() {
+        mutableStateFlow.update {
+            it.copy(
+                addEditSendType = AddEditSendType.EditItem(sendItemId = "sendId"),
+                isSendControlsEnabled = true,
+                deletionHours = 168,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Deletion date")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(text = "1 hour")
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithText(text = "This date is enforced by your organization")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deletion date chooser should open its options when send controls is disabled`() {
+        mutableStateFlow.update {
+            it.copy(isSendControlsEnabled = false, deletionHours = 168)
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "This date is enforced by your organization")
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithText(
+                text = "The Send will be permanently deleted on the specified date and time.",
+            )
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(text = "Deletion date")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(text = "1 hour")
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `custom deletion date chooser should open its options when send controls is disabled`() {
+        mutableStateFlow.update {
+            it.copy(
+                addEditSendType = AddEditSendType.EditItem(sendItemId = "sendId"),
+                isSendControlsEnabled = false,
+                deletionHours = 168,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "This date is enforced by your organization")
+            .assertDoesNotExist()
+
+        composeTestRule
+            .onNodeWithText(text = "Deletion date")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(text = "1 hour")
+            .assertIsDisplayed()
+    }
+
     @Test
     fun `on name input change should send NameChange`() {
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -58,7 +58,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -287,22 +286,6 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
                 )
             }
         }
-
-    @Test
-    fun `enforcedDeletionHours should only be populated when send controls is enabled`() {
-        mutableEffectiveSendPolicyFlow.value =
-            DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
-
-        val flagOffState = createViewModel().stateFlow.value
-        assertEquals(DEFAULT_STATE.copy(deletionHours = ENFORCED_DELETION_HOURS), flagOffState)
-        assertNull(flagOffState.enforcedDeletionHours)
-
-        mutableSendControlsFlagFlow.value = true
-
-        val flagOnState = createViewModel().stateFlow.value
-        assertEquals(ENFORCED_DELETION_STATE, flagOnState)
-        assertEquals(ENFORCED_DELETION_HOURS, flagOnState.enforcedDeletionHours)
-    }
 
     @Test
     fun `deletion date should not change when the policy changes with send controls off`() =

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -219,8 +220,162 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
             }
         }
 
+    private fun AddEditSendState.deletionDateOrNull(): Instant? =
+        (viewState as? AddEditSendState.ViewState.Content)?.common?.deletionDate
+
     private fun AddEditSendState.isHideEmailAddressEnabledOrNull(): Boolean? =
         (viewState as? AddEditSendState.ViewState.Content)?.common?.isHideEmailAddressEnabled
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `initial state should use the enforced deletion window when send controls is enabled`() {
+        mutableSendControlsFlagFlow.value = true
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
+
+        val state = createViewModel().stateFlow.value
+
+        assertEquals(ENFORCED_DELETION_HOURS, state.enforcedDeletionHours)
+        assertEquals(ENFORCED_DELETION_DATE, state.deletionDateOrNull())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `initial state should use the default deletion window when send controls is disabled`() {
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
+
+        val state = createViewModel().stateFlow.value
+
+        assertNull(state.enforcedDeletionHours)
+        assertEquals(DEFAULT_COMMON_STATE.deletionDate, state.deletionDateOrNull())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deletion date should update when the enforced deletion window changes in add mode`() =
+        runTest {
+            mutableSendControlsFlagFlow.value = true
+            val viewModel = createViewModel()
+
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_COMMON_STATE.deletionDate, awaitItem().deletionDateOrNull())
+
+                mutableEffectiveSendPolicyFlow.value =
+                    DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
+
+                assertEquals(ENFORCED_DELETION_DATE, awaitItem().deletionDateOrNull())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deletion date should not change when the enforced deletion window changes in edit mode`() =
+        runTest {
+            mutableSendControlsFlagFlow.value = true
+            val sendId = "sendId-1"
+            val mockSendView = createMockSendView(number = 1)
+            every {
+                mockSendView.toViewState(
+                    baseWebSendUrl = DEFAULT_ENVIRONMENT_URL,
+                    isHideEmailAddressEnabled = true,
+                )
+            } returns DEFAULT_VIEW_STATE
+            mutableSendDataStateFlow.value = DataState.Loaded(mockSendView)
+            val initialState = DEFAULT_STATE.copy(
+                addEditSendType = AddEditSendType.EditItem(sendItemId = sendId),
+                isSendControlsEnabled = true,
+            )
+            val viewModel = createViewModel(
+                state = initialState,
+                addEditSendType = AddEditSendType.EditItem(sendItemId = sendId),
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_COMMON_STATE.deletionDate, awaitItem().deletionDateOrNull())
+
+                mutableEffectiveSendPolicyFlow.value =
+                    DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
+
+                val updatedState = awaitItem()
+                assertEquals(ENFORCED_DELETION_HOURS, updatedState.enforcedDeletionHours)
+                assertEquals(DEFAULT_COMMON_STATE.deletionDate, updatedState.deletionDateOrNull())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `enforcedDeletionHours should only be populated when send controls is enabled`() {
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
+
+        assertNull(createViewModel().stateFlow.value.enforcedDeletionHours)
+
+        mutableSendControlsFlagFlow.value = true
+
+        assertEquals(
+            ENFORCED_DELETION_HOURS,
+            createViewModel().stateFlow.value.enforcedDeletionHours,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deletion date should not change when the policy changes while send controls is disabled`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_COMMON_STATE.deletionDate, awaitItem().deletionDateOrNull())
+
+                mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY.copy(
+                    deletionHours = ENFORCED_DELETION_HOURS,
+                    disableHideEmail = true,
+                )
+
+                val updatedState = awaitItem()
+                assertNull(updatedState.enforcedDeletionHours)
+                assertEquals(DEFAULT_COMMON_STATE.deletionDate, updatedState.deletionDateOrNull())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deletion date should revert to the default window when send controls is turned off`() =
+        runTest {
+            mutableSendControlsFlagFlow.value = true
+            mutableEffectiveSendPolicyFlow.value =
+                DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
+            val viewModel = createViewModel()
+
+            viewModel.stateFlow.test {
+                assertEquals(ENFORCED_DELETION_DATE, awaitItem().deletionDateOrNull())
+
+                mutableSendControlsFlagFlow.value = false
+
+                val updatedState = awaitItem()
+                assertNull(updatedState.enforcedDeletionHours)
+                assertEquals(DEFAULT_COMMON_STATE.deletionDate, updatedState.deletionDateOrNull())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deletion date should revert to the default window when the enforcement is lifted`() =
+        runTest {
+            mutableSendControlsFlagFlow.value = true
+            mutableEffectiveSendPolicyFlow.value =
+                DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
+            val viewModel = createViewModel()
+
+            viewModel.stateFlow.test {
+                assertEquals(ENFORCED_DELETION_DATE, awaitItem().deletionDateOrNull())
+
+                mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY
+
+                assertEquals(DEFAULT_COMMON_STATE.deletionDate, awaitItem().deletionDateOrNull())
+            }
+        }
 
     @Test
     fun `initial state should read from saved state when present`() {
@@ -1589,6 +1744,10 @@ private val DEFAULT_STATE = AddEditSendState(
     sendType = SendItemType.TEXT,
     isPremium = true,
 )
+
+private val ENFORCED_DELETION_DATE: Instant = Instant.parse("2023-10-28T12:00:00Z")
+
+private const val ENFORCED_DELETION_HOURS: Int = 24
 
 private val DEFAULT_EFFECTIVE_SEND_POLICY = EffectiveSendPolicy(
     allowedDomains = null,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -243,35 +243,26 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
             }
         }
 
-    private fun AddEditSendState.deletionDateOrNull(): Instant? =
-        (viewState as? AddEditSendState.ViewState.Content)?.common?.deletionDate
-
-    @Suppress("MaxLineLength")
     @Test
     fun `initial state should use the enforced deletion window when send controls is enabled`() {
         mutableSendControlsFlagFlow.value = true
         mutableEffectiveSendPolicyFlow.value =
             DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
 
-        val state = createViewModel().stateFlow.value
-
-        assertEquals(ENFORCED_DELETION_HOURS, state.enforcedDeletionHours)
-        assertEquals(ENFORCED_DELETION_DATE, state.deletionDateOrNull())
+        assertEquals(ENFORCED_DELETION_STATE, createViewModel().stateFlow.value)
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `initial state should use the default deletion window when send controls is disabled`() {
         mutableEffectiveSendPolicyFlow.value =
             DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
 
-        val state = createViewModel().stateFlow.value
-
-        assertNull(state.enforcedDeletionHours)
-        assertEquals(DEFAULT_COMMON_STATE.deletionDate, state.deletionDateOrNull())
+        assertEquals(
+            DEFAULT_STATE.copy(deletionHours = ENFORCED_DELETION_HOURS),
+            createViewModel().stateFlow.value,
+        )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `deletion date should update when the enforced deletion window changes in add mode`() =
         runTest {
@@ -279,16 +270,15 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
-                assertEquals(DEFAULT_COMMON_STATE.deletionDate, awaitItem().deletionDateOrNull())
+                assertEquals(DEFAULT_STATE.copy(isSendControlsEnabled = true), awaitItem())
 
                 mutableEffectiveSendPolicyFlow.value =
                     DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
 
-                assertEquals(ENFORCED_DELETION_DATE, awaitItem().deletionDateOrNull())
+                assertEquals(ENFORCED_DELETION_STATE, awaitItem())
             }
         }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `deletion date should not change when the enforced deletion window changes in edit mode`() =
         runTest {
@@ -312,54 +302,62 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
             )
 
             viewModel.stateFlow.test {
-                assertEquals(DEFAULT_COMMON_STATE.deletionDate, awaitItem().deletionDateOrNull())
+                assertEquals(initialState, awaitItem())
 
                 mutableEffectiveSendPolicyFlow.value =
                     DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
 
-                val updatedState = awaitItem()
-                assertEquals(ENFORCED_DELETION_HOURS, updatedState.enforcedDeletionHours)
-                assertEquals(DEFAULT_COMMON_STATE.deletionDate, updatedState.deletionDateOrNull())
+                // The existing Send keeps its own deletion date even though it is now enforced.
+                assertEquals(
+                    initialState.copy(deletionHours = ENFORCED_DELETION_HOURS),
+                    awaitItem(),
+                )
             }
         }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `enforcedDeletionHours should only be populated when send controls is enabled`() {
         mutableEffectiveSendPolicyFlow.value =
             DEFAULT_EFFECTIVE_SEND_POLICY.copy(deletionHours = ENFORCED_DELETION_HOURS)
 
-        assertNull(createViewModel().stateFlow.value.enforcedDeletionHours)
+        val flagOffState = createViewModel().stateFlow.value
+        assertEquals(DEFAULT_STATE.copy(deletionHours = ENFORCED_DELETION_HOURS), flagOffState)
+        assertNull(flagOffState.enforcedDeletionHours)
 
         mutableSendControlsFlagFlow.value = true
 
-        assertEquals(
-            ENFORCED_DELETION_HOURS,
-            createViewModel().stateFlow.value.enforcedDeletionHours,
-        )
+        val flagOnState = createViewModel().stateFlow.value
+        assertEquals(ENFORCED_DELETION_STATE, flagOnState)
+        assertEquals(ENFORCED_DELETION_HOURS, flagOnState.enforcedDeletionHours)
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `deletion date should not change when the policy changes while send controls is disabled`() =
+    fun `deletion date should not change when the policy changes with send controls off`() =
         runTest {
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
-                assertEquals(DEFAULT_COMMON_STATE.deletionDate, awaitItem().deletionDateOrNull())
+                assertEquals(DEFAULT_STATE, awaitItem())
 
                 mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY.copy(
                     deletionHours = ENFORCED_DELETION_HOURS,
                     disableHideEmail = true,
                 )
 
-                val updatedState = awaitItem()
-                assertNull(updatedState.enforcedDeletionHours)
-                assertEquals(DEFAULT_COMMON_STATE.deletionDate, updatedState.deletionDateOrNull())
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        deletionHours = ENFORCED_DELETION_HOURS,
+                        viewState = DEFAULT_VIEW_STATE.copy(
+                            common = DEFAULT_COMMON_STATE.copy(
+                                isHideEmailAddressEnabled = false,
+                            ),
+                        ),
+                    ),
+                    awaitItem(),
+                )
             }
         }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `deletion date should revert to the default window when send controls is turned off`() =
         runTest {
@@ -369,17 +367,17 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
-                assertEquals(ENFORCED_DELETION_DATE, awaitItem().deletionDateOrNull())
+                assertEquals(ENFORCED_DELETION_STATE, awaitItem())
 
                 mutableSendControlsFlagFlow.value = false
 
-                val updatedState = awaitItem()
-                assertNull(updatedState.enforcedDeletionHours)
-                assertEquals(DEFAULT_COMMON_STATE.deletionDate, updatedState.deletionDateOrNull())
+                assertEquals(
+                    DEFAULT_STATE.copy(deletionHours = ENFORCED_DELETION_HOURS),
+                    awaitItem(),
+                )
             }
         }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `deletion date should revert to the default window when the enforcement is lifted`() =
         runTest {
@@ -389,11 +387,11 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
-                assertEquals(ENFORCED_DELETION_DATE, awaitItem().deletionDateOrNull())
+                assertEquals(ENFORCED_DELETION_STATE, awaitItem())
 
                 mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY
 
-                assertEquals(DEFAULT_COMMON_STATE.deletionDate, awaitItem().deletionDateOrNull())
+                assertEquals(DEFAULT_STATE.copy(isSendControlsEnabled = true), awaitItem())
             }
         }
 
@@ -1768,6 +1766,14 @@ private val DEFAULT_STATE = AddEditSendState(
 private val ENFORCED_DELETION_DATE: Instant = Instant.parse("2023-10-28T12:00:00Z")
 
 private const val ENFORCED_DELETION_HOURS: Int = 24
+
+private val ENFORCED_DELETION_STATE = DEFAULT_STATE.copy(
+    isSendControlsEnabled = true,
+    deletionHours = ENFORCED_DELETION_HOURS,
+    viewState = DEFAULT_VIEW_STATE.copy(
+        common = DEFAULT_COMMON_STATE.copy(deletionDate = ENFORCED_DELETION_DATE),
+    ),
+)
 
 private val DEFAULT_EFFECTIVE_SEND_POLICY = EffectiveSendPolicy(
     allowedDomains = null,

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -465,6 +465,7 @@ Scanning will happen automatically.</string>
     <string name="deletion_date">Deletion date</string>
     <string name="deletion_time">Deletion time</string>
     <string name="deletion_date_info">The Send will be permanently deleted on the specified date and time.</string>
+    <string name="this_date_is_enforced_by_your_organization">This date is enforced by your organization</string>
     <string name="who_can_view">Who can view</string>
     <string name="anyone_with_the_link">Anyone with the link</string>
     <string name="anyone_with_link_can_view_send">Anyone with this link can view this Send</string>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40532

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When an org's SendControls policy sets `deletionHours`, the deletion date stops being the user's to pick. The chooser on the Add/Edit Send screen is now locked to the enforced value, and the helper text under it changes to "This date is enforced by your organization" so it's clear why the field can't be changed.

A new Send picks up the enforced window instead of the usual 7 days. An existing Send keeps the deletion date it was created with — editing a Send for some unrelated reason shouldn't quietly push its deletion date out.

The View screen is left alone. The ticket's technical breakdown asked for the same helper text there, but the Figma acceptance criteria says to keep showing the date as normal, and the ticket itself flags this as an open question for design (item G3). Happy to add it if design comes back the other way.

All of it sits behind the `pm-31885-send-controls` flag. With the flag off the field behaves exactly as before: editable, default 7-day window, original helper text. If the flag or the policy is switched off while the screen is open, a new Send's date falls back to the 7-day default, so the chooser and the state can't end up showing different things.

Stacked on #7249.


## 📸 Screenshots
| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/77d8d386-ca59-4b91-b142-04886aba4487" /> | <img width="365" src="https://github.com/user-attachments/assets/82efaa74-4793-4fac-86b9-9a42f4560b47" /> |
| <img width="365" src="https://github.com/user-attachments/assets/a3c29285-4464-410e-ac1b-ce87f9609eb9"/> | <img width="365" src="https://github.com/user-attachments/assets/675c160c-0803-4f9f-ba94-6fa6eced4c4d" /> |
