### PR TITLE
[AI-76] llm: Fix Bash allowlist and Resolve routing in evaluating-sdk-internal-updates

### DIFF
--- a/.claude/skills/evaluating-sdk-internal-updates/SKILL.md
+++ b/.claude/skills/evaluating-sdk-internal-updates/SKILL.md
@@ -1,7 +1,21 @@
 ---
 name: evaluating-sdk-internal-updates
 description: Evaluates a bitwarden/android "Update SDK to" PR against the sdk-internal commit range for compile-time and runtime breaking changes, maps affected symbols to Android call sites, and applies clear in-scope fixes. Use when reviewing an SDK bump PR, a bitwardenSdk version change, or triaging sdk-internal breaking changes.
-allowed-tools: Bash(gh pr diff:*), Bash(git -C * log *), Bash(git -C * show *), Bash(git add:*), Bash(git commit:*), Bash(grep:*), Bash(./gradlew *), Read, Grep, Glob, Edit, Write, Skill(implementing-android-code), Skill(bitwarden-delivery-tools:committing-changes)
+allowed-tools:
+  - Bash(gh pr diff:*)
+  - Bash(git -C * log *)
+  - Bash(git -C * show *)
+  - Bash(git add:*)
+  - Bash(git commit:*)
+  - Bash(grep:*)
+  - Bash(./gradlew *)
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Skill(implementing-android-code)
+  - Skill(bitwarden-delivery-tools:committing-changes)
 ---
 
 # Evaluating sdk-internal Updates

--- a/.claude/skills/evaluating-sdk-internal-updates/SKILL.md
+++ b/.claude/skills/evaluating-sdk-internal-updates/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: evaluating-sdk-internal-updates
 description: Evaluates a bitwarden/android "Update SDK to" PR against the sdk-internal commit range for compile-time and runtime breaking changes, maps affected symbols to Android call sites, and applies clear in-scope fixes. Use when reviewing an SDK bump PR, a bitwardenSdk version change, or triaging sdk-internal breaking changes.
-allowed-tools: Bash(gh pr diff:*), Bash(git -C *:*), Bash(grep:*), Bash(./gradlew*:*), Read, Grep, Glob, Skill(plan-android-work), Skill(work-on-android)
+allowed-tools: Bash(gh pr diff:*), Bash(git -C * log *), Bash(git -C * show *), Bash(git add:*), Bash(git commit:*), Bash(grep:*), Bash(./gradlew *), Read, Grep, Glob, Edit, Write, Skill(implementing-android-code), Skill(bitwarden-delivery-tools:committing-changes)
 ---
 
 # Evaluating sdk-internal Updates
@@ -20,12 +20,12 @@ A hunk that only touches a macro invocation (e.g. `state_bridge! { ... }`) doesn
 4. `git -C <sdk-internal-path> log --oneline OLD..NEW -G'uniffi::export|derive\(uniffi|#\[uniffi' -- '*.rs'` → candidate binding-surface commits.
 5. Classify per hunk, not per commit — a commit with one additive headline change can still have a second, unrelated breaking hunk. If a hunk only touches a macro invocation, read the macro's definition before classifying. `git -C <sdk-internal-path> show <sha> -- '*.rs'`.
 6. For every distinct symbol/type touched (every hunk, not just the commit's headline change), grep the whole repo for the bare symbol name to find Android call sites — a fixed module list or a `com.bitwarden.sdk.<Symbol>` import-prefix check both miss real consumers.
-7. Report: compile-time breaks, runtime breaks, safe/no-call-site — each with commit, symbol, and call sites.
+7. Report: compile-time breaks, runtime breaks, safe/no-call-site — each with commit, symbol, and call sites. Cite sdk-internal commits and PRs as `bitwarden/sdk-internal#<NNN>` or a full commit URL/SHA — never a bare `#<NNN>` copied from a commit subject line. A bare reference auto-links within whatever repo the report is posted to (e.g. `bitwarden/android`), tagging an unrelated issue or PR there.
 
 ## Resolve
 
-Resolve the findings from Step 7 by deciding on a fix, invoking `/plan-android-work` with the report to plan the implementation, followed by invoking `/work-on-android` with the generated plan to implement required changes.
+Resolve the findings from Step 7 by deciding on a fix (step 8), implementing and committing it directly (step 9), then verifying (step 10).
 
 8. Decide the fix for anything found, compile-time or runtime, whenever the correct behavior is clear and within scope. For a new required method, grep for the underlying concept, not the new method/type name (it won't exist yet) — no existing consumer means stub it: a `// no-op` comment or a null/default return that satisfies the compiler, not a behavioral decision. Never `TODO()` — it throws at runtime, which is a crash, not a stub. A sibling's structure (naming, placement, style) is a template; its behavior (storage, defaulting, error handling, side effects) is not evidence for yours. If unsure, report it instead of guessing, along with anything needing a product decision.
-9. Implement every fix from step 8 by `/plan-android-work` (pass it the step 7 findings) followed by `/work-on-android` (pass it the resulting plan) — never edit the fix in yourself, not even a one-line stub.
+9. Implement every fix from step 8 directly: invoke `Skill(implementing-android-code)` first if the fix isn't purely mechanical, then commit with `Skill(bitwarden-delivery-tools:committing-changes)`.
 10. Verify with the same compile task used in step 3.

--- a/.github/workflows/sdlc-sdk-update-evaluate.yml
+++ b/.github/workflows/sdlc-sdk-update-evaluate.yml
@@ -120,7 +120,7 @@ jobs:
             that nothing needs fixing — the comment is the audit trail that the check ran.
           claude_args: |
             --model opus
-            --allowedTools "Bash(gh pr diff:*),Bash(git -C *:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(grep:*),Bash(./gradlew*:*),Read,Grep,Glob,Edit,Write,Skill,mcp__github_comment__update_claude_comment"
+            --allowedTools "Bash(gh pr diff:*),Bash(git -C * log *),Bash(git -C * show *),Bash(git add:*),Bash(git commit:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(grep:*),Bash(./gradlew *),Read,Grep,Glob,Edit,Write,Skill,mcp__github_comment__update_claude_comment"
 
       - name: Push any resolved fix
         if: steps.gate.outputs.skip == 'false'


### PR DESCRIPTION
## 🎟️ Tracking

[AI-76](https://bitwarden.atlassian.net/browse/AI-76)

## 📔 Objective

The `SDLC / SDK Update Evaluation` action hit 13 permission denials on PR #7254 ([comment](https://github.com/bitwarden/android/pull/7254#issuecomment-5258936612)) because two `--allowedTools` Bash patterns mix Claude Code's legacy trailing `:*` prefix-match syntax with an inline `*` wildcard — a combination the CLI itself treats as invalid. Every real `git -C` and `./gradlew` invocation was denied, forcing the run to skip the local compile check and commit-range scan the skill's own steps depend on.

This also rewrites the skill's Resolve step to commit fixes directly instead of routing through `/plan-android-work` → `/work-on-android`, both of which are multi-phase commands gated on human confirmation at every step and incompatible with this skill's unattended CI invocation. 

And it qualifies sdk-internal commit/PR references as `bitwarden/sdk-internal#<NNN>` in the generated report, since a bare `#<NNN>` copied from a commit subject auto-links within `bitwarden/android`, tagging unrelated issues there.


[AI-76]: https://bitwarden.atlassian.net/browse/AI-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ