### PR TITLE
llm: Route GitHub Packages credential through $GITHUB_ENV in SDK-eval workflow

### DIFF
--- a/.github/workflows/sdlc-sdk-update-evaluate.yml
+++ b/.github/workflows/sdlc-sdk-update-evaluate.yml
@@ -85,11 +85,17 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: ./.github/actions/setup-android-build
 
+      - name: Expose GitHub Packages credential
+        if: steps.gate.outputs.skip == 'false'
+        # claude-code-action's composite step shadows caller env, so GITHUB_TOKEN has to
+        # reach the Claude CLI subprocess through $GITHUB_ENV for settings.gradle.kts.
+        env:
+          GH_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "GITHUB_TOKEN=$GH_PACKAGES_TOKEN" >> "$GITHUB_ENV"
+
       - name: Run Claude Code
         id: claude
         if: steps.gate.outputs.skip == 'false'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # settings.gradle.kts resolves the SDK from GitHub Packages
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-RESPONSE-API-KEY }}


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/android/pull/7267 — the SDK-eval workflow's compile-verification step failed to authenticate against GitHub Packages on that PR.

## 📔 Objective

The compile-verification step in the SDK-eval workflow 401'd resolving `com.bitwarden:sdk-android`, even though the job's `GITHUB_TOKEN` carries `packages:read` identical to the working `build.yml`/`test.yml` setup. `claude-code-action`'s CLI-launching step shadows the calling workflow's env, per its own `action.yml`, so `GITHUB_TOKEN` set on the outer step never reached the Gradle process Claude's Bash tool spawned. Routing the token through `$GITHUB_ENV` propagates it past that shadowing, matching how every other workflow in this repo already passes this token.
