### PR TITLE
[PM-42156] Fix optional bool checks in workflows

### DIFF
--- a/.github/workflows/build-authenticator.yml
+++ b/.github/workflows/build-authenticator.yml
@@ -102,7 +102,7 @@ jobs:
           --name com.bitwarden.authenticator.dev-google-services.json --file ${{ github.workspace }}/authenticator/src/debug/google-services.json --output none
 
       - name: Download Firebase credentials
-        if: ${{ env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -113,7 +113,7 @@ jobs:
           --name authenticator_play_firebase-creds.json --file ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json --output none
 
       - name: Download Play Store credentials
-        if: ${{ env.PUBLISH_TO_PLAY_STORE }}
+        if: ${{ env.PUBLISH_TO_PLAY_STORE == 'true' }}
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -130,7 +130,7 @@ jobs:
         uses: ./.github/actions/setup-android-build
 
       - name: Verify Play Store credentials
-        if: ${{ env.PUBLISH_TO_PLAY_STORE }}
+        if: ${{ env.PUBLISH_TO_PLAY_STORE == 'true' }}
         run: |
           bundle exec fastlane run validate_play_store_json_key \
           json_key:"${{ github.workspace }}/secrets/authenticator_play_store-creds.json"
@@ -219,11 +219,11 @@ jobs:
           if-no-files-found: error
 
       - name: Install Firebase app distribution plugin
-        if: ${{ matrix.variant == 'aab' && env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ matrix.variant == 'aab' && env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         run: bundle exec fastlane add_plugin firebase_app_distribution
 
       - name: Distribute to Firebase - prod.aab
-        if: ${{ matrix.variant == 'aab' && env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ matrix.variant == 'aab' && env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         env:
           FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
         run: |
@@ -231,7 +231,7 @@ jobs:
           serviceCredentialsFile:"$FIREBASE_CREDS_PATH"
 
       - name: Publish to Play Store - prod.aab
-        if: ${{ matrix.variant == 'aab' && env.PUBLISH_TO_PLAY_STORE }}
+        if: ${{ matrix.variant == 'aab' && env.PUBLISH_TO_PLAY_STORE == 'true' }}
         env:
           PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/authenticator_play_store-creds.json
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
           --name google-services.json --file ${{ github.workspace }}/app/src/standardBeta/google-services.json --output none
 
       - name: Download Firebase credentials
-        if: ${{ matrix.variant == 'prod' && env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ matrix.variant == 'prod' && env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -302,11 +302,11 @@ jobs:
           if-no-files-found: error
 
       - name: Install Firebase app distribution plugin
-        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'apk' && env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'apk' && env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         run: bundle exec fastlane add_plugin firebase_app_distribution
 
       - name: Distribute to Firebase - prod.apk
-        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'apk' && env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'apk' && env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         env:
           APP_PLAY_FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/app_play_prod_firebase-creds.json
         run: |
@@ -315,7 +315,7 @@ jobs:
           service_credentials_file:$APP_PLAY_FIREBASE_CREDS_PATH
 
       - name: Distribute to Firebase - beta.apk
-        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'apk' && env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'apk' && env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         env:
           APP_PLAY_FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/app_play_prod_firebase-creds.json
         run: |
@@ -324,12 +324,12 @@ jobs:
           service_credentials_file:$APP_PLAY_FIREBASE_CREDS_PATH
 
       - name: Verify Play Store credentials
-        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' && env.PUBLISH_TO_PLAY_STORE }}
+        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' && env.PUBLISH_TO_PLAY_STORE == 'true' }}
         run: |
           bundle exec fastlane run validate_play_store_json_key
 
       - name: Publish to Play Store - prod.aab
-        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' && env.PUBLISH_TO_PLAY_STORE }}
+        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' && env.PUBLISH_TO_PLAY_STORE == 'true' }}
         run: |
           bundle exec fastlane publishProdToPlayStore
           bundle exec fastlane publishBetaToPlayStore
@@ -372,7 +372,7 @@ jobs:
           --name app_beta_fdroid-keystore.jks --file ${{ github.workspace }}/keystores/app_beta_fdroid-keystore.jks --output none
 
       - name: Download Firebase credentials
-        if: ${{ env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -462,11 +462,11 @@ jobs:
           if-no-files-found: error
 
       - name: Install Firebase app distribution plugin
-        if: ${{ env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         run: bundle exec fastlane add_plugin firebase_app_distribution
 
       - name: Distribute to Firebase - fdroid.apk
-        if: ${{ env.DISTRIBUTE_TO_FIREBASE }}
+        if: ${{ env.DISTRIBUTE_TO_FIREBASE == 'true' }}
         env:
           APP_FDROID_FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/app_fdroid_firebase-creds.json
         run: |


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42156

## 📔 Objective

Fix for the issue where the “optionally distribute” logic wasn’t being treated as optional

**Testing for both Google Play and Firebase distribution selection boxes:**

_(note that **fix** version with both boxes checked has identical results as **main** version checked or unchecked)_

PWM (main): https://github.com/bitwarden/android/actions/runs/32166161553
PWM (fix with both boxes **checked**): https://github.com/bitwarden/android/actions/runs/32171933070
PWM (fix with both boxes **unchecked**): https://github.com/bitwarden/android/actions/runs/32166554369

BWA (main): https://github.com/bitwarden/android/actions/runs/32166274004
BWA (fix with both boxes **checked**): https://github.com/bitwarden/android/actions/runs/32165438880
BWA (fix with both boxes **unchecked**): https://github.com/bitwarden/android/actions/runs/32163461438