### PR TITLE
[PM-41870] Allow save prompt and fallback to writable collection when organization data ownership is enabled

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
@@ -80,11 +80,6 @@ class AutofillProcessorImpl(
             return
         }
 
-        if (policyManager.getActivePolicies(PolicyType.ORGANIZATION_DATA_OWNERSHIP).any()) {
-            saveCallback.onSuccess()
-            return
-        }
-
         request
             .fillContexts
             .lastOrNull()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
@@ -245,6 +245,7 @@ fun List<CollectionView>.getDefaultCollectionViewOrNull(
 ): CollectionView? =
     if (isIndividualVaultDisabled) {
         firstOrNull { it.type == CollectionType.DEFAULT_USER_COLLECTION }
+            ?: firstOrNull { !it.readOnly }
     } else {
         null
     }


### PR DESCRIPTION
## 🎟️ Tracking

Closes #7256 [PM-41838](https://bitwarden.atlassian.net/browse/PM-41838)

## 📔 Objective

1. Removes an early return in `AutofillProcessorImpl.kt` that was automatically canceling Autofill save requests whenever `ORGANIZATION_DATA_OWNERSHIP` policy was enabled.
2. Updates `getDefaultCollectionViewOrNull()` in `CipherViewExtensions.kt` so that when `DEFAULT_USER_COLLECTION` is null, the app automatically selects the first writable collection as a fallback for much better UX.

## 📸 Screenshots

### 1. Autofill Save Prompt
| Before | After |
| :---: | :---: |
| <img width="320" alt="old-autofill" src="https://github.com/user-attachments/assets/e698fe3d-2501-43ad-9fa1-5a3722bc3018" /> | <img width="320" alt="new-autofill" src="https://github.com/user-attachments/assets/c119a449-c53c-4b8a-8b35-1aa8bdc546c6" /> |

### 2. Collection Default Selection
| Before | After |
| :---: | :---: |
| <img width="320" alt="old-default" src="https://github.com/user-attachments/assets/d881cf8d-f4de-4366-a591-2ed102024edf" /> | <img width="320" alt="new-default" src="https://github.com/user-attachments/assets/30a7ad05-7639-42f1-bf69-df60af2dc421" /> |


[PM-41838]: https://bitwarden.atlassian.net/browse/PM-41838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ