### PR TITLE
[PM-40531] feat: Lock the "Who can view" selection when enforced by policy

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
@@ -176,9 +176,8 @@ fun AddEditSendContent(
             onOpenPasswordGeneratorClick = addSendHandlers.onOpenPasswordGeneratorClick,
             onPasswordCopyClick = addSendHandlers.onPasswordCopyClick,
             password = state.common.passwordInput,
-            isEnabled = !policyDisablesSend,
+            isEnabled = !policyDisablesSend && enforcedWhoCanAccess == null,
             isSendsRestrictedByPolicy = policyDisablesSend,
-            enforcedWhoCanAccess = enforcedWhoCanAccess,
             modifier = Modifier
                 .testTag("SendAuthTypeChooser")
                 .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.bitwarden.network.model.SendAccessTypeJson
 import com.bitwarden.ui.platform.base.util.cardStyle
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.animation.AnimateNullableContentVisibility
@@ -63,6 +64,7 @@ import com.x8bit.bitwarden.ui.tools.feature.send.addedit.handlers.AddEditSendHan
 fun AddEditSendContent(
     state: AddEditSendState.ViewState.Content,
     enforcedDeletionHours: Int?,
+    enforcedWhoCanAccess: SendAccessTypeJson?,
     policyDisablesSend: Boolean,
     policySendOptionsInEffect: Boolean,
     shouldHideEmailAddressToggle: Boolean,
@@ -176,6 +178,7 @@ fun AddEditSendContent(
             password = state.common.passwordInput,
             isEnabled = !policyDisablesSend,
             isSendsRestrictedByPolicy = policyDisablesSend,
+            enforcedWhoCanAccess = enforcedWhoCanAccess,
             modifier = Modifier
                 .testTag("SendAuthTypeChooser")
                 .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
@@ -174,6 +174,7 @@ fun AddEditSendScreen(
             is AddEditSendState.ViewState.Content -> AddEditSendContent(
                 state = viewState,
                 enforcedDeletionHours = state.enforcedDeletionHours,
+                enforcedWhoCanAccess = state.enforcedWhoCanAccess,
                 policyDisablesSend = state.policyDisablesSend,
                 policySendOptionsInEffect = state.shouldDisplayPolicyWarning,
                 shouldHideEmailAddressToggle = state.shouldHideEmailAddressToggle,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -452,7 +452,7 @@ class AddEditSendViewModel @Inject constructor(
         val newDeletionDate = state.newDeletionDateOrNull(
             newEnforcedDeletionHours = newEnforcedDeletionHours,
         )
-        // Only a new Send adopts the enforced access type — an existing Send keeps the one it was
+        // Only a new Send adopts the enforced access type. An existing Send keeps the one it was
         // created with.
         val newEnforcedWhoCanAccess = effectiveSendPolicy
             .whoCanAccess

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -80,11 +80,19 @@ private const val KEY_STATE = "state"
 private const val MAX_FILE_SIZE_BYTES: Long = 100 * 1024 * 1024
 
 /**
- * Returns the [SendAuth] this access type enforces, preserving [current] when it already matches
- * the enforced type so that any emails already entered are kept.
+ * Whether this access type restricts a Send to a single option. [SendAccessTypeJson.ANY] leaves
+ * every option available, so it restricts nothing.
  */
-private fun SendAccessTypeJson.toSendAuth(current: SendAuth): SendAuth = when (this) {
-    SendAccessTypeJson.ANY -> SendAuth.None
+private val SendAccessTypeJson.restrictsAccess: Boolean
+    get() = this != SendAccessTypeJson.ANY
+
+/**
+ * Returns the [SendAuth] this access type restricts a Send to, preserving [current] when it already
+ * matches the restricted type so that any emails already entered are kept.
+ */
+private fun SendAccessTypeJson.toEnforcedSendAuth(current: SendAuth): SendAuth = when (this) {
+    // Every option stays available, so the current selection is left alone.
+    SendAccessTypeJson.ANY -> current
     SendAccessTypeJson.PASSWORD_PROTECTED -> SendAuth.Password
     SendAccessTypeJson.SPECIFIC_PEOPLE -> current as? SendAuth.Email ?: SendAuth.Email()
 }
@@ -150,7 +158,7 @@ class AddEditSendViewModel @Inject constructor(
                         sendAuth = effectiveSendPolicy
                             .whoCanAccess
                             ?.takeIf { isSendControlsEnabled }
-                            ?.toSendAuth(current = SendAuth.None)
+                            ?.toEnforcedSendAuth(current = SendAuth.None)
                             ?: SendAuth.None,
                     ),
                     selectedType = shareSendType ?: when (sendType) {
@@ -467,7 +475,7 @@ class AddEditSendViewModel @Inject constructor(
                 // chooser reads it straight from state, so unlocking cannot desync the two, and
                 // anything already entered survives.
                 sendAuth = newEnforcedWhoCanAccess
-                    ?.toSendAuth(current = it.sendAuth)
+                    ?.toEnforcedSendAuth(current = it.sendAuth)
                     ?: it.sendAuth,
             )
         }
@@ -1031,11 +1039,12 @@ data class AddEditSendState(
 
     /**
      * Helper to determine the access type Sends are restricted to by the SendControls policy, or
-     * `null` when the access type is left to the user. The legacy send options policy has no
-     * equivalent enforcement, so this is only in effect alongside the SendControls feature flag.
+     * `null` when the access type is left to the user. [SendAccessTypeJson.ANY] leaves every option
+     * available, so it is not a restriction. The legacy send options policy has no equivalent
+     * enforcement, so this is only in effect alongside the SendControls feature flag.
      */
     val enforcedWhoCanAccess: SendAccessTypeJson?
-        get() = whoCanAccess.takeIf { isSendControlsEnabled }
+        get() = whoCanAccess?.takeIf { isSendControlsEnabled && it.restrictsAccess }
 
     /**
      * Helper to determine the screen display name.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -80,6 +80,16 @@ private const val KEY_STATE = "state"
 private const val MAX_FILE_SIZE_BYTES: Long = 100 * 1024 * 1024
 
 /**
+ * Returns the [SendAuth] this access type enforces, preserving [current] when it already matches
+ * the enforced type so that any emails already entered are kept.
+ */
+private fun SendAccessTypeJson.toSendAuth(current: SendAuth): SendAuth = when (this) {
+    SendAccessTypeJson.ANY -> SendAuth.None
+    SendAccessTypeJson.PASSWORD_PROTECTED -> SendAuth.Password
+    SendAccessTypeJson.SPECIFIC_PEOPLE -> current as? SendAuth.Email ?: SendAuth.Email()
+}
+
+/**
  * View model for the add/edit send screen.
  */
 @Suppress("TooManyFunctions", "LongParameterList", "LargeClass")
@@ -137,7 +147,11 @@ class AddEditSendViewModel @Inject constructor(
                         expirationDate = null,
                         sendUrl = null,
                         hasPassword = false,
-                        sendAuth = SendAuth.None,
+                        sendAuth = effectiveSendPolicy
+                            .whoCanAccess
+                            ?.takeIf { isSendControlsEnabled }
+                            ?.toSendAuth(current = SendAuth.None)
+                            ?: SendAuth.None,
                     ),
                     selectedType = shareSendType ?: when (sendType) {
                         SendItemType.FILE -> {
@@ -430,6 +444,11 @@ class AddEditSendViewModel @Inject constructor(
         val newDeletionDate = state.newDeletionDateOrNull(
             newEnforcedDeletionHours = newEnforcedDeletionHours,
         )
+        // Only a new Send adopts the enforced access type — an existing Send keeps the one it was
+        // created with.
+        val newEnforcedWhoCanAccess = effectiveSendPolicy
+            .whoCanAccess
+            ?.takeIf { action.isSendControlsEnabled && state.isAddMode }
         mutableStateFlow.update { currentState ->
             currentState.copy(
                 policyDisablesSend = effectiveSendPolicy.disableSend,
@@ -444,6 +463,12 @@ class AddEditSendViewModel @Inject constructor(
             it.copy(
                 deletionDate = newDeletionDate ?: it.deletionDate,
                 isHideEmailAddressEnabled = !effectiveSendPolicy.disableHideEmail,
+                // Dropping the enforcement deliberately leaves the current selection alone: the
+                // chooser reads it straight from state, so unlocking cannot desync the two, and
+                // anything already entered survives.
+                sendAuth = newEnforcedWhoCanAccess
+                    ?.toSendAuth(current = it.sendAuth)
+                    ?: it.sendAuth,
             )
         }
     }
@@ -977,7 +1002,7 @@ class AddEditSendViewModel @Inject constructor(
  * @property deletionHours The enforced Send deletion window in hours, sourced from
  * [EffectiveSendPolicy.deletionHours]. Currently unused by the UI.
  * @property whoCanAccess The access type Sends are restricted to, sourced from
- * [EffectiveSendPolicy.whoCanAccess]. Currently unused by the UI.
+ * [EffectiveSendPolicy.whoCanAccess].
  */
 @Parcelize
 data class AddEditSendState(
@@ -1003,6 +1028,14 @@ data class AddEditSendState(
      * enforcement, so this is only in effect alongside the SendControls feature flag.
      */
     val enforcedDeletionHours: Int? get() = deletionHours.takeIf { isSendControlsEnabled }
+
+    /**
+     * Helper to determine the access type Sends are restricted to by the SendControls policy, or
+     * `null` when the access type is left to the user. The legacy send options policy has no
+     * equivalent enforcement, so this is only in effect alongside the SendControls feature flag.
+     */
+    val enforcedWhoCanAccess: SendAccessTypeJson?
+        get() = whoCanAccess.takeIf { isSendControlsEnabled }
 
     /**
      * Helper to determine the screen display name.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -80,13 +80,6 @@ private const val KEY_STATE = "state"
 private const val MAX_FILE_SIZE_BYTES: Long = 100 * 1024 * 1024
 
 /**
- * Whether this access type restricts a Send to a single option. [SendAccessTypeJson.ANY] leaves
- * every option available, so it restricts nothing.
- */
-private val SendAccessTypeJson.restrictsAccess: Boolean
-    get() = this != SendAccessTypeJson.ANY
-
-/**
  * Returns the [SendAuth] this access type restricts a Send to, preserving [current] when it already
  * matches the restricted type so that any emails already entered are kept.
  */
@@ -1044,7 +1037,7 @@ data class AddEditSendState(
      * enforcement, so this is only in effect alongside the SendControls feature flag.
      */
     val enforcedWhoCanAccess: SendAccessTypeJson?
-        get() = whoCanAccess?.takeIf { isSendControlsEnabled && it.restrictsAccess }
+        get() = whoCanAccess?.takeIf { isSendControlsEnabled && it != SendAccessTypeJson.ANY }
 
     /**
      * Helper to determine the screen display name.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendAuthTypeChooser.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendAuthTypeChooser.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.bitwarden.network.model.SendAccessTypeJson
 import com.bitwarden.ui.platform.base.util.cardStyle
 import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
@@ -47,6 +48,9 @@ import kotlinx.collections.immutable.toPersistentList
  * @param onPasswordCopyClick Callback invoked when the Copy button is clicked
  * @param isEnabled Whether the chooser is enabled.
  * @param isSendsRestrictedByPolicy if sends are restricted by a policy.
+ * @param enforcedWhoCanAccess The access type enforced by the SendControls policy, or `null` when
+ * the access type is left to the user. When enforced, the chooser is locked to the value already
+ * applied to [sendAuth].
  * @param modifier Modifier for the composable.
  */
 @Suppress("LongMethod")
@@ -63,6 +67,7 @@ fun AddEditSendAuthTypeChooser(
     password: String,
     isEnabled: Boolean,
     isSendsRestrictedByPolicy: Boolean,
+    enforcedWhoCanAccess: SendAccessTypeJson?,
     modifier: Modifier = Modifier,
 ) {
     var shouldShowDialog by rememberSaveable { mutableStateOf(false) }
@@ -80,7 +85,7 @@ fun AddEditSendAuthTypeChooser(
     Column(modifier = modifier) {
         BitwardenMultiSelectButton(
             label = stringResource(id = BitwardenString.who_can_view),
-            isEnabled = isEnabled,
+            isEnabled = isEnabled && enforcedWhoCanAccess == null,
             options = options.toPersistentList(),
             selectedOption = sendAuth.text(),
             onOptionSelected = { selected ->

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendAuthTypeChooser.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/components/AddEditSendAuthTypeChooser.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import com.bitwarden.network.model.SendAccessTypeJson
 import com.bitwarden.ui.platform.base.util.cardStyle
 import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
@@ -48,9 +47,6 @@ import kotlinx.collections.immutable.toPersistentList
  * @param onPasswordCopyClick Callback invoked when the Copy button is clicked
  * @param isEnabled Whether the chooser is enabled.
  * @param isSendsRestrictedByPolicy if sends are restricted by a policy.
- * @param enforcedWhoCanAccess The access type enforced by the SendControls policy, or `null` when
- * the access type is left to the user. When enforced, the chooser is locked to the value already
- * applied to [sendAuth].
  * @param modifier Modifier for the composable.
  */
 @Suppress("LongMethod")
@@ -67,7 +63,6 @@ fun AddEditSendAuthTypeChooser(
     password: String,
     isEnabled: Boolean,
     isSendsRestrictedByPolicy: Boolean,
-    enforcedWhoCanAccess: SendAccessTypeJson?,
     modifier: Modifier = Modifier,
 ) {
     var shouldShowDialog by rememberSaveable { mutableStateOf(false) }
@@ -85,7 +80,7 @@ fun AddEditSendAuthTypeChooser(
     Column(modifier = modifier) {
         BitwardenMultiSelectButton(
             label = stringResource(id = BitwardenString.who_can_view),
-            isEnabled = isEnabled && enforcedWhoCanAccess == null,
+            isEnabled = isEnabled,
             options = options.toPersistentList(),
             selectedOption = sendAuth.text(),
             onOptionSelected = { selected ->

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -1718,6 +1718,11 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
+            .onNodeWithTag("SendVisibilityChooser")
+            .performScrollTo()
+            .assertIsNotEnabled()
+
+        composeTestRule
             .onNodeWithTag("SendAuthTypeChooser")
             .performScrollTo()
             .performClick()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.network.model.SendAccessTypeJson
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.manager.exit.ExitManager
@@ -1702,6 +1703,98 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
             .filterToOne(hasAnyAncestor(hasSetTextAction()))
             .performScrollTo()
             .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `who can view chooser should not open its options when enforced by policy`() {
+        mutableStateFlow.update {
+            it.copy(
+                isSendControlsEnabled = true,
+                whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE,
+                viewState = DEFAULT_VIEW_STATE.copy(
+                    common = DEFAULT_COMMON_STATE.copy(sendAuth = SendAuth.Email()),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("SendAuthTypeChooser")
+            .performScrollTo()
+            .performClick()
+
+        // The enforced option is displayed, but the other options are never composed.
+        composeTestRule
+            .onNodeWithText("Anyone with the link")
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithText("Anyone with a password set by you")
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithText("Specific people")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `who can view chooser should display the enforced option when locked to a password`() {
+        mutableStateFlow.update {
+            it.copy(
+                isSendControlsEnabled = true,
+                whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED,
+                viewState = DEFAULT_VIEW_STATE.copy(
+                    common = DEFAULT_COMMON_STATE.copy(sendAuth = SendAuth.Password),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText("Anyone with a password set by you")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `who can view chooser should open its options when send controls is disabled`() {
+        mutableStateFlow.update {
+            it.copy(
+                isSendControlsEnabled = false,
+                whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE,
+                viewState = DEFAULT_VIEW_STATE.copy(
+                    common = DEFAULT_COMMON_STATE.copy(sendAuth = SendAuth.None),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("SendAuthTypeChooser")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText("Specific people")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `who can view chooser should open its options when the policy leaves it unset`() {
+        mutableStateFlow.update {
+            it.copy(
+                isSendControlsEnabled = true,
+                whoCanAccess = null,
+                viewState = DEFAULT_VIEW_STATE.copy(
+                    common = DEFAULT_COMMON_STATE.copy(sendAuth = SendAuth.None),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("SendAuthTypeChooser")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText("Specific people")
+            .assertIsDisplayed()
     }
     //endregion Authentication UI Tests
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -1776,6 +1776,32 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `who can view chooser should open its options when the policy allows any access type`() {
+        mutableStateFlow.update {
+            it.copy(
+                isSendControlsEnabled = true,
+                whoCanAccess = SendAccessTypeJson.ANY,
+                viewState = DEFAULT_VIEW_STATE.copy(
+                    common = DEFAULT_COMMON_STATE.copy(sendAuth = SendAuth.None),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("SendAuthTypeChooser")
+            .performScrollTo()
+            .performClick()
+
+        // ANY leaves every option available, so nothing is locked.
+        composeTestRule
+            .onNodeWithText("Specific people")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("Anyone with a password set by you")
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun `who can view chooser should open its options when the policy leaves it unset`() {
         mutableStateFlow.update {
             it.copy(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -419,8 +419,8 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
             mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY
                 .copy(whoCanAccess = SendAccessTypeJson.ANY)
 
-            val state = initialState.copy(whoCanAccess = SendAccessTypeJson.ANY)
-            assertEquals(state, awaitItem())
+            val state = awaitItem()
+            assertEquals(initialState.copy(whoCanAccess = SendAccessTypeJson.ANY), state)
             assertNull(state.enforcedWhoCanAccess)
         }
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -7,6 +7,7 @@ import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
+import com.bitwarden.network.model.SendAccessTypeJson
 import com.bitwarden.send.SendView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
@@ -350,6 +351,249 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
                 assertEquals(DEFAULT_STATE.copy(isSendControlsEnabled = true), awaitItem())
             }
         }
+
+    @Test
+    fun `initial state should use the enforced access type when send controls is enabled`() {
+        every { UUID.randomUUID().toString() } returns "uuid"
+        mutableSendControlsFlagFlow.value = true
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE)
+
+        assertEquals(
+            enforcedAccessState(
+                whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE,
+                sendAuth = SendAuth.Email(),
+            ),
+            createViewModel().stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `initial state should use the enforced access type for a password protected policy`() {
+        mutableSendControlsFlagFlow.value = true
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED)
+
+        assertEquals(
+            enforcedAccessState(
+                whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED,
+                sendAuth = SendAuth.Password,
+            ),
+            createViewModel().stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `initial state should use the enforced access type for an any policy`() {
+        mutableSendControlsFlagFlow.value = true
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(whoCanAccess = SendAccessTypeJson.ANY)
+
+        assertEquals(
+            enforcedAccessState(
+                whoCanAccess = SendAccessTypeJson.ANY,
+                sendAuth = SendAuth.None,
+            ),
+            createViewModel().stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `initial state should use the enforced access type without a premium account`() {
+        every { UUID.randomUUID().toString() } returns "uuid"
+        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+            accounts = listOf(DEFAULT_ACCOUNT.copy(isPremium = false)),
+        )
+        mutableSendControlsFlagFlow.value = true
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE)
+
+        // The policy outranks the premium requirement that gates picking this option by hand.
+        assertEquals(
+            enforcedAccessState(
+                whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE,
+                sendAuth = SendAuth.Email(),
+            ).copy(isPremium = false),
+            createViewModel().stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `initial state should leave the access type alone when send controls is disabled`() {
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE)
+
+        assertEquals(
+            DEFAULT_STATE.copy(whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE),
+            createViewModel().stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `access type should update when the enforced access type changes in add mode`() = runTest {
+        mutableSendControlsFlagFlow.value = true
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(DEFAULT_STATE.copy(isSendControlsEnabled = true), awaitItem())
+
+            mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY
+                .copy(whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED)
+
+            assertEquals(
+                enforcedAccessState(
+                    whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED,
+                    sendAuth = SendAuth.Password,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `access type should keep entered emails when the enforcement repeats the current type`() =
+        runTest {
+            mutableSendControlsFlagFlow.value = true
+            val enteredEmails = SendAuth.Email(
+                emails = persistentListOf(AuthEmail(value = "test@example.com")),
+            )
+            val initialState = DEFAULT_STATE.copy(
+                isSendControlsEnabled = true,
+                viewState = DEFAULT_VIEW_STATE.copy(
+                    common = DEFAULT_COMMON_STATE.copy(sendAuth = enteredEmails),
+                ),
+            )
+            val viewModel = createViewModel(state = initialState)
+
+            viewModel.stateFlow.test {
+                assertEquals(initialState, awaitItem())
+
+                mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY
+                    .copy(whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE)
+
+                // The emails already typed survive the policy re-confirming the same type.
+                assertEquals(
+                    initialState.copy(whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `access type should not change when the enforced access type changes in edit mode`() =
+        runTest {
+            mutableSendControlsFlagFlow.value = true
+            val sendId = "sendId-1"
+            val mockSendView = createMockSendView(number = 1)
+            every {
+                mockSendView.toViewState(
+                    baseWebSendUrl = DEFAULT_ENVIRONMENT_URL,
+                    isHideEmailAddressEnabled = true,
+                )
+            } returns DEFAULT_VIEW_STATE
+            mutableSendDataStateFlow.value = DataState.Loaded(mockSendView)
+            val initialState = DEFAULT_STATE.copy(
+                addEditSendType = AddEditSendType.EditItem(sendItemId = sendId),
+                isSendControlsEnabled = true,
+            )
+            val viewModel = createViewModel(
+                state = initialState,
+                addEditSendType = AddEditSendType.EditItem(sendItemId = sendId),
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(initialState, awaitItem())
+
+                mutableEffectiveSendPolicyFlow.value =
+                    DEFAULT_EFFECTIVE_SEND_POLICY.copy(
+                        whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE,
+                    )
+
+                // The existing Send keeps its own access type even though it is now enforced.
+                assertEquals(
+                    initialState.copy(whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `access type should not change when the policy changes with send controls off`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(DEFAULT_STATE, awaitItem())
+
+            mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY
+                .copy(whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE)
+
+            assertEquals(
+                DEFAULT_STATE.copy(whoCanAccess = SendAccessTypeJson.SPECIFIC_PEOPLE),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `access type should stay put when the enforcement is lifted`() = runTest {
+        mutableSendControlsFlagFlow.value = true
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED)
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(
+                enforcedAccessState(
+                    whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED,
+                    sendAuth = SendAuth.Password,
+                ),
+                awaitItem(),
+            )
+
+            mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY
+
+            // Unlocking the chooser leaves the selection as-is rather than discarding it.
+            assertEquals(
+                DEFAULT_STATE.copy(
+                    isSendControlsEnabled = true,
+                    viewState = DEFAULT_VIEW_STATE.copy(
+                        common = DEFAULT_COMMON_STATE.copy(sendAuth = SendAuth.Password),
+                    ),
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `access type should stay put when send controls is turned off`() = runTest {
+        mutableSendControlsFlagFlow.value = true
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED)
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(
+                enforcedAccessState(
+                    whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED,
+                    sendAuth = SendAuth.Password,
+                ),
+                awaitItem(),
+            )
+
+            mutableSendControlsFlagFlow.value = false
+
+            assertEquals(
+                DEFAULT_STATE.copy(
+                    whoCanAccess = SendAccessTypeJson.PASSWORD_PROTECTED,
+                    viewState = DEFAULT_VIEW_STATE.copy(
+                        common = DEFAULT_COMMON_STATE.copy(sendAuth = SendAuth.Password),
+                    ),
+                ),
+                awaitItem(),
+            )
+        }
+    }
 
     @Test
     fun `initial state should read from saved state when present`() {
@@ -1717,6 +1961,20 @@ private val DEFAULT_STATE = AddEditSendState(
     whoCanAccess = null,
     sendType = SendItemType.TEXT,
     isPremium = true,
+)
+
+/**
+ * Builds the state expected when [whoCanAccess] is enforced and has forced [sendAuth].
+ */
+private fun enforcedAccessState(
+    whoCanAccess: SendAccessTypeJson,
+    sendAuth: SendAuth,
+): AddEditSendState = DEFAULT_STATE.copy(
+    isSendControlsEnabled = true,
+    whoCanAccess = whoCanAccess,
+    viewState = DEFAULT_VIEW_STATE.copy(
+        common = DEFAULT_COMMON_STATE.copy(sendAuth = sendAuth),
+    ),
 )
 
 private val ENFORCED_DELETION_DATE: Instant = Instant.parse("2023-10-28T12:00:00Z")

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -384,18 +385,44 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `initial state should use the enforced access type for an any policy`() {
+    fun `initial state should leave the access type alone for an any policy`() {
         mutableSendControlsFlagFlow.value = true
         mutableEffectiveSendPolicyFlow.value =
             DEFAULT_EFFECTIVE_SEND_POLICY.copy(whoCanAccess = SendAccessTypeJson.ANY)
 
+        // Every option stays available, so nothing is enforced and the chooser stays interactive.
+        val state = createViewModel().stateFlow.value
         assertEquals(
-            enforcedAccessState(
+            DEFAULT_STATE.copy(
+                isSendControlsEnabled = true,
                 whoCanAccess = SendAccessTypeJson.ANY,
-                sendAuth = SendAuth.None,
             ),
-            createViewModel().stateFlow.value,
+            state,
         )
+        assertNull(state.enforcedWhoCanAccess)
+    }
+
+    @Test
+    fun `access type should stay put when an any policy arrives`() = runTest {
+        mutableSendControlsFlagFlow.value = true
+        val initialState = DEFAULT_STATE.copy(
+            isSendControlsEnabled = true,
+            viewState = DEFAULT_VIEW_STATE.copy(
+                common = DEFAULT_COMMON_STATE.copy(sendAuth = SendAuth.Password),
+            ),
+        )
+        val viewModel = createViewModel(state = initialState)
+
+        viewModel.stateFlow.test {
+            assertEquals(initialState, awaitItem())
+
+            mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY
+                .copy(whoCanAccess = SendAccessTypeJson.ANY)
+
+            val state = initialState.copy(whoCanAccess = SendAccessTypeJson.ANY)
+            assertEquals(state, awaitItem())
+            assertNull(state.enforcedWhoCanAccess)
+        }
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40531

## 📔 Objective

When an org's SendControls policy sets `whoCanAccess`, the "Who can view" chooser on the Add Send
screen starts on the enforced option and can't be changed.

### What changed

- Two policy values restrict the chooser, and both map to an option that already exists:
  `SPECIFIC_PEOPLE` → Specific people, `PASSWORD_PROTECTED` → Anyone with a password set by you
- `ANY` leaves every option available, so it is not a restriction. The chooser stays interactive,
  same as no policy at all
- Lock only, no new options and no new strings
- Email and password sub-fields stay editable while the chooser is locked

### Why the ViewModel, not the chooser

- The ticket's breakdown suggested forcing the value in `AddEditSendAuthTypeChooser`
- Doing it there would let the chooser show one thing while state held another, and state is what
  gets saved
- The chooser already reads its selection from state, so its side of this is a one-line `isEnabled`
  change

### Out of scope

- Existing Sends keep the access type they were created with. Non-compliant items get handled
  separately, when the edit option is disabled for them
- Supporting text is unchanged, so no "enforced by your organization" message

### Worth flagging

- Dropping the enforcement mid-screen re-enables the picker and leaves the selection and anything
  typed alone. PM-40532 reset the deletion date to its default instead; resetting here would throw
  away entered emails or a password for no reason
- Specific people is forced even without premium, since the policy outranks the premium gate that
  normally blocks picking it by hand

## 📸 Screenshots
| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/6c5a4583-02cf-48f7-9171-d5b8388cd5d0" /> | <img width="365" src="https://github.com/user-attachments/assets/02080b75-7817-42a2-9891-b59e9a1e8736" /> |
| <img width="365" src="https://github.com/user-attachments/assets/6c5a4583-02cf-48f7-9171-d5b8388cd5d0" /> | <img width="365" src="https://github.com/user-attachments/assets/b579b2be-9495-4cfc-9ebe-6424f48262ca" /> |
