### PR TITLE
PM-42171: chore: Remove suspend from certain SDK functions

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSource.kt
@@ -122,7 +122,7 @@ interface AuthSdkSource {
      * Checks the password strength for the given [email] and [password] combination, along with
      * some [additionalInputs].
      */
-    suspend fun passwordStrength(
+    fun passwordStrength(
         email: String,
         password: String,
         additionalInputs: List<String> = emptyList(),
@@ -132,7 +132,7 @@ interface AuthSdkSource {
      * Checks that the given [password] with the given [passwordStrength] satisfies the given
      * [policy]. Returns `true` if so and `false` otherwise.
      */
-    suspend fun satisfiesPolicy(
+    fun satisfiesPolicy(
         password: String,
         passwordStrength: PasswordStrength,
         policy: MasterPasswordPolicyOptions,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceImpl.kt
@@ -201,35 +201,33 @@ class AuthSdkSourceImpl(
             )
     }
 
-    override suspend fun passwordStrength(
+    override fun passwordStrength(
         email: String,
         password: String,
         additionalInputs: List<String>,
     ): Result<PasswordStrength> = runCatchingWithLogs {
-        useClient {
-            @Suppress("UnsafeCallOnNullableType")
-            auth()
+        requireNotNull(
+            globalClient
+                .auth()
                 .passwordStrength(
                     password = password,
                     email = email,
                     additionalInputs = additionalInputs,
                 )
-                .toPasswordStrengthOrNull()!!
-        }
+                .toPasswordStrengthOrNull(),
+        )
     }
 
-    override suspend fun satisfiesPolicy(
+    override fun satisfiesPolicy(
         password: String,
         passwordStrength: PasswordStrength,
         policy: MasterPasswordPolicyOptions,
     ): Result<Boolean> = runCatchingWithLogs {
-        useClient {
-            auth().satisfiesPolicy(
-                password = password,
-                strength = passwordStrength.toUByte(),
-                policy = policy,
-            )
-        }
+        globalClient.auth().satisfiesPolicy(
+            password = password,
+            strength = passwordStrength.toUByte(),
+            policy = policy,
+        )
     }
 
     override fun filterPolicies(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
@@ -378,7 +378,7 @@ interface AuthRepository :
      * If no value is passed for the [email] will use the active email of the current active
      * account via the [userStateFlow].
      */
-    suspend fun getPasswordStrength(email: String? = null, password: String): PasswordStrengthResult
+    fun getPasswordStrength(email: String? = null, password: String): PasswordStrengthResult
 
     /**
      * Validates the master password for the current logged-in user.
@@ -394,7 +394,7 @@ interface AuthRepository :
      * Validates the given [password] against the master password
      * policies for the current user.
      */
-    suspend fun validatePasswordAgainstPolicies(password: String): Boolean
+    fun validatePasswordAgainstPolicies(password: String): Boolean
 
     /**
      * Send a verification email.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1444,7 +1444,7 @@ class AuthRepositoryImpl(
                 onSuccess = { BreachCountResult.Success(it) },
             )
 
-    override suspend fun getPasswordStrength(
+    override fun getPasswordStrength(
         email: String?,
         password: String,
     ): PasswordStrengthResult =
@@ -1537,7 +1537,7 @@ class AuthRepositoryImpl(
             )
     }
 
-    override suspend fun validatePasswordAgainstPolicies(
+    override fun validatePasswordAgainstPolicies(
         password: String,
     ): Boolean = passwordPolicies
         .all { validatePasswordAgainstPolicy(password, it) }
@@ -1620,7 +1620,7 @@ class AuthRepositoryImpl(
         )
 
     @Suppress("CyclomaticComplexMethod")
-    private suspend fun validatePasswordAgainstPolicy(
+    private fun validatePasswordAgainstPolicy(
         password: String,
         policy: PolicyInformation.MasterPassword,
     ): Boolean {
@@ -1659,7 +1659,7 @@ class AuthRepositoryImpl(
      * Return true if there are any [PolicyInformation.MasterPassword] policies that the user's
      * master password has failed to pass.
      */
-    private suspend fun passwordPassesPolicies(
+    private fun passwordPassesPolicies(
         password: String,
         policies: List<PolicyView>,
     ): Boolean {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceTest.kt
@@ -34,6 +34,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -459,109 +460,98 @@ class AuthSdkSourceTest {
         }
 
     @Test
-    fun `passwordStrength should call SDK and return a Result with the correct data`() =
-        runBlocking {
-            val slot = slot<suspend Client.() -> PasswordStrength>()
-            coEvery {
-                sdkClientManager.singleUseClient(block = capture(slot))
-            } coAnswers { slot.captured(client) }
-            val email = "email"
-            val password = "password"
-            val additionalInputs = listOf("test1", "test2")
-            val sdkResult = 3.toUByte()
-            val expectedResult = PasswordStrength.LEVEL_3
-            coEvery {
-                clientAuth.passwordStrength(
-                    email = email,
-                    password = password,
-                    additionalInputs = additionalInputs,
-                )
-            } returns sdkResult
-
-            val result = authSkdSource.passwordStrength(
+    fun `passwordStrength should call SDK and return a Result with the correct data`() {
+        val email = "email"
+        val password = "password"
+        val additionalInputs = listOf("test1", "test2")
+        val sdkResult = 3.toUByte()
+        val expectedResult = PasswordStrength.LEVEL_3
+        every {
+            clientAuth.passwordStrength(
                 email = email,
                 password = password,
                 additionalInputs = additionalInputs,
             )
-            assertEquals(
-                expectedResult.asSuccess(),
-                result,
+        } returns sdkResult
+
+        val result = authSkdSource.passwordStrength(
+            email = email,
+            password = password,
+            additionalInputs = additionalInputs,
+        )
+        assertEquals(
+            expectedResult.asSuccess(),
+            result,
+        )
+        verify(exactly = 1) {
+            clientAuth.passwordStrength(
+                email = email,
+                password = password,
+                additionalInputs = additionalInputs,
             )
-            coVerify {
-                clientAuth.passwordStrength(
-                    email = email,
-                    password = password,
-                    additionalInputs = additionalInputs,
-                )
-            }
         }
+    }
 
     @Test
-    fun `satisfiesPolicy should call SDK and return a Result with the correct data`() =
-        runBlocking {
-            val slot = slot<suspend Client.() -> Boolean>()
-            coEvery {
-                sdkClientManager.singleUseClient(block = capture(slot))
-            } coAnswers { slot.captured(client) }
-            val password = "password"
-            val passwordStrength = PasswordStrength.LEVEL_3
-            val rawStrength = 3.toUByte()
-            val policy = mockk<MasterPasswordPolicyOptions>()
-            val expectedResult = true
-            coEvery {
-                clientAuth.satisfiesPolicy(
-                    password = password,
-                    strength = rawStrength,
-                    policy = policy,
-                )
-            } returns expectedResult
-
-            val result = authSkdSource.satisfiesPolicy(
+    fun `satisfiesPolicy should call SDK and return a Result with the correct data`() {
+        val password = "password"
+        val passwordStrength = PasswordStrength.LEVEL_3
+        val rawStrength = 3.toUByte()
+        val policy = mockk<MasterPasswordPolicyOptions>()
+        val expectedResult = true
+        every {
+            clientAuth.satisfiesPolicy(
                 password = password,
-                passwordStrength = passwordStrength,
+                strength = rawStrength,
                 policy = policy,
             )
-            assertEquals(
-                expectedResult.asSuccess(),
-                result,
+        } returns expectedResult
+
+        val result = authSkdSource.satisfiesPolicy(
+            password = password,
+            passwordStrength = passwordStrength,
+            policy = policy,
+        )
+        assertEquals(
+            expectedResult.asSuccess(),
+            result,
+        )
+        verify(exactly = 1) {
+            clientAuth.satisfiesPolicy(
+                password = password,
+                strength = rawStrength,
+                policy = policy,
             )
-            coVerify {
-                clientAuth.satisfiesPolicy(
-                    password = password,
-                    strength = rawStrength,
-                    policy = policy,
-                )
-            }
         }
+    }
 
     @Test
-    fun `filterPolicies should call SDK and return a Result with the correct data`() =
-        runBlocking {
-            val policies = listOf(mockk<PolicyView>())
-            val organizations = listOf(mockk<OrganizationUserPolicyContext>())
-            val policyType = mockk<PolicyType>()
-            val expectedResult = listOf(mockk<PolicyView>())
-            coEvery {
-                clientPolicies.filterByType(
-                    policies = policies,
-                    organizationUserPolicyContexts = organizations,
-                    policyType = policyType,
-                )
-            } returns expectedResult
-
-            val result = authSkdSource.filterPolicies(
+    fun `filterPolicies should call SDK and return a Result with the correct data`() {
+        val policies = listOf(mockk<PolicyView>())
+        val organizations = listOf(mockk<OrganizationUserPolicyContext>())
+        val policyType = mockk<PolicyType>()
+        val expectedResult = listOf(mockk<PolicyView>())
+        every {
+            clientPolicies.filterByType(
                 policies = policies,
-                organizations = organizations,
+                organizationUserPolicyContexts = organizations,
                 policyType = policyType,
             )
+        } returns expectedResult
 
-            assertEquals(expectedResult.asSuccess(), result)
-            coVerify(exactly = 1) {
-                clientPolicies.filterByType(
-                    policies = policies,
-                    organizationUserPolicyContexts = organizations,
-                    policyType = policyType,
-                )
-            }
+        val result = authSkdSource.filterPolicies(
+            policies = policies,
+            organizations = organizations,
+            policyType = policyType,
+        )
+
+        assertEquals(expectedResult.asSuccess(), result)
+        verify(exactly = 1) {
+            clientPolicies.filterByType(
+                policies = policies,
+                organizationUserPolicyContexts = organizations,
+                policyType = policyType,
+            )
         }
+    }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -6486,24 +6486,24 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `getPasswordStrength returns expected results for various strength levels`() = runTest {
-        coEvery {
+    fun `getPasswordStrength returns expected results for various strength levels`() {
+        every {
             authSdkSource.passwordStrength(any(), eq("level_0"))
         } returns LEVEL_0.asSuccess()
 
-        coEvery {
+        every {
             authSdkSource.passwordStrength(any(), eq("level_1"))
         } returns LEVEL_1.asSuccess()
 
-        coEvery {
+        every {
             authSdkSource.passwordStrength(any(), eq("level_2"))
         } returns LEVEL_2.asSuccess()
 
-        coEvery {
+        every {
             authSdkSource.passwordStrength(any(), eq("level_3"))
         } returns LEVEL_3.asSuccess()
 
-        coEvery {
+        every {
             authSdkSource.passwordStrength(any(), eq("level_4"))
         } returns LEVEL_4.asSuccess()
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42171](https://bitwarden.atlassian.net/browse/PM-42171)

## 📔 Objective

This PR removes the `suspend` keyword from SDK functions that can be called synchronously and with the global client.


[PM-42171]: https://bitwarden.atlassian.net/browse/PM-42171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ