### PR TITLE
[PM-42108] feat: Add policy restriction banner to View Send

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceScreen.kt
@@ -26,6 +26,7 @@ import com.bitwarden.ui.platform.base.util.annotatedStringResource
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.base.util.toAnnotatedString
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.card.BitwardenContentCard
 import com.bitwarden.ui.platform.components.content.model.ContentBlockData
@@ -34,6 +35,7 @@ import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.bitwarden.ui.util.asText
 import kotlinx.collections.immutable.persistentListOf
 
 /**
@@ -165,8 +167,10 @@ private fun NeedSomeInspirationCard(
 ) {
     BitwardenActionCard(
         cardTitle = stringResource(BitwardenString.need_some_inspiration),
-        actionText = stringResource(BitwardenString.check_out_the_passphrase_generator),
-        onActionClick = onActionClicked,
+        actionButton = BitwardenButtonData(
+            label = BitwardenString.check_out_the_passphrase_generator.asText(),
+            onClick = onActionClicked,
+        ),
         modifier = modifier.fillMaxWidth(),
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
@@ -27,6 +27,7 @@ import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.base.util.toListItemCardStyle
 import com.bitwarden.ui.platform.components.appbar.BitwardenMediumTopAppBar
 import com.bitwarden.ui.platform.components.appbar.NavigationIcon
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.components.row.BitwardenPushRow
@@ -37,6 +38,7 @@ import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.bitwarden.ui.util.asText
 
 /**
  * Displays the settings screen.
@@ -107,17 +109,19 @@ fun SettingsScreen(
                     cardSubtitle = stringResource(
                         id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
                     ),
-                    actionText = stringResource(id = BitwardenString.learn_more),
-                    isExternalLink = true,
+                    actionButton = BitwardenButtonData(
+                        label = BitwardenString.learn_more.asText(),
+                        onClick = {
+                            viewModel.trySendAction(SettingsAction.UpgradedToPremiumCardClick)
+                        },
+                        isExternalLink = true,
+                    ),
                     leadingContent = {
                         Icon(
                             painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),
                             contentDescription = null,
                             tint = BitwardenTheme.colorScheme.icon.secondary,
                         )
-                    },
-                    onActionClick = {
-                        viewModel.trySendAction(SettingsAction.UpgradedToPremiumCardClick)
                     },
                     onDismissClick = {
                         viewModel.trySendAction(SettingsAction.UpgradedToPremiumCardDismiss)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -37,6 +37,7 @@ import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.account.dialog.BitwardenLogoutConfirmationDialog
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.badge.NotificationBadge
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.card.actionCardExitAnimation
 import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
@@ -59,6 +60,7 @@ import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.util.Text
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
@@ -178,10 +180,12 @@ fun AccountSecurityScreen(
             ) {
                 BitwardenActionCard(
                     cardTitle = stringResource(id = BitwardenString.set_up_unlock),
-                    actionText = stringResource(BitwardenString.get_started),
-                    onActionClick = {
-                        viewModel.trySendAction(AccountSecurityAction.UnlockActionCardCtaClick)
-                    },
+                    actionButton = BitwardenButtonData(
+                        label = BitwardenString.get_started.asText(),
+                        onClick = {
+                            viewModel.trySendAction(AccountSecurityAction.UnlockActionCardCtaClick)
+                        },
+                    ),
                     onDismissClick = {
                         viewModel.trySendAction(AccountSecurityAction.UnlockActionCardDismiss)
                     },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -44,6 +44,7 @@ import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.base.util.toAnnotatedString
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.badge.NotificationBadge
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.button.model.BitwardenHelpButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.card.BitwardenActionCardSmall
@@ -67,6 +68,7 @@ import com.bitwarden.ui.platform.manager.util.startSystemAutofillSettingsActivit
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.browser.BrowserAutofillSettingsCard
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.handlers.AutoFillHandlers
@@ -400,8 +402,10 @@ private fun AutofillCallToActionCard(
             CtaState.AUTOFILL -> {
                 BitwardenActionCard(
                     cardTitle = stringResource(id = BitwardenString.turn_on_autofill),
-                    actionText = stringResource(id = BitwardenString.get_started),
-                    onActionClick = autoFillHandlers.onAutofillActionCardClick,
+                    actionButton = BitwardenButtonData(
+                        label = BitwardenString.get_started.asText(),
+                        onClick = autoFillHandlers.onAutofillActionCardClick,
+                    ),
                     onDismissClick = autoFillHandlers.onAutofillActionCardDismissClick,
                     leadingContent = { NotificationBadge(notificationCount = 1) },
                 )
@@ -418,8 +422,10 @@ private fun AutofillCallToActionCard(
                         id = BitwardenString.turn_on_browser_autofill_integration,
                     ),
                     cardSubtitle = stringResource(id = subTitleRes),
-                    actionText = stringResource(id = BitwardenString.get_started),
-                    onActionClick = autoFillHandlers.onBrowserAutofillActionCardClick,
+                    actionButton = BitwardenButtonData(
+                        label = BitwardenString.get_started.asText(),
+                        onClick = autoFillHandlers.onBrowserAutofillActionCardClick,
+                    ),
                     onDismissClick = autoFillHandlers.onBrowserAutofillActionCardDismissClick,
                     leadingContent = { NotificationBadge(notificationCount = 1) },
                 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
@@ -29,6 +29,7 @@ import com.bitwarden.ui.platform.base.util.mirrorIfRtl
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.badge.NotificationBadge
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.card.actionCardExitAnimation
 import com.bitwarden.ui.platform.components.model.CardStyle
@@ -40,6 +41,7 @@ import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.platform.composition.util.vfo1Foundation
 
 /**
@@ -103,11 +105,13 @@ fun VaultSettingsScreen(
             ) {
                 BitwardenActionCard(
                     cardTitle = stringResource(id = BitwardenString.import_saved_logins),
-                    actionText = stringResource(BitwardenString.get_started),
+                    actionButton = BitwardenButtonData(
+                        label = BitwardenString.get_started.asText(),
+                        onClick = {
+                            viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
+                        },
+                    ),
                     cardSubtitle = stringResource(BitwardenString.use_a_computer_to_import_logins),
-                    onActionClick = {
-                        viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
-                    },
                     onDismissClick = {
                         viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardDismissClick)
                     },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -50,6 +50,7 @@ import com.bitwarden.ui.platform.components.appbar.model.TopAppBarDividerStyle
 import com.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.bitwarden.ui.platform.components.button.BitwardenTextButton
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.button.model.BitwardenHelpButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
@@ -397,8 +398,11 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.ScrollContent(
                     cardSubtitle = stringResource(
                         id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
                     ),
-                    actionText = stringResource(id = BitwardenString.learn_more),
-                    isExternalLink = true,
+                    actionButton = BitwardenButtonData(
+                        label = BitwardenString.learn_more.asText(),
+                        onClick = onUpgradedToPremiumCardClick,
+                        isExternalLink = true,
+                    ),
                     leadingContent = {
                         Icon(
                             painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),
@@ -406,7 +410,6 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.ScrollContent(
                             tint = BitwardenTheme.colorScheme.icon.secondary,
                         )
                     },
-                    onActionClick = onUpgradedToPremiumCardClick,
                     onDismissClick = onUpgradedToPremiumCardDismiss,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -438,8 +441,10 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.ScrollContent(
                     cardSubtitle = stringResource(
                         BitwardenString.learn_more_about_generating_secure_login_credentials_with_guided_tour,
                     ),
-                    actionText = stringResource(BitwardenString.get_started),
-                    onActionClick = passwordHandlers.onGeneratorActionCardClicked,
+                    actionButton = BitwardenButtonData(
+                        label = BitwardenString.get_started.asText(),
+                        onClick = passwordHandlers.onGeneratorActionCardClicked,
+                    ),
                     onDismissClick = passwordHandlers.onGeneratorActionCardDismissed,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
@@ -294,7 +294,11 @@ internal fun UpgradedToPremiumActionCard(
         cardSubtitle = stringResource(
             id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
         ),
-        actionText = stringResource(id = BitwardenString.learn_more),
+        actionButton = BitwardenButtonData(
+            label = BitwardenString.learn_more.asText(),
+            onClick = onActionClick,
+            isExternalLink = true,
+        ),
         leadingContent = {
             Icon(
                 painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),
@@ -302,8 +306,6 @@ internal fun UpgradedToPremiumActionCard(
                 tint = BitwardenTheme.colorScheme.icon.secondary,
             )
         },
-        isExternalLink = true,
-        onActionClick = onActionClick,
         onDismissClick = onDismissClick,
         modifier = modifier,
     )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -50,6 +51,7 @@ import com.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedErrorButton
 import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
+import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.content.BitwardenErrorContent
 import com.bitwarden.ui.platform.components.content.BitwardenLoadingContent
 import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
@@ -59,6 +61,8 @@ import com.bitwarden.ui.platform.components.fab.BitwardenFloatingActionButton
 import com.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.bitwarden.ui.platform.components.header.BitwardenExpandingHeader
 import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
+import com.bitwarden.ui.platform.components.icon.BitwardenIcon
+import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
@@ -73,6 +77,7 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendRoute
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.ModeType
+import com.x8bit.bitwarden.ui.tools.feature.send.viewsend.model.SendPolicyRestriction
 
 /**
  * Displays view send screen.
@@ -194,6 +199,7 @@ private fun ViewSendScreenContent(
         is ViewSendState.ViewState.Content -> {
             ViewStateContent(
                 state = viewState,
+                policyRestriction = state.policyRestriction,
                 onCopyClick = onCopyClick,
                 onCopyNotesClick = onCopyNotesClick,
                 onDeleteClick = onDeleteClick,
@@ -219,6 +225,7 @@ private fun ViewSendScreenContent(
 @Composable
 private fun ViewStateContent(
     state: ViewSendState.ViewState.Content,
+    policyRestriction: SendPolicyRestriction?,
     onCopyClick: () -> Unit,
     onCopyNotesClick: () -> Unit,
     onDeleteClick: () -> Unit,
@@ -229,6 +236,24 @@ private fun ViewStateContent(
         modifier = modifier.verticalScroll(state = rememberScrollState()),
     ) {
         Spacer(modifier = Modifier.height(height = 12.dp))
+        policyRestriction?.let {
+            BitwardenActionCard(
+                cardTitle = stringResource(id = BitwardenString.organization_policy_restriction),
+                cardSubtitle = it.message(),
+                leadingContent = {
+                    BitwardenIcon(
+                        iconData = IconData.Local(iconRes = BitwardenDrawable.ic_info_circle),
+                        tint = BitwardenTheme.colorScheme.text.primary,
+                        modifier = Modifier.size(size = 16.dp),
+                    )
+                },
+                modifier = Modifier
+                    .testTag(tag = "SendPolicyRestrictionBanner")
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+            Spacer(modifier = Modifier.height(height = 16.dp))
+        }
         ShareLinkSection(
             shareLink = state.shareLink,
             modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/model/SendPolicyRestriction.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/model/SendPolicyRestriction.kt
@@ -1,6 +1,9 @@
 package com.x8bit.bitwarden.ui.tools.feature.send.viewsend.model
 
 import android.os.Parcelable
+import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.util.Text
+import com.bitwarden.ui.util.asText
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -9,9 +12,9 @@ import kotlinx.parcelize.Parcelize
  */
 sealed class SendPolicyRestriction : Parcelable {
     /**
-     * Whether a compliant copy of the Send can be made to replace it.
+     * The explanation shown to the user for this restriction.
      */
-    abstract val isCopyable: Boolean
+    abstract val message: Text
 
     /**
      * The Send is a file send, so it cannot be brought into compliance: its attachment is not
@@ -19,7 +22,10 @@ sealed class SendPolicyRestriction : Parcelable {
      */
     @Parcelize
     data object FileNotCompliant : SendPolicyRestriction() {
-        override val isCopyable: Boolean get() = false
+        override val message: Text
+            get() = BitwardenString
+                .this_send_is_not_compliant_with_your_organizations_send_policy
+                .asText()
     }
 
     /**
@@ -28,7 +34,8 @@ sealed class SendPolicyRestriction : Parcelable {
      */
     @Parcelize
     data object TypeNotAllowed : SendPolicyRestriction() {
-        override val isCopyable: Boolean get() = false
+        override val message: Text
+            get() = BitwardenString.text_sends_are_not_allowed_for_your_organization.asText()
     }
 
     /**
@@ -36,6 +43,7 @@ sealed class SendPolicyRestriction : Parcelable {
      */
     @Parcelize
     data object CopyRequired : SendPolicyRestriction() {
-        override val isCopyable: Boolean get() = true
+        override val message: Text
+            get() = BitwardenString.to_edit_this_send_make_a_copy.asText()
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.bitwarden.ui.platform.components.button.BitwardenTextSelectionButton
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
 import com.bitwarden.ui.platform.components.coachmark.scope.CoachMarkScope
@@ -29,6 +30,7 @@ import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.ui.platform.composition.util.vfo1Foundation
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
@@ -130,8 +132,10 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
                     cardSubtitle = stringResource(
                         BitwardenString.we_ll_walk_you_through_the_key_features_to_add_a_new_login,
                     ),
-                    actionText = stringResource(BitwardenString.get_started),
-                    onActionClick = loginItemTypeHandlers.onStartLoginCoachMarkTour,
+                    actionButton = BitwardenButtonData(
+                        label = BitwardenString.get_started.asText(),
+                        onClick = loginItemTypeHandlers.onStartLoginCoachMarkTour,
+                    ),
                     onDismissClick = loginItemTypeHandlers.onDismissLearnAboutLoginsCard,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.base.util.toListItemCardStyle
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
 import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
@@ -26,6 +27,7 @@ import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenMasterPasswordDialog
 import com.x8bit.bitwarden.ui.platform.components.listitem.BitwardenGroupItem
 import com.x8bit.bitwarden.ui.platform.components.listitem.BitwardenListItem
@@ -326,8 +328,10 @@ private fun ActionCard(
                     id = BitwardenString
                         .to_regain_access_to_your_archive_restart_your_premium_subscription,
                 ),
-                actionText = stringResource(id = BitwardenString.restart_premium),
-                onActionClick = vaultItemListingHandlers.upgradeToPremiumClick,
+                actionButton = BitwardenButtonData(
+                    label = BitwardenString.restart_premium.asText(),
+                    onClick = vaultItemListingHandlers.upgradeToPremiumClick,
+                ),
                 modifier = modifier,
             )
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultActionCard.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultActionCard.kt
@@ -4,11 +4,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.vault.feature.vault.handlers.VaultHandlers
 
 /**
@@ -28,8 +30,11 @@ fun VaultActionCard(
                 cardSubtitle = stringResource(
                     id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
                 ),
-                actionText = stringResource(id = BitwardenString.learn_more),
-                isExternalLink = true,
+                actionButton = BitwardenButtonData(
+                    label = BitwardenString.learn_more.asText(),
+                    onClick = { vaultHandlers.actionCardClick(actionCardState) },
+                    isExternalLink = true,
+                ),
                 leadingContent = {
                     Icon(
                         painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),
@@ -37,7 +42,6 @@ fun VaultActionCard(
                         tint = BitwardenTheme.colorScheme.icon.secondary,
                     )
                 },
-                onActionClick = { vaultHandlers.actionCardClick(actionCardState) },
                 onDismissClick = { vaultHandlers.dismissActionCardClick(actionCardState) },
                 modifier = modifier,
             )
@@ -52,8 +56,10 @@ fun VaultActionCard(
                     id = BitwardenString
                         .a_premium_plan_gives_you_more_tools_to_stay_secure_and_in_control,
                 ),
-                actionText = stringResource(id = BitwardenString.learn_more),
-                onActionClick = { vaultHandlers.actionCardClick(actionCardState) },
+                actionButton = BitwardenButtonData(
+                    label = BitwardenString.learn_more.asText(),
+                    onClick = { vaultHandlers.actionCardClick(actionCardState) },
+                ),
                 onDismissClick = { vaultHandlers.dismissActionCardClick(actionCardState) },
                 modifier = modifier,
             )
@@ -63,8 +69,10 @@ fun VaultActionCard(
             BitwardenActionCard(
                 cardTitle = stringResource(id = BitwardenString.your_subscription_needs_attention),
                 cardSubtitle = stringResource(id = BitwardenString.check_your_plan_for_details),
-                actionText = stringResource(id = BitwardenString.view_plan),
-                onActionClick = { vaultHandlers.actionCardClick(actionCardState) },
+                actionButton = BitwardenButtonData(
+                    label = BitwardenString.view_plan.asText(),
+                    onClick = { vaultHandlers.actionCardClick(actionCardState) },
+                ),
                 modifier = modifier,
             )
         }
@@ -75,7 +83,10 @@ fun VaultActionCard(
                 cardSubtitle = stringResource(
                     id = BitwardenString.keep_items_you_dont_need_right_now_safe_but_out_sight,
                 ),
-                actionText = stringResource(id = BitwardenString.go_to_archive),
+                actionButton = BitwardenButtonData(
+                    label = BitwardenString.go_to_archive.asText(),
+                    onClick = { vaultHandlers.actionCardClick(actionCardState) },
+                ),
                 leadingContent = {
                     Icon(
                         painter = rememberVectorPainter(id = BitwardenDrawable.ic_archive),
@@ -83,7 +94,6 @@ fun VaultActionCard(
                         tint = BitwardenTheme.colorScheme.icon.secondary,
                     )
                 },
-                onActionClick = { vaultHandlers.actionCardClick(actionCardState) },
                 onDismissClick = { vaultHandlers.dismissActionCardClick(actionCardState) },
                 modifier = modifier,
             )
@@ -93,8 +103,10 @@ fun VaultActionCard(
             BitwardenActionCard(
                 cardTitle = stringResource(id = BitwardenString.import_saved_logins),
                 cardSubtitle = stringResource(id = BitwardenString.use_a_computer_to_import_logins),
-                actionText = stringResource(id = BitwardenString.get_started),
-                onActionClick = { vaultHandlers.actionCardClick(actionCardState) },
+                actionButton = BitwardenButtonData(
+                    label = BitwardenString.get_started.asText(),
+                    onClick = { vaultHandlers.actionCardClick(actionCardState) },
+                ),
                 onDismissClick = { vaultHandlers.dismissActionCardClick(actionCardState) },
                 modifier = modifier,
             )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.util.asText
@@ -103,6 +104,96 @@ class ViewSendScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = message)
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun `policy restriction banner should not be displayed by default`() {
+        composeTestRule
+            .onNodeWithText(text = "Organization policy restriction")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `policy restriction banner should display the copy required explanation`() {
+        mutableStateFlow.update { it.copy(isSendDisabled = true, isSendControlsEnabled = true) }
+
+        // Both flags are required, so the banner is still absent until enforcement is enabled.
+        composeTestRule
+            .onNodeWithText(text = "Organization policy restriction")
+            .assertDoesNotExist()
+
+        mutableStateFlow.update { it.copy(isSendControlsExistingSendsEnabled = true) }
+
+        composeTestRule
+            .onNodeWithText(text = "Organization policy restriction")
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                text = "To edit this Send, make a copy. If this Send can expire at the set " +
+                    "deletion date, no action is needed.",
+            )
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `policy restriction banner should display the not compliant explanation for a file send`() {
+        mutableStateFlow.update {
+            it.copy(
+                sendType = SendItemType.FILE,
+                isSendDisabled = true,
+                isSendControlsEnabled = true,
+                isSendControlsExistingSendsEnabled = true,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(
+                text = "This Send is not compliant with your organization’s Send policy and will " +
+                    "automatically expire at the set deletion date.",
+            )
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `policy restriction banner should display the type not allowed explanation`() {
+        mutableStateFlow.update {
+            it.copy(
+                allowedSendTypes = listOf(SendTypeJson.FILE),
+                isSendDisabled = true,
+                isSendControlsEnabled = true,
+                isSendControlsExistingSendsEnabled = true,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(
+                text = "Text Sends are not allowed for your organization and this Send will " +
+                    "automatically expire at the set deletion date.",
+            )
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `edit fab should be hidden when a policy restriction applies`() {
+        composeTestRule
+            .onNodeWithContentDescription(label = "Edit Send")
+            .assertIsDisplayed()
+
+        mutableStateFlow.update {
+            it.copy(
+                isSendDisabled = true,
+                isSendControlsEnabled = true,
+                isSendControlsExistingSendsEnabled = true,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(label = "Edit Send")
+            .assertDoesNotExist()
     }
 
     @Test

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -571,9 +571,11 @@ private fun ActionCard(
             BitwardenActionCard(
                 modifier = modifier,
                 cardSubtitle = stringResource(id = BitwardenString.download_bitwarden_card_message),
-                actionText = stringResource(id = BitwardenString.download_now),
+                actionButton = BitwardenButtonData(
+                    label = BitwardenString.download_now.asText(),
+                    onClick = onDownloadBitwardenClick,
+                ),
                 cardTitle = stringResource(id = BitwardenString.download_bitwarden_card_title),
-                onActionClick = onDownloadBitwardenClick,
                 onDismissClick = onDownloadBitwardenDismissClick,
                 leadingContent = {
                     Icon(
@@ -589,8 +591,10 @@ private fun ActionCard(
             BitwardenActionCard(
                 modifier = modifier,
                 cardTitle = stringResource(id = BitwardenString.sync_with_the_bitwarden_app),
-                actionText = stringResource(id = BitwardenString.take_me_to_app_settings),
-                onActionClick = onSyncWithBitwardenClick,
+                actionButton = BitwardenButtonData(
+                    label = BitwardenString.take_me_to_app_settings.asText(),
+                    onClick = onSyncWithBitwardenClick,
+                ),
                 cardSubtitle = stringResource(
                     id = BitwardenString.sync_with_bitwarden_action_card_message,
                 ),

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
@@ -44,29 +44,24 @@ import com.bitwarden.ui.util.asText
  * button, and leading icon content.
  *
  * @param cardTitle The title of the card.
- * @param actionText The text content on the CTA button, or `null` to omit the button, which suits
- * a card that only explains something. [onActionClick] is required alongside it.
- * @param onActionClick The action to perform when the CTA button is clicked.
+ * @param actionButton The data for the CTA button, or `null` to omit it, which suits a card that
+ * only explains something.
  * @param modifier The [Modifier] to be applied to the card.
  * @param onDismissClick Optional action to perform when the dismiss button is clicked.
  * @param cardSubtitle The subtitle of the card.
  * @param secondaryButton The optional data for a secondary button.
  * @param leadingContent Optional content to display on the leading side of the [cardTitle] [Text].
- * @param isExternalLink Whether the CTA launches an external link, which announces the
- * external-link affordance to screen readers via the shared `external_link_format` string.
  */
 @Suppress("LongMethod")
 @Composable
 fun BitwardenActionCard(
     cardTitle: String,
-    actionText: String? = null,
-    onActionClick: (() -> Unit)? = null,
+    actionButton: BitwardenButtonData? = null,
     modifier: Modifier = Modifier,
     onDismissClick: (() -> Unit)? = null,
     cardSubtitle: String? = null,
     secondaryButton: BitwardenButtonData? = null,
     leadingContent: @Composable (() -> Unit)? = null,
-    isExternalLink: Boolean = false,
 ) {
     Card(
         modifier = modifier,
@@ -124,7 +119,7 @@ fun BitwardenActionCard(
                 )
             }
         }
-        if (actionText != null && onActionClick != null) {
+        if (actionButton != null || secondaryButton != null) {
             if (cardSubtitle == null && rowBottomPx > titleBottomPx) {
                 // When the subtitle is missing, we want to ensure that the filled button is 16dp
                 // below the title but the close button can be taller than the title which will push
@@ -137,14 +132,14 @@ fun BitwardenActionCard(
             } else {
                 Spacer(modifier = Modifier.height(height = 16.dp))
             }
-            BitwardenFilledButton(
-                label = actionText,
-                onClick = onActionClick,
-                isExternalLink = isExternalLink,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .fillMaxWidth(),
-            )
+            actionButton?.let {
+                BitwardenFilledButton(
+                    buttonData = it,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .fillMaxWidth(),
+                )
+            }
             secondaryButton?.let {
                 BitwardenTextButton(
                     buttonData = it,
@@ -171,8 +166,10 @@ private fun BitwardenActionCardWithSubtitleNoDismiss_preview() {
     BitwardenTheme {
         BitwardenActionCard(
             cardTitle = "Title",
-            actionText = "Action",
-            onActionClick = {},
+            actionButton = BitwardenButtonData(
+                label = "Action".asText(),
+                onClick = {},
+            ),
         )
     }
 }
@@ -184,8 +181,10 @@ private fun BitwardenActionCard_preview() {
     BitwardenTheme {
         BitwardenActionCard(
             cardTitle = "Title",
-            actionText = "Action",
-            onActionClick = {},
+            actionButton = BitwardenButtonData(
+                label = "Action".asText(),
+                onClick = {},
+            ),
             onDismissClick = {},
         )
     }
@@ -198,8 +197,10 @@ private fun BitwardenActionCardWithLeadingContent_preview() {
     BitwardenTheme {
         BitwardenActionCard(
             cardTitle = "Title",
-            actionText = "Action",
-            onActionClick = {},
+            actionButton = BitwardenButtonData(
+                label = "Action".asText(),
+                onClick = {},
+            ),
             onDismissClick = {},
             leadingContent = {
                 NotificationBadge(
@@ -218,8 +219,10 @@ private fun BitwardenActionCardWithSubtitle_preview() {
         BitwardenActionCard(
             cardTitle = "Title",
             cardSubtitle = "Subtitle",
-            actionText = "Action",
-            onActionClick = {},
+            actionButton = BitwardenButtonData(
+                label = "Action".asText(),
+                onClick = {},
+            ),
             onDismissClick = {},
             secondaryButton = BitwardenButtonData(
                 label = "Learn More".asText(),

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
@@ -40,12 +40,14 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.util.asText
 
 /**
- * A design component action card, which contains a title, action button, and a dismiss button
- * by default, with optional leading icon content.
+ * A design component action card, which contains a title, with an optional action button, dismiss
+ * button, and leading icon content.
  *
  * @param cardTitle The title of the card.
- * @param actionText The text content on the CTA button.
+ * @param actionText The text content on the CTA button, or `null` to omit the button, which suits
+ * a card that only explains something. [onActionClick] is required alongside it.
  * @param onActionClick The action to perform when the CTA button is clicked.
+ * @param modifier The [Modifier] to be applied to the card.
  * @param onDismissClick Optional action to perform when the dismiss button is clicked.
  * @param cardSubtitle The subtitle of the card.
  * @param secondaryButton The optional data for a secondary button.
@@ -57,8 +59,8 @@ import com.bitwarden.ui.util.asText
 @Composable
 fun BitwardenActionCard(
     cardTitle: String,
-    actionText: String,
-    onActionClick: () -> Unit,
+    actionText: String? = null,
+    onActionClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     onDismissClick: (() -> Unit)? = null,
     cardSubtitle: String? = null,
@@ -122,32 +124,35 @@ fun BitwardenActionCard(
                 )
             }
         }
-        if (cardSubtitle == null && rowBottomPx > titleBottomPx) {
-            // When the subtitle is missing, we want to ensure that the filled button is 16dp below
-            // the title but the close button can be taller than the title which will push the
-            // button further down. So we measure the difference and use that to offset the spacer
-            // size.
-            Spacer(
-                modifier = Modifier.height(height = 16.dp - (rowBottomPx - titleBottomPx).toDp()),
-            )
-        } else {
-            Spacer(modifier = Modifier.height(height = 16.dp))
-        }
-        BitwardenFilledButton(
-            label = actionText,
-            onClick = onActionClick,
-            isExternalLink = isExternalLink,
-            modifier = Modifier
-                .padding(horizontal = 16.dp)
-                .fillMaxWidth(),
-        )
-        secondaryButton?.let {
-            BitwardenTextButton(
-                buttonData = it,
+        if (actionText != null && onActionClick != null) {
+            if (cardSubtitle == null && rowBottomPx > titleBottomPx) {
+                // When the subtitle is missing, we want to ensure that the filled button is 16dp
+                // below the title but the close button can be taller than the title which will push
+                // the button further down. So we measure the difference and use that to offset the
+                // spacer size.
+                Spacer(
+                    modifier = Modifier
+                        .height(height = 16.dp - (rowBottomPx - titleBottomPx).toDp()),
+                )
+            } else {
+                Spacer(modifier = Modifier.height(height = 16.dp))
+            }
+            BitwardenFilledButton(
+                label = actionText,
+                onClick = onActionClick,
+                isExternalLink = isExternalLink,
                 modifier = Modifier
                     .padding(horizontal = 16.dp)
                     .fillMaxWidth(),
             )
+            secondaryButton?.let {
+                BitwardenTextButton(
+                    buttonData = it,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .fillMaxWidth(),
+                )
+            }
         }
         Spacer(modifier = Modifier.height(height = 16.dp))
     }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -512,6 +512,10 @@ Scanning will happen automatically.</string>
     <string name="about_send">About Send</string>
     <string name="hide_email">Hide my email address from recipients</string>
     <string name="send_options_policy_in_effect">One or more organization policies are affecting your Send options.</string>
+    <string name="organization_policy_restriction">Organization policy restriction</string>
+    <string name="this_send_is_not_compliant_with_your_organizations_send_policy">This Send is not compliant with your organization’s Send policy and will automatically expire at the set deletion date.</string>
+    <string name="text_sends_are_not_allowed_for_your_organization">Text Sends are not allowed for your organization and this Send will automatically expire at the set deletion date.</string>
+    <string name="to_edit_this_send_make_a_copy">To edit this Send, make a copy. If this Send can expire at the set deletion date, no action is needed.</string>
     <string name="send_file_premium_required">Free accounts are restricted to sharing text only. A Premium membership is required to use files with Send.</string>
     <string name="sharing_with_specific_people_is_a_premium_feature">Sharing with specific people is a Premium feature. Your current plan does not include access to this feature.</string>
     <string name="password_prompt">Master password re-prompt</string>

--- a/ui/src/test/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCardTest.kt
+++ b/ui/src/test/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCardTest.kt
@@ -1,6 +1,7 @@
 package com.bitwarden.ui.platform.components.card
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import com.bitwarden.ui.platform.base.BaseComposeTest
@@ -46,6 +47,42 @@ class BitwardenActionCardTest : BaseComposeTest() {
         composeTestRule
             .onNodeWithContentDescription(label = "Learn more, External link")
             .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(text = "Learn more")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `no buttons are displayed when neither button is provided`() {
+        setTestContent {
+            BitwardenTheme {
+                BitwardenActionCard(
+                    cardTitle = "Title",
+                    cardSubtitle = "Subtitle",
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithText(text = "Subtitle")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNode(matcher = hasClickAction())
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `secondary button is displayed when the action button is omitted`() {
+        setTestContent {
+            BitwardenTheme {
+                BitwardenActionCard(
+                    cardTitle = "Title",
+                    secondaryButton = BitwardenButtonData(
+                        label = "Learn more".asText(),
+                        onClick = {},
+                    ),
+                )
+            }
+        }
         composeTestRule
             .onNodeWithText(text = "Learn more")
             .assertIsDisplayed()

--- a/ui/src/test/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCardTest.kt
+++ b/ui/src/test/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCardTest.kt
@@ -4,19 +4,23 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import com.bitwarden.ui.platform.base.BaseComposeTest
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.bitwarden.ui.util.asText
 import org.junit.Test
 
 class BitwardenActionCardTest : BaseComposeTest() {
 
     @Test
-    fun `action button content description defaults to actionText`() {
+    fun `action button content description defaults to the action button label`() {
         setTestContent {
             BitwardenTheme {
                 BitwardenActionCard(
                     cardTitle = "Title",
-                    actionText = "Learn more",
-                    onActionClick = {},
+                    actionButton = BitwardenButtonData(
+                        label = "Learn more".asText(),
+                        onClick = {},
+                    ),
                 )
             }
         }
@@ -31,9 +35,11 @@ class BitwardenActionCardTest : BaseComposeTest() {
             BitwardenTheme {
                 BitwardenActionCard(
                     cardTitle = "Title",
-                    actionText = "Learn more",
-                    isExternalLink = true,
-                    onActionClick = {},
+                    actionButton = BitwardenButtonData(
+                        label = "Learn more".asText(),
+                        onClick = {},
+                        isExternalLink = true,
+                    ),
                 )
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42108

## 📔 Objective

Shows a read-only banner on View Send when a Send is restricted by the org's SendControls policy,
explaining why it cannot be brought into compliance.

### What changed

- Banner titled "Organization policy restriction" with one of three bodies, picked from the
  restriction computed in PM-42107: file send not compliant, Text sends not allowed, or copy
  required
- Body text lives on `SendPolicyRestriction` itself, the same way `SendAuth` carries its own
  display text
- Renders above the Send details, absent entirely when no restriction applies

### Reusing BitwardenActionCard

- Uses the existing `BitwardenActionCard` rather than a new component. It already has a title, a
  subtitle, a leading icon slot, and the CTA button PM-42110 needs, and `bitwardenCardColors()`
  already defaults to the same `background.tertiary` token as `BitwardenInfoCalloutCard`
- Made `actionText` and `onActionClick` nullable with defaults so the button can be omitted, since
  two of the three variants have no action
- That component has 24 call sites. The change is additive, parameter order is unchanged, and the
  full app plus authenticator suites pass, so existing callers are unaffected

### Not in this PR

- "Make a copy", which is PM-42110. With this card in place that becomes two arguments rather than
  a component change

### Note for reviewers

Fifth in the stack: main <- #7266 <- #7269 <- #7272 <- this. Please review #7272 first. The diff
here is only the last four commits.

## 📸 Screenshots
<img width="350" alt="image" src="https://github.com/user-attachments/assets/d529d55a-9590-49ee-b695-e7a30b56c6f2" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/1e93e40d-d432-482a-a9a3-4c0423a0b313" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/74b642d1-9c0b-45f9-aaf2-e12cd6b4eca7" />


