### PR TITLE
PM-41853: bug: Fix account keys migration for keystore encrypted shared preferences

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
@@ -726,7 +726,7 @@ class AuthDiskSourceImpl(
                 val userId = account.profile.userId
                 val accountKeysKey = PROFILE_ACCOUNT_KEYS_KEY.appendIdentifier(userId)
                 val privateKeyKey = MASTER_KEY_ENCRYPTION_PRIVATE_KEY.appendIdentifier(userId)
-                val accountKeys = getEncryptedString(key = accountKeysKey)
+                val accountKeys = getLegacyEncryptedString(key = accountKeysKey)
                     ?.let { json.decodeFromStringOrNull<AccountKeysJson>(it) }
                 val privateKey = accountKeys
                     ?.publicKeyEncryptionKeyPair
@@ -738,7 +738,7 @@ class AuthDiskSourceImpl(
                         accountCryptographicState = accountKeys.toAccountCryptographicState(it),
                     )
                     // Remove the Account Keys and Private Key
-                    putEncryptedString(key = accountKeysKey, value = null)
+                    clearLegacyEncryptedString(key = accountKeysKey)
                     putString(key = privateKeyKey, value = null)
                 }
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/legacy/DiskSourceMigrationLoggerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/legacy/DiskSourceMigrationLoggerImpl.kt
@@ -25,16 +25,12 @@ internal class DiskSourceMigrationLoggerImpl(
     init {
         flightRecorderManager
             .isLoggingReadyFlow
-            .filter { it }
-            .onEach {
-                // The older encrypted shared preferences has its own values written to disk,
-                // so it is normal for there to be 2 values still present.
-                if (keystoreEncryptedPreferences.all.isNotEmpty() &&
-                    encryptedPreferences.all.size <= 2
-                ) {
-                    Timber.d("Encrypted data has been migrated to Keystore encryption.")
-                }
+            .filter { isLoggingReady ->
+                isLoggingReady &&
+                    keystoreEncryptedPreferences.all.isNotEmpty() &&
+                    encryptedPreferences.all.isEmpty()
             }
+            .onEach { Timber.d("Encrypted data has been migrated to Keystore encryption.") }
             .launchIn(unconfinedScope)
     }
 }

--- a/data/src/main/kotlin/com/bitwarden/data/datasource/disk/BaseEncryptedDiskSource.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/datasource/disk/BaseEncryptedDiskSource.kt
@@ -16,6 +16,14 @@ abstract class BaseEncryptedDiskSource(
     private val encryptedSharedPreferences: SharedPreferences,
     private val keystoreEncryptedPreferences: SharedPreferences,
 ) : BaseDiskSource(sharedPreferences = sharedPreferences) {
+    protected fun getLegacyEncryptedString(
+        key: String,
+    ): String? = encryptedSharedPreferences.getString("$LEGACY_PREFIX$key", null)
+
+    protected fun clearLegacyEncryptedString(key: String) {
+        encryptedSharedPreferences.edit { remove("$LEGACY_PREFIX$key") }
+    }
+
     protected fun getEncryptedString(
         key: String,
     ): String? = keystoreEncryptedPreferences.getString(key, null)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41853](https://bitwarden.atlassian.net/browse/PM-41853)

## 📔 Objective

This PR ensures that the account keys migration to cryptographic state is pulling the legacy values from the correct location during the migration. The updated migration process will migrate from the legacy encrypted shared preferences and migrate to the new location (in the keystore encrypted shared preferences).

If the account keys were already migrated to cryptographic state, the downstream `migrateToKeystoreEncryption` will handle the final migration.


[PM-41853]: https://bitwarden.atlassian.net/browse/PM-41853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ