### PR TITLE
[PM-41900] fix: Update the vault selection dialog title

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationContent.kt
@@ -22,7 +22,6 @@ import kotlinx.collections.immutable.toImmutableList
 /**
  * Content view for the [VaultMoveToOrganizationScreen].
  */
-@Suppress("LongMethod")
 @Composable
 fun VaultMoveToOrganizationContent(
     state: VaultMoveToOrganizationState.ViewState.Content,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationContent.kt
@@ -43,10 +43,6 @@ fun VaultMoveToOrganizationContent(
                     label = stringResource(
                         id = vfo1Foundation(BitwardenString.vault, BitwardenString.organization),
                     ),
-                    dialogTitle = vfo1Foundation(
-                        new = stringResource(id = BitwardenString.filter_by_vault),
-                        old = null,
-                    ),
                     options = state
                         .organizations
                         .map { it.name }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
@@ -49,7 +49,6 @@ import kotlinx.collections.immutable.toImmutableList
  * @param isEnabled Whether the button is enabled.
  * @param cardStyle Indicates the type of card style to be applied.
  * @param modifier A [Modifier] that you can use to apply custom modifications to the composable.
- * @param dialogTitle The title to apply to the dialog (defaults to [label] when `null`).
  * @param dialogSubtitle The subtitle to apply to the dialog.
  * @param supportingText An optional supporting text that will appear below the text field.
  * @param helpData An optional [BitwardenHelpButtonData], representing the help button.
@@ -68,7 +67,6 @@ fun BitwardenMultiSelectButton(
     onOptionSelected: (String) -> Unit,
     cardStyle: CardStyle?,
     modifier: Modifier = Modifier,
-    dialogTitle: String? = null,
     dialogSubtitle: String? = null,
     isEnabled: Boolean = true,
     supportingText: String? = null,
@@ -80,7 +78,6 @@ fun BitwardenMultiSelectButton(
 ) {
     BitwardenMultiSelectButton(
         label = label,
-        dialogTitle = dialogTitle,
         dialogSubtitle = dialogSubtitle,
         options = options.map { MultiSelectOption.Row(it) }.toImmutableList(),
         selectedOption = selectedOption?.let { MultiSelectOption.Row(it) },
@@ -122,7 +119,6 @@ fun BitwardenMultiSelectButton(
  * @param supportingContent An optional supporting content that will appear below the button.
  * @param cardStyle Indicates the type of card style to be applied.
  * @param modifier A [Modifier] that you can use to apply custom modifications to the composable.
- * @param dialogTitle The title to apply to the dialog (defaults to [label] when `null`).
  * @param helpData An optional [BitwardenHelpButtonData], representing the help button.
  * @param insets Inner padding to be applied withing the card.
  * @param textFieldTestTag The optional test tag associated with the inner text field.
@@ -139,7 +135,6 @@ fun BitwardenMultiSelectButton(
     onOptionSelected: (MultiSelectOption.Row) -> Unit,
     cardStyle: CardStyle?,
     modifier: Modifier = Modifier,
-    dialogTitle: String? = null,
     dialogSubtitle: String? = null,
     isEnabled: Boolean = true,
     supportingContent: @Composable (ColumnScope.() -> Unit)?,
@@ -171,7 +166,7 @@ fun BitwardenMultiSelectButton(
 
     if (shouldShowDialog) {
         BitwardenSelectionDialog(
-            title = dialogTitle ?: label,
+            title = label,
             subTitle = dialogSubtitle,
             onDismissRequest = { shouldShowDialog = false },
         ) {

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
@@ -119,6 +119,7 @@ fun BitwardenMultiSelectButton(
  * @param supportingContent An optional supporting content that will appear below the button.
  * @param cardStyle Indicates the type of card style to be applied.
  * @param modifier A [Modifier] that you can use to apply custom modifications to the composable.
+ * @param dialogSubtitle The subtitle to apply to the dialog.
  * @param helpData An optional [BitwardenHelpButtonData], representing the help button.
  * @param insets Inner padding to be applied withing the card.
  * @param textFieldTestTag The optional test tag associated with the inner text field.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41900

## 📔 Objective

When you move a personal vault item into an organization vault, the picker dialog was titled
"Filter items by vault". That copy is borrowed from the vault list filter and doesn't really fit
here.

The dropdown's label is already "Vault", and `BitwardenMultiSelectButton` falls back to the label
when no explicit `dialogTitle` is passed. So the fix is deleting the override rather than adding a
new string, and it drops one more `vfo1Foundation` call site — slightly less to unwind when the flag
goes away.

The second commit is cleanup. `dialogTitle` was added to `BitwardenMultiSelectButton` back in the
VFO-1 branch (#7196) purely for that one call site. With the override gone it had no callers left,
so I pulled the parameter out of both overloads.


## 📸 Screenshots
| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/5720a770-143d-4fb1-b1aa-4b8bcf8752f5" /> | <img width="365" src="https://github.com/user-attachments/assets/0f87bee2-0c5f-4e84-988a-d4c0485c2ef7" /> |
