### PR TITLE
[PM-42107] feat: Wire SendControls policy awareness into the View Send screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -80,6 +80,27 @@ private const val KEY_STATE = "state"
 private const val MAX_FILE_SIZE_BYTES: Long = 100 * 1024 * 1024
 
 /**
+ * Whether this email address belongs to one of [allowedDomains], compared case-insensitively.
+ */
+private fun String.hasAllowedDomain(allowedDomains: List<String>): Boolean {
+    val domain = substringAfterLast(delimiter = '@', missingDelimiterValue = "")
+    return allowedDomains.any { it.equals(other = domain, ignoreCase = true) }
+}
+
+/**
+ * Splits this comma-separated policy value into trimmed, non-blank domains.
+ *
+ * Returns an empty list when no domain is configured, which includes a value that holds nothing
+ * usable such as `","`. An empty result is treated as no restriction rather than as a restriction
+ * nothing can satisfy, since the latter would block saving with no way for the user to recover.
+ */
+private fun String?.toAllowedDomains(): List<String> = this
+    ?.split(",")
+    ?.map { it.trim() }
+    ?.filter { it.isNotBlank() }
+    .orEmpty()
+
+/**
  * Returns the [SendAuth] this access type restricts a Send to, preserving [current] when it already
  * matches the restricted type so that any emails already entered are kept.
  */
@@ -494,6 +515,24 @@ class AddEditSendViewModel @Inject constructor(
         return clock.instant().plus(hours, ChronoUnit.HOURS)
     }
 
+    /**
+     * Returns the error to show when any of [emails] falls outside the recipient domains the
+     * SendControls policy allows, or `null` when every recipient is acceptable.
+     */
+    private fun AddEditSendState.disallowedDomainErrorOrNull(
+        emails: List<AuthEmail>,
+    ): AddEditSendState.DialogState.Error? {
+        val enforced = enforcedAllowedDomains
+        if (enforced.isEmpty()) return null
+        if (emails.all { it.value.hasAllowedDomain(enforced) }) return null
+        return AddEditSendState.DialogState.Error(
+            title = BitwardenString.invalid_email_addresses.asText(),
+            message = BitwardenString
+                .only_include_the_following_domains_x_please_review_and_try_again
+                .asText(enforced.joinToString(separator = ", ")),
+        )
+    }
+
     @Suppress("LongMethod")
     private fun handleSendDataReceive(action: AddEditSendAction.Internal.SendDataReceive) {
         when (val sendDataState = action.sendDataState) {
@@ -800,6 +839,11 @@ class AddEditSendViewModel @Inject constructor(
                     }
                     return@onContent
                 }
+
+                state.disallowedDomainErrorOrNull(emails = nonBlankEmails)?.let { error ->
+                    mutableStateFlow.update { it.copy(dialogState = error) }
+                    return@onContent
+                }
             }
 
             (content.selectedType as? AddEditSendState.ViewState.Content.SendType.File)
@@ -996,8 +1040,8 @@ class AddEditSendViewModel @Inject constructor(
 /**
  * Models state for the add/edit send screen.
  *
- * @property allowedDomains The allowed recipient email domains, sourced from
- * [EffectiveSendPolicy.allowedDomains]. Currently unused by the UI.
+ * @property allowedDomains The allowed recipient email domains as a comma-separated list, sourced
+ * from [EffectiveSendPolicy.allowedDomains].
  * @property allowedSendTypes The types of Sends that are allowed to be created, sourced from
  * [EffectiveSendPolicy.allowedSendTypes]. Currently unused by the UI.
  * @property deletionHours The enforced Send deletion window in hours, sourced from
@@ -1022,6 +1066,14 @@ data class AddEditSendState(
     val whoCanAccess: SendAccessTypeJson?,
     val isPremium: Boolean,
 ) : Parcelable {
+
+    /**
+     * Helper to determine the recipient email domains the SendControls policy restricts a Send to,
+     * or an empty list when recipients may use any domain. The legacy send options policy has no
+     * equivalent enforcement, so this is only in effect alongside the SendControls feature flag.
+     */
+    val enforcedAllowedDomains: List<String>
+        get() = allowedDomains.takeIf { isSendControlsEnabled }.toAllowedDomains()
 
     /**
      * Helper to determine the Send deletion window enforced by the SendControls policy, or `null`

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -51,6 +51,7 @@ import com.x8bit.bitwarden.ui.tools.feature.send.addedit.util.toViewState
 import com.x8bit.bitwarden.ui.tools.feature.send.model.SendItemType
 import com.x8bit.bitwarden.ui.tools.feature.send.util.toSendUrl
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.combine
@@ -94,11 +95,12 @@ private fun String.hasAllowedDomain(allowedDomains: List<String>): Boolean {
  * usable such as `","`. An empty result is treated as no restriction rather than as a restriction
  * nothing can satisfy, since the latter would block saving with no way for the user to recover.
  */
-private fun String?.toAllowedDomains(): List<String> = this
+private fun String?.splitToDomains(): ImmutableList<String> = this
     ?.split(",")
     ?.map { it.trim() }
     ?.filter { it.isNotBlank() }
     .orEmpty()
+    .toImmutableList()
 
 /**
  * Returns the [SendAuth] this access type restricts a Send to, preserving [current] when it already
@@ -1072,8 +1074,8 @@ data class AddEditSendState(
      * or an empty list when recipients may use any domain. The legacy send options policy has no
      * equivalent enforcement, so this is only in effect alongside the SendControls feature flag.
      */
-    val enforcedAllowedDomains: List<String>
-        get() = allowedDomains.takeIf { isSendControlsEnabled }.toAllowedDomains()
+    val enforcedAllowedDomains: ImmutableList<String>
+        get() = allowedDomains.takeIf { isSendControlsEnabled }.splitToDomains()
 
     /**
      * Helper to determine the Send deletion window enforced by the SendControls policy, or `null`

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
@@ -3,8 +3,10 @@ package com.x8bit.bitwarden.ui.tools.feature.send.viewsend
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.data.repository.util.baseWebSendUrl
+import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.send.SendView
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
@@ -14,14 +16,20 @@ import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.x8bit.bitwarden.data.platform.manager.model.EffectiveSendPolicy
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import com.x8bit.bitwarden.ui.tools.feature.send.model.SendItemType
+import com.x8bit.bitwarden.ui.tools.feature.send.util.toSendItemType
+import com.x8bit.bitwarden.ui.tools.feature.send.viewsend.model.SendPolicyRestriction
 import com.x8bit.bitwarden.ui.tools.feature.send.viewsend.util.toViewSendViewStateContent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -36,7 +44,7 @@ private const val KEY_STATE = "state"
 /**
  * View model for the view send screen.
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class ViewSendViewModel @Inject constructor(
     private val clipboardManager: BitwardenClipboardManager,
@@ -44,6 +52,8 @@ class ViewSendViewModel @Inject constructor(
     private val clock: Clock,
     private val vaultRepository: VaultRepository,
     environmentRepository: EnvironmentRepository,
+    featureFlagManager: FeatureFlagManager,
+    policyManager: PolicyManager,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<ViewSendState, ViewSendEvent, ViewSendAction>(
     // We load the state from the savedStateHandle for testing purposes.
@@ -55,6 +65,10 @@ class ViewSendViewModel @Inject constructor(
             viewState = ViewSendState.ViewState.Loading,
             dialogState = null,
             baseWebSendUrl = environmentRepository.environment.baseWebSendUrl,
+            allowedSendTypes = null,
+            isSendDisabled = false,
+            isSendControlsEnabled = false,
+            isSendControlsExistingSendsEnabled = false,
         )
     },
 ) {
@@ -67,6 +81,22 @@ class ViewSendViewModel @Inject constructor(
         snackbarRelayManager
             .getSnackbarDataFlow(SnackbarRelay.SEND_UPDATED)
             .map { ViewSendAction.Internal.SnackbarDataReceived(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
+        // The effective policy itself depends on the feature flags, so all three are observed
+        // together to keep the derived restriction consistent whenever any one of them changes.
+        combine(
+            policyManager.getEffectiveSendPolicyFlow(),
+            featureFlagManager.getFeatureFlagFlow(key = FlagKey.SendControls),
+            featureFlagManager.getFeatureFlagFlow(key = FlagKey.SendControlsExistingSends),
+        ) { effectiveSendPolicy, isSendControlsEnabled, isSendControlsExistingSendsEnabled ->
+            ViewSendAction.Internal.EffectiveSendPolicyReceive(
+                effectiveSendPolicy = effectiveSendPolicy,
+                isSendControlsEnabled = isSendControlsEnabled,
+                isSendControlsExistingSendsEnabled = isSendControlsExistingSendsEnabled,
+            )
+        }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
     }
@@ -88,7 +118,23 @@ class ViewSendViewModel @Inject constructor(
         when (action) {
             is ViewSendAction.Internal.SendDataReceive -> handleSendDataReceive(action)
             is ViewSendAction.Internal.DeleteResultReceive -> handleDeleteResultReceive(action)
+            is ViewSendAction.Internal.EffectiveSendPolicyReceive -> {
+                handleEffectiveSendPolicyReceive(action)
+            }
+
             is ViewSendAction.Internal.SnackbarDataReceived -> handleSnackbarDataReceived(action)
+        }
+    }
+
+    private fun handleEffectiveSendPolicyReceive(
+        action: ViewSendAction.Internal.EffectiveSendPolicyReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(
+                allowedSendTypes = action.effectiveSendPolicy.allowedSendTypes,
+                isSendControlsEnabled = action.isSendControlsEnabled,
+                isSendControlsExistingSendsEnabled = action.isSendControlsExistingSendsEnabled,
+            )
         }
     }
 
@@ -218,6 +264,7 @@ class ViewSendViewModel @Inject constructor(
     private fun updateStateWithSendView(sendView: SendView) {
         mutableStateFlow.update {
             it.copy(
+                isSendDisabled = sendView.disabled,
                 viewState = sendView.toViewSendViewStateContent(
                     baseWebSendUrl = it.baseWebSendUrl,
                     clock = clock,
@@ -239,6 +286,14 @@ class ViewSendViewModel @Inject constructor(
 
 /**
  * Models state for the new send screen.
+ *
+ * @property allowedSendTypes The types of Sends that are allowed to exist, sourced from
+ * [EffectiveSendPolicy.allowedSendTypes]. A `null` value means no type restriction is in effect.
+ * @property isSendDisabled Whether the server has marked this Send disabled.
+ * @property isSendControlsEnabled Whether the SendControls policy is in effect, which is what makes
+ * a disabled Send attributable to that policy.
+ * @property isSendControlsExistingSendsEnabled Whether enforcement against Sends that predate the
+ * policy is enabled.
  */
 @Parcelize
 data class ViewSendState(
@@ -247,6 +302,10 @@ data class ViewSendState(
     val viewState: ViewState,
     val dialogState: DialogState?,
     val baseWebSendUrl: String,
+    val allowedSendTypes: List<SendTypeJson>?,
+    val isSendDisabled: Boolean,
+    val isSendControlsEnabled: Boolean,
+    val isSendControlsExistingSendsEnabled: Boolean,
 ) : Parcelable {
     /**
      * Helper to determine the screen display name.
@@ -258,9 +317,37 @@ data class ViewSendState(
         }
 
     /**
-     * Whether the fab is visible.
+     * Helper to determine how the SendControls policy restricts this Send, or `null` when it is
+     * unrestricted and the screen behaves as it always has.
+     *
+     * A Send is only treated as policy-restricted while both feature flags are enabled, since
+     * `disabled` is also set when the Send is deactivated by hand on another client.
      */
-    val isFabVisible: Boolean get() = viewState is ViewState.Content
+    val policyRestriction: SendPolicyRestriction?
+        get() = when {
+            !isSendControlsExistingSendsEnabled || !isSendControlsEnabled -> null
+            !isSendDisabled -> null
+            // A file send is reported as simply non-compliant even when its type is also
+            // disallowed, since its attachment cannot be uploaded again either way.
+            sendType == SendItemType.FILE -> SendPolicyRestriction.FileNotCompliant
+            !isSendTypeAllowed -> SendPolicyRestriction.TypeNotAllowed
+            else -> SendPolicyRestriction.CopyRequired
+        }
+
+    /**
+     * Whether the fab is visible. A policy-restricted Send cannot be edited, so it has no fab.
+     */
+    val isFabVisible: Boolean
+        get() = viewState is ViewState.Content && policyRestriction == null
+
+    /**
+     * Whether this Send's type is still allowed by the policy.
+     */
+    private val isSendTypeAllowed: Boolean
+        get() = allowedSendTypes
+            ?.map { it.toSendItemType() }
+            ?.contains(sendType)
+            ?: true
 
     /**
      * Represents the specific view states for the view send screen.
@@ -418,6 +505,16 @@ sealed class ViewSendAction {
          * Indicates a result for deleting the send has been received.
          */
         data class DeleteResultReceive(val result: DeleteSendResult) : Internal()
+
+        /**
+         * Indicates that the effective Send policy, or either feature flag it depends on, has
+         * changed.
+         */
+        data class EffectiveSendPolicyReceive(
+            val effectiveSendPolicy: EffectiveSendPolicy,
+            val isSendControlsEnabled: Boolean,
+            val isSendControlsExistingSendsEnabled: Boolean,
+        ) : Internal()
 
         /**
          * Indicates that the send item data has been received.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
@@ -345,8 +345,7 @@ data class ViewSendState(
      */
     private val isSendTypeAllowed: Boolean
         get() = allowedSendTypes
-            ?.map { it.toSendItemType() }
-            ?.contains(sendType)
+            ?.any { it.toSendItemType() == sendType }
             ?: true
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
@@ -285,7 +285,7 @@ class ViewSendViewModel @Inject constructor(
 }
 
 /**
- * Models state for the new send screen.
+ * Models state for the view send screen.
  *
  * @property allowedSendTypes The types of Sends that are allowed to exist, sourced from
  * [EffectiveSendPolicy.allowedSendTypes]. A `null` value means no type restriction is in effect.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/model/SendPolicyRestriction.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/model/SendPolicyRestriction.kt
@@ -1,0 +1,41 @@
+package com.x8bit.bitwarden.ui.tools.feature.send.viewsend.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * The reason a Send is restricted by its organization's SendControls policy, which determines the
+ * warning shown on the view send screen and whether a compliant copy can be made.
+ */
+sealed class SendPolicyRestriction : Parcelable {
+    /**
+     * Whether a compliant copy of the Send can be made to replace it.
+     */
+    abstract val isCopyable: Boolean
+
+    /**
+     * The Send is a file send, so it cannot be brought into compliance: its attachment is not
+     * available to upload again.
+     */
+    @Parcelize
+    data object FileNotCompliant : SendPolicyRestriction() {
+        override val isCopyable: Boolean get() = false
+    }
+
+    /**
+     * The Send's type is no longer allowed by the policy, so a copy would be blocked by the same
+     * restriction.
+     */
+    @Parcelize
+    data object TypeNotAllowed : SendPolicyRestriction() {
+        override val isCopyable: Boolean get() = false
+    }
+
+    /**
+     * The Send can be replaced by a copy that satisfies the policy.
+     */
+    @Parcelize
+    data object CopyRequired : SendPolicyRestriction() {
+        override val isCopyable: Boolean get() = true
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -55,6 +55,7 @@ import io.mockk.runs
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -926,6 +927,178 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
             ),
             viewModel.stateFlow.value,
         )
+    }
+
+    @Test
+    fun `SaveClick with a recipient outside the allowed domains should show error dialog`() {
+        val viewState = emailViewState(emails = listOf("recipient@example.com"))
+        val viewModel = createViewModelWithDomainPolicy(
+            viewState = viewState,
+            allowedDomains = "bitwarden.com",
+        )
+
+        viewModel.trySendAction(AddEditSendAction.SaveClick)
+
+        assertEquals(
+            domainPolicyState(viewState = viewState, allowedDomains = "bitwarden.com").copy(
+                dialogState = AddEditSendState.DialogState.Error(
+                    title = BitwardenString.invalid_email_addresses.asText(),
+                    message = BitwardenString
+                        .only_include_the_following_domains_x_please_review_and_try_again
+                        .asText("bitwarden.com"),
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `SaveClick outside the allowed domains should list every allowed domain`() {
+        val viewState = emailViewState(emails = listOf("recipient@example.com"))
+        val domains = "bitwarden.com,bitwarden.eu"
+        val viewModel = createViewModelWithDomainPolicy(
+            viewState = viewState,
+            allowedDomains = domains,
+        )
+
+        viewModel.trySendAction(AddEditSendAction.SaveClick)
+
+        assertEquals(
+            domainPolicyState(viewState = viewState, allowedDomains = domains).copy(
+                dialogState = AddEditSendState.DialogState.Error(
+                    title = BitwardenString.invalid_email_addresses.asText(),
+                    message = BitwardenString
+                        .only_include_the_following_domains_x_please_review_and_try_again
+                        .asText("bitwarden.com, bitwarden.eu"),
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `SaveClick outside the allowed domains should normalize the policy value`() {
+        val viewState = emailViewState(emails = listOf("recipient@example.com"))
+        val domains = " bitwarden.com , , bitwarden.eu "
+        val viewModel = createViewModelWithDomainPolicy(
+            viewState = viewState,
+            allowedDomains = domains,
+        )
+
+        viewModel.trySendAction(AddEditSendAction.SaveClick)
+
+        // Padding and the empty entry are dropped for both matching and display.
+        assertEquals(
+            domainPolicyState(viewState = viewState, allowedDomains = domains).copy(
+                dialogState = AddEditSendState.DialogState.Error(
+                    title = BitwardenString.invalid_email_addresses.asText(),
+                    message = BitwardenString
+                        .only_include_the_following_domains_x_please_review_and_try_again
+                        .asText("bitwarden.com, bitwarden.eu"),
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `SaveClick with every recipient inside the allowed domains should save`() {
+        val viewState = emailViewState(
+            emails = listOf("one@bitwarden.com", "two@BITWARDEN.EU"),
+        )
+        val mockSendView = stubCreateSend(viewState = viewState)
+        val viewModel = createViewModelWithDomainPolicy(
+            viewState = viewState,
+            allowedDomains = "bitwarden.com, bitwarden.eu",
+        )
+
+        viewModel.trySendAction(AddEditSendAction.SaveClick)
+
+        // Matching is case-insensitive, so the save proceeds to the repository.
+        coVerify(exactly = 1) {
+            vaultRepository.createSend(sendView = mockSendView, fileUri = null)
+        }
+    }
+
+    @Test
+    fun `SaveClick should skip domain validation when send controls is disabled`() {
+        val viewState = emailViewState(emails = listOf("recipient@example.com"))
+        val mockSendView = stubCreateSend(viewState = viewState)
+        val viewModel = createViewModelWithDomainPolicy(
+            viewState = viewState,
+            allowedDomains = "bitwarden.com",
+            isSendControlsEnabled = false,
+        )
+
+        viewModel.trySendAction(AddEditSendAction.SaveClick)
+
+        coVerify(exactly = 1) {
+            vaultRepository.createSend(sendView = mockSendView, fileUri = null)
+        }
+    }
+
+    @Test
+    fun `SaveClick should skip domain validation when the policy sets no domains`() {
+        val viewState = emailViewState(emails = listOf("recipient@example.com"))
+        val mockSendView = stubCreateSend(viewState = viewState)
+        val viewModel = createViewModelWithDomainPolicy(
+            viewState = viewState,
+            allowedDomains = null,
+        )
+
+        viewModel.trySendAction(AddEditSendAction.SaveClick)
+
+        coVerify(exactly = 1) {
+            vaultRepository.createSend(sendView = mockSendView, fileUri = null)
+        }
+    }
+
+    @Test
+    fun `SaveClick should skip domain validation for other access types`() {
+        val viewState = DEFAULT_VIEW_STATE.copy(
+            common = DEFAULT_COMMON_STATE.copy(name = "test", sendAuth = SendAuth.Password),
+        )
+        val mockSendView = stubCreateSend(viewState = viewState)
+        val viewModel = createViewModelWithDomainPolicy(
+            viewState = viewState,
+            allowedDomains = "bitwarden.com",
+        )
+
+        viewModel.trySendAction(AddEditSendAction.SaveClick)
+
+        coVerify(exactly = 1) {
+            vaultRepository.createSend(sendView = mockSendView, fileUri = null)
+        }
+    }
+
+    /**
+     * Stubs out a successful conversion and creation of the Send backing [viewState], returning the
+     * [SendView] the repository is expected to be called with.
+     */
+    private fun stubCreateSend(viewState: AddEditSendState.ViewState.Content): SendView {
+        val mockSendView = mockk<SendView>()
+        every { viewState.toSendView(clock) } returns mockSendView
+        coEvery {
+            vaultRepository.createSend(sendView = mockSendView, fileUri = null)
+        } returns CreateSendResult.Error(message = null, error = null)
+        return mockSendView
+    }
+
+    /**
+     * Creates a view model whose SendControls policy restricts recipients to [allowedDomains].
+     *
+     * The policy is applied through the flows rather than the initial state, since the view model
+     * overwrites its own policy fields as soon as it subscribes to them.
+     */
+    private fun createViewModelWithDomainPolicy(
+        viewState: AddEditSendState.ViewState.Content,
+        allowedDomains: String?,
+        isSendControlsEnabled: Boolean = true,
+    ): AddEditSendViewModel {
+        mutableSendControlsFlagFlow.value = isSendControlsEnabled
+        mutableEffectiveSendPolicyFlow.value =
+            DEFAULT_EFFECTIVE_SEND_POLICY.copy(allowedDomains = allowedDomains)
+        return createViewModel(DEFAULT_STATE.copy(viewState = viewState))
     }
 
     @Test
@@ -1989,6 +2162,32 @@ private val DEFAULT_STATE = AddEditSendState(
     sendType = SendItemType.TEXT,
     isPremium = true,
 )
+
+/**
+ * Builds the state expected once the SendControls policy restricting recipients to
+ * [allowedDomains] has been applied on top of [viewState].
+ */
+private fun domainPolicyState(
+    viewState: AddEditSendState.ViewState.Content,
+    allowedDomains: String?,
+): AddEditSendState = DEFAULT_STATE.copy(
+    viewState = viewState,
+    isSendControlsEnabled = true,
+    allowedDomains = allowedDomains,
+)
+
+/**
+ * Builds a named content view state whose recipients are [emails].
+ */
+private fun emailViewState(emails: List<String>): AddEditSendState.ViewState.Content =
+    DEFAULT_VIEW_STATE.copy(
+        common = DEFAULT_COMMON_STATE.copy(
+            name = "test",
+            sendAuth = SendAuth.Email(
+                emails = emails.map { AuthEmail(value = it) }.toImmutableList(),
+            ),
+        ),
+    )
 
 /**
  * Builds the state expected when [whoCanAccess] is enforced and has forced [sendAuth].

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
@@ -357,4 +357,8 @@ private val DEFAULT_STATE = ViewSendState(
     viewState = DEFAULT_CONTENT_VIEW_STATE,
     dialogState = null,
     baseWebSendUrl = "https://send.bitwarden.com/#",
+    allowedSendTypes = null,
+    isSendDisabled = false,
+    isSendControlsEnabled = false,
+    isSendControlsExistingSendsEnabled = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModelTest.kt
@@ -6,6 +6,7 @@ import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
+import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.send.SendView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
@@ -23,6 +24,7 @@ import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import com.x8bit.bitwarden.ui.tools.feature.send.model.SendItemType
+import com.x8bit.bitwarden.ui.tools.feature.send.viewsend.model.SendPolicyRestriction
 import com.x8bit.bitwarden.ui.tools.feature.send.viewsend.util.toViewSendViewStateContent
 import io.mockk.coEvery
 import io.mockk.every
@@ -37,6 +39,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -103,6 +108,131 @@ class ViewSendViewModelTest : BaseViewModelTest() {
         )
     }
 
+    @Test
+    fun `policy restriction should require a copy for a disabled text send`() {
+        val state = restrictedState()
+
+        assertEquals(SendPolicyRestriction.CopyRequired, state.policyRestriction)
+        assertFalse(state.isFabVisible)
+    }
+
+    @Test
+    fun `policy restriction should report a file send as not compliant`() {
+        val state = restrictedState(sendType = SendItemType.FILE)
+
+        assertEquals(SendPolicyRestriction.FileNotCompliant, state.policyRestriction)
+        assertFalse(state.isFabVisible)
+    }
+
+    @Test
+    fun `policy restriction should report a text send whose type is not allowed`() {
+        val state = restrictedState(allowedSendTypes = listOf(SendTypeJson.FILE))
+
+        assertEquals(SendPolicyRestriction.TypeNotAllowed, state.policyRestriction)
+        assertFalse(state.isFabVisible)
+    }
+
+    @Test
+    fun `policy restriction should report a file send as not compliant before type`() {
+        val state = restrictedState(
+            sendType = SendItemType.FILE,
+            allowedSendTypes = listOf(SendTypeJson.TEXT),
+        )
+
+        // A file send cannot be copied either way, so the type restriction is not reported.
+        assertEquals(SendPolicyRestriction.FileNotCompliant, state.policyRestriction)
+    }
+
+    @Test
+    fun `policy restriction should be absent when the send type is allowed`() {
+        val state = restrictedState(allowedSendTypes = listOf(SendTypeJson.TEXT))
+
+        assertEquals(SendPolicyRestriction.CopyRequired, state.policyRestriction)
+    }
+
+    @Test
+    fun `policy restriction should be absent when the send is not disabled`() {
+        val state = restrictedState(isSendDisabled = false)
+
+        assertNull(state.policyRestriction)
+        assertTrue(state.isFabVisible)
+    }
+
+    @Test
+    fun `policy restriction should be absent when send controls is disabled`() {
+        val state = restrictedState(isSendControlsEnabled = false)
+
+        assertNull(state.policyRestriction)
+        assertTrue(state.isFabVisible)
+    }
+
+    @Test
+    fun `policy restriction should be absent when existing sends enforcement is disabled`() {
+        val state = restrictedState(isSendControlsExistingSendsEnabled = false)
+
+        assertNull(state.policyRestriction)
+        assertTrue(state.isFabVisible)
+    }
+
+    @Test
+    fun `state should update when the enforced send types change`() = runTest {
+        mutableSendStateFlow.value = DataState.Loaded(createDisabledSendView())
+        mutableSendControlsFlagFlow.value = true
+        mutableExistingSendsFlagFlow.value = true
+        val viewModel = createViewModel()
+        val enforcedState = DEFAULT_STATE.copy(
+            isSendDisabled = true,
+            isSendControlsEnabled = true,
+            isSendControlsExistingSendsEnabled = true,
+            viewState = DEFAULT_CONTENT_VIEW_STATE,
+        )
+
+        viewModel.stateFlow.test {
+            val initialState = awaitItem()
+            assertEquals(enforcedState, initialState)
+            assertEquals(SendPolicyRestriction.CopyRequired, initialState.policyRestriction)
+
+            mutableEffectiveSendPolicyFlow.value = DEFAULT_EFFECTIVE_SEND_POLICY
+                .copy(allowedSendTypes = listOf(SendTypeJson.FILE))
+
+            val state = awaitItem()
+            assertEquals(enforcedState.copy(allowedSendTypes = listOf(SendTypeJson.FILE)), state)
+            assertEquals(SendPolicyRestriction.TypeNotAllowed, state.policyRestriction)
+        }
+    }
+
+    @Test
+    fun `state should update when the existing sends flag is turned off`() = runTest {
+        mutableSendStateFlow.value = DataState.Loaded(createDisabledSendView())
+        mutableSendControlsFlagFlow.value = true
+        mutableExistingSendsFlagFlow.value = true
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(SendPolicyRestriction.CopyRequired, awaitItem().policyRestriction)
+
+            mutableExistingSendsFlagFlow.value = false
+
+            val state = awaitItem()
+            assertEquals(
+                DEFAULT_STATE.copy(
+                    isSendDisabled = true,
+                    isSendControlsEnabled = true,
+                    viewState = DEFAULT_CONTENT_VIEW_STATE,
+                ),
+                state,
+            )
+            assertNull(state.policyRestriction)
+        }
+    }
+
+    @Test
+    fun `fab should remain hidden while the view state is loading`() {
+        val state = restrictedState(isSendDisabled = false)
+            .copy(viewState = ViewSendState.ViewState.Loading)
+
+        assertFalse(state.isFabVisible)
+    }
 
     @Test
     fun `on CloseClick should send NavigateBack`() = runTest {
@@ -517,6 +647,34 @@ private val DEFAULT_STATE = ViewSendState(
     isSendControlsEnabled = false,
     isSendControlsExistingSendsEnabled = false,
 )
+
+/**
+ * Builds a state that is policy-restricted by default, so each test only names the field it varies.
+ */
+private fun restrictedState(
+    sendType: SendItemType = SendItemType.TEXT,
+    allowedSendTypes: List<SendTypeJson>? = null,
+    isSendDisabled: Boolean = true,
+    isSendControlsEnabled: Boolean = true,
+    isSendControlsExistingSendsEnabled: Boolean = true,
+): ViewSendState = DEFAULT_STATE.copy(
+    sendType = sendType,
+    allowedSendTypes = allowedSendTypes,
+    isSendDisabled = isSendDisabled,
+    isSendControlsEnabled = isSendControlsEnabled,
+    isSendControlsExistingSendsEnabled = isSendControlsExistingSendsEnabled,
+    viewState = DEFAULT_CONTENT_VIEW_STATE,
+)
+
+/**
+ * Builds a [SendView] the server has marked disabled, mapped to [DEFAULT_CONTENT_VIEW_STATE].
+ */
+private fun createDisabledSendView(): SendView = mockk<SendView> {
+    every { disabled } returns true
+    every {
+        toViewSendViewStateContent(baseWebSendUrl = any(), clock = any())
+    } returns DEFAULT_CONTENT_VIEW_STATE
+}
 
 private val DEFAULT_EFFECTIVE_SEND_POLICY = EffectiveSendPolicy(
     allowedDomains = null,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModelTest.kt
@@ -144,7 +144,7 @@ class ViewSendViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `policy restriction should be absent when the send type is allowed`() {
+    fun `policy restriction should require a copy when the send type is allowed`() {
         val state = restrictedState(allowedSendTypes = listOf(SendTypeJson.TEXT))
 
         assertEquals(SendPolicyRestriction.CopyRequired, state.policyRestriction)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModelTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.tools.feature.send.viewsend
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
@@ -12,7 +13,10 @@ import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.x8bit.bitwarden.data.platform.manager.model.EffectiveSendPolicy
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSendView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
@@ -51,6 +55,20 @@ class ViewSendViewModelTest : BaseViewModelTest() {
     private val environmentRepository = mockk<EnvironmentRepository> {
         every { environment } returns Environment.Prod.Us
     }
+    private val mutableEffectiveSendPolicyFlow = MutableStateFlow(DEFAULT_EFFECTIVE_SEND_POLICY)
+    private val policyManager = mockk<PolicyManager> {
+        every { getEffectiveSendPolicyFlow() } returns mutableEffectiveSendPolicyFlow
+    }
+    private val mutableSendControlsFlagFlow = MutableStateFlow(false)
+    private val mutableExistingSendsFlagFlow = MutableStateFlow(false)
+    private val featureFlagManager = mockk<FeatureFlagManager> {
+        every {
+            getFeatureFlagFlow(key = FlagKey.SendControls)
+        } returns mutableSendControlsFlagFlow
+        every {
+            getFeatureFlagFlow(key = FlagKey.SendControlsExistingSends)
+        } returns mutableExistingSendsFlagFlow
+    }
     private val mutableSnackbarDataFlow: MutableSharedFlow<BitwardenSnackbarData> =
         bufferedMutableSharedFlow()
     private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay> = mockk {
@@ -84,6 +102,7 @@ class ViewSendViewModelTest : BaseViewModelTest() {
             viewModel.stateFlow.value,
         )
     }
+
 
     @Test
     fun `on CloseClick should send NavigateBack`() = runTest {
@@ -462,6 +481,8 @@ class ViewSendViewModelTest : BaseViewModelTest() {
         clock = FIXED_CLOCK,
         vaultRepository = vaultRepository,
         environmentRepository = environmentRepository,
+        featureFlagManager = featureFlagManager,
+        policyManager = policyManager,
         snackbarRelayManager = snackbarRelayManager,
         savedStateHandle = SavedStateHandle().apply {
             set(key = "state", value = state)
@@ -491,6 +512,19 @@ private val DEFAULT_STATE = ViewSendState(
     viewState = ViewSendState.ViewState.Loading,
     dialogState = null,
     baseWebSendUrl = "https://send.bitwarden.com/#",
+    allowedSendTypes = null,
+    isSendDisabled = false,
+    isSendControlsEnabled = false,
+    isSendControlsExistingSendsEnabled = false,
+)
+
+private val DEFAULT_EFFECTIVE_SEND_POLICY = EffectiveSendPolicy(
+    allowedDomains = null,
+    allowedSendTypes = null,
+    deletionHours = null,
+    disableHideEmail = false,
+    disableSend = false,
+    whoCanAccess = null,
 )
 
 private val FIXED_CLOCK: Clock = Clock.fixed(

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1250,6 +1250,7 @@ Do you want to switch to this account?</string>
     <string name="invalid_email_addresses">Invalid email addresses</string>
     <string name="one_or_more_email_addresses_are_incorrect">One or more email addresses are incorrect. Please review and try again.</string>
     <string name="no_email_addresses_entered">No email addresses entered</string>
+    <string name="only_include_the_following_domains_x_please_review_and_try_again">Only include the following domains: %1$s. Please review and try again.</string>
     <string name="enter_at_least_one_valid_email_address_to_share_this_send">Enter at least one valid email address to share this Send.</string>
     <string name="sync_with_browser">Sync with browser</string>
     <string name="sync_with_browser_description">To connect to %1$s, sync your default browser with the Bitwarden mobile app. When your browser opens, complete sign-in if prompted.\nOnce syncing is complete, you’ll be returned to this app.</string>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42107
https://bitwarden.atlassian.net/browse/PM-42109

## 📔 Objective

Teaches the View Send screen about the SendControls policy so it can tell when a Send the server
marked `disabled` is non-compliant, and why. Also hides the edit FAB for those Sends, which is
PM-42109.

### What changed

- `ViewSendViewModel` now observes the effective Send policy alongside both feature flags, in one
  `combine` so the derived result cannot go stale when any of them changes
- New `SendPolicyRestriction` model with three cases: file send not compliant, type no longer
  allowed, and copy required. Each says whether a compliant copy is possible
- A Send counts as restricted only when `pm-31885-send-controls-existing-sends` is on,
  `pm-31885-send-controls` is on, and the Send is disabled
- File sends report as not compliant even when their type is also disallowed, since the attachment
  cannot be uploaded again either way
- Edit FAB is hidden whenever a restriction applies (PM-42109)

### Not in this PR

- The banner itself, which is PM-42108. Nothing new is visible on screen yet, this is the state and
  the decision logic only
- "Make a copy", which is PM-42110

### Note for reviewers

This stacks on #7269, so please review that first. The diff here is only the last three commits.

## 📸 Screenshots

No visible change in this PR. The banner arrives with PM-42108.
