### PR TITLE
[PM-41896] fix: Default the owner dropdown to the collection's organization

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditNavigation.kt
@@ -110,7 +110,7 @@ fun NavController.navigateToVaultAddEdit(
             vaultItemId = args.vaultAddEditType.vaultItemId,
             vaultItemCipherType = args.vaultItemCipherType,
             selectedFolderId = args.selectedFolderId,
-            selectedCollectionId = args.selectedFolderId,
+            selectedCollectionId = args.selectedCollectionId,
         ),
         navOptions = navOptions,
     )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditNavigationTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditNavigationTest.kt
@@ -1,0 +1,59 @@
+package com.x8bit.bitwarden.ui.vault.feature.addedit
+
+import com.bitwarden.ui.platform.base.createMockNavHostController
+import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class VaultAddEditNavigationTest {
+    private val navController = createMockNavHostController()
+
+    @Test
+    fun `navigateToVaultAddEdit should pass along the selected collection ID`() {
+        navController.navigateToVaultAddEdit(
+            args = VaultAddEditArgs(
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
+                selectedCollectionId = "mockCollectionId",
+            ),
+        )
+
+        verify(exactly = 1) {
+            navController.navigate(
+                route = VaultAddEditRoute(
+                    vaultAddEditMode = VaultAddEditMode.ADD,
+                    vaultItemId = null,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
+                    selectedFolderId = null,
+                    selectedCollectionId = "mockCollectionId",
+                ),
+                navOptions = null,
+            )
+        }
+    }
+
+    @Test
+    fun `navigateToVaultAddEdit should pass along the selected folder ID`() {
+        navController.navigateToVaultAddEdit(
+            args = VaultAddEditArgs(
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
+                selectedFolderId = "mockFolderId",
+            ),
+        )
+
+        verify(exactly = 1) {
+            navController.navigate(
+                route = VaultAddEditRoute(
+                    vaultAddEditMode = VaultAddEditMode.ADD,
+                    vaultItemId = null,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
+                    selectedFolderId = "mockFolderId",
+                    selectedCollectionId = null,
+                ),
+                navOptions = null,
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
@@ -682,8 +682,77 @@ class CipherViewExtensionsTest {
         )
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `appendFolderAndOwnerData should default the owner to the selected collection's organization`() {
+        val viewState = createSecureNoteViewState(
+            cipherView = null,
+            availableOwners = listOf(USER_OWNER, ORGANIZATION_OWNER),
+            availableFolders = emptyList(),
+            selectedOwnerId = null,
+            selectedFolderId = null,
+            selectedCollectionId = "mockId-1",
+        )
+        val account = createAccount()
+        val collectionList = listOf(createMockCollectionView(number = 1))
+
+        val result = viewState.appendFolderAndOwnerData(
+            folderViewList = emptyList(),
+            collectionViewList = collectionList,
+            activeAccount = account,
+            isIndividualVaultDisabled = false,
+            resourceManager = resourceManager,
+            isVfo1FoundationEnabled = true,
+        )
+
+        val expected = createSecureNoteViewState(
+            cipherView = null,
+            availableOwners = listOf(USER_OWNER, ORGANIZATION_OWNER),
+            availableFolders = listOf(NO_FOLDER_ITEM),
+            selectedOwnerId = ORGANIZATION_OWNER.id,
+            selectedFolderId = null,
+            selectedCollectionId = "mockId-1",
+        )
+        assertEquals(expected, result)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `appendFolderAndOwnerData should leave the owner unselected when no collection is selected`() {
+        val viewState = createSecureNoteViewState(
+            cipherView = null,
+            availableOwners = listOf(USER_OWNER, ORGANIZATION_OWNER),
+            availableFolders = emptyList(),
+            selectedOwnerId = null,
+            selectedFolderId = null,
+            selectedCollectionId = null,
+        )
+        val account = createAccount()
+        val collectionList = listOf(createMockCollectionView(number = 1))
+
+        val result = viewState.appendFolderAndOwnerData(
+            folderViewList = emptyList(),
+            collectionViewList = collectionList,
+            activeAccount = account,
+            isIndividualVaultDisabled = false,
+            resourceManager = resourceManager,
+            isVfo1FoundationEnabled = true,
+        )
+
+        val expected = createSecureNoteViewState(
+            cipherView = null,
+            availableOwners = listOf(USER_OWNER, ORGANIZATION_OWNER_UNSELECTED_COLLECTION),
+            availableFolders = listOf(NO_FOLDER_ITEM),
+            selectedOwnerId = null,
+            selectedFolderId = null,
+            selectedCollectionId = null,
+        )
+        assertEquals(expected, result)
+    }
+
+    @Suppress("LongParameterList")
     private fun createSecureNoteViewState(
-        cipherView: CipherView = createMockCipherView(number = 1),
+        cipherView: CipherView? = createMockCipherView(number = 1),
         availableOwners: List<VaultAddEditState.Owner> = listOf(
             USER_OWNER,
             ORGANIZATION_OWNER,
@@ -694,6 +763,7 @@ class CipherViewExtensionsTest {
         ),
         selectedFolderId: String? = availableFolders.firstOrNull()?.id,
         selectedOwnerId: String? = availableOwners.firstOrNull()?.id,
+        selectedCollectionId: String? = null,
     ): VaultAddEditState.ViewState.Content =
         VaultAddEditState.ViewState.Content(
             common = VaultAddEditState.ViewState.Content.Common(
@@ -721,6 +791,7 @@ class CipherViewExtensionsTest {
                 ),
                 availableFolders = emptyList(),
                 availableOwners = persistentListOf(),
+                selectedCollectionId = selectedCollectionId,
             )
                 .let {
                     if (availableOwners.isNotEmpty()) {
@@ -1011,6 +1082,19 @@ private val ORGANIZATION_OWNER_DEFAULT_COLLECTION = VaultAddEditState.Owner(
         ),
     ),
 )
+private val ORGANIZATION_OWNER_UNSELECTED_COLLECTION = VaultAddEditState.Owner(
+    id = "mockOrganizationId-1",
+    name = "organizationName".asText(),
+    collections = listOf(
+        VaultCollection(
+            id = "mockId-1",
+            name = "mockName-1",
+            isSelected = false,
+            isDefaultUserCollection = false,
+        ),
+    ),
+)
+
 private val USER_OWNER = VaultAddEditState.Owner(
     id = null,
     name = BitwardenString.my_vault.asText(),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -1918,6 +1918,33 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `ItemTypeToAddSelected sends NavigateToAddVaultItem with the collection ID when viewing a collection`() =
+        runTest {
+            val viewModel = createVaultItemListingViewModel(
+                savedStateHandle = createSavedStateHandleWithVaultItemListingType(
+                    vaultItemListingType = VaultItemListingType.Collection(
+                        collectionId = "mockId-1",
+                    ),
+                ),
+            )
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(
+                    VaultItemListingsAction.ItemTypeToAddSelected(
+                        itemType = CreateVaultItemType.LOGIN,
+                    ),
+                )
+                assertEquals(
+                    VaultItemListingEvent.NavigateToAddVaultItem(
+                        vaultItemCipherType = VaultItemCipherType.LOGIN,
+                        selectedCollectionId = "mockId-1",
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
     @Test
     fun `FolderClick for vault item should emit NavigateToFolderItem`() = runTest {
         val viewModel = createVaultItemListingViewModel()


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41896

## 📔 Objective

Creating an item while viewing an organization's collection defaulted the Owner dropdown to the personal vault instead of the collection's organization. 

`navigateToVaultAddEdit` was passing the folder ID into the `selectedCollectionId` slot, so the collection ID never reached the add/edit screen. It arrived as null and Owner fell back to the first available owner. Copy/paste slip from #5131. 

## 📸 Screenshots

https://github.com/user-attachments/assets/73855e2c-63c6-477f-9271-7cfab5ed9004


