### PR TITLE
[PM-42245] fix: Restore WebAuthn callbacks with unsupported Auth Tab browsers

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImpl.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImpl.kt
@@ -98,9 +98,19 @@ internal class IntentManagerImpl(
                 }
             }
         } else {
-            // Fall back to a Custom Tab.
-            Timber.d("Launching uri with CustomTabs fallback for $providerPackageName")
-            startCustomTabsActivity(uri = uri)
+            when (authTabData) {
+                is AuthTabData.CustomScheme -> {
+                    Timber.d("Launching uri with CustomTabs fallback for $providerPackageName")
+                    startCustomTabsActivity(uri = uri)
+                }
+
+                is AuthTabData.HttpsScheme -> {
+                    Timber.d(
+                        "Launching uri with external browser fallback for $providerPackageName",
+                    )
+                    launchUri(uri = uri)
+                }
+            }
         }
     }
 

--- a/ui/src/test/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImplTest.kt
+++ b/ui/src/test/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImplTest.kt
@@ -1,0 +1,170 @@
+package com.bitwarden.ui.platform.manager
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
+import androidx.browser.auth.AuthTabIntent
+import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
+import com.bitwarden.core.data.manager.BuildInfoManager
+import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
+import io.mockk.anyConstructed
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Clock
+
+@Config(sdk = [Config.NEWEST_SDK])
+@RunWith(RobolectricTestRunner::class)
+class IntentManagerImplTest {
+
+    private val activity: Activity = mockk(relaxed = true)
+    private val launcher: ActivityResultLauncher<Intent> = mockk(relaxed = true)
+    private val authTabIntent: AuthTabIntent = mockk(relaxed = true)
+    private val customTabsIntent: CustomTabsIntent = mockk(relaxed = true)
+
+    private val intentManager = IntentManagerImpl(
+        activity = activity,
+        clock = Clock.systemUTC(),
+        buildInfoManager = mockk<BuildInfoManager>(),
+    )
+
+    @Before
+    fun setup() {
+        mockkStatic(CustomTabsClient::class)
+        mockkConstructor(AuthTabIntent.Builder::class)
+        mockkConstructor(CustomTabsIntent.Builder::class)
+        every {
+            CustomTabsClient.getPackageName(activity, null)
+        } returns PROVIDER_PACKAGE_NAME
+        every {
+            anyConstructed<AuthTabIntent.Builder>().build()
+        } returns authTabIntent
+        every {
+            anyConstructed<CustomTabsIntent.Builder>().build()
+        } returns customTabsIntent
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `startAuthTab with supported provider and HttpsScheme launches Auth Tab`() {
+        val uri = Uri.parse(CONNECTOR_URL)
+        val authTabData = AuthTabData.HttpsScheme(
+            host = CALLBACK_HOST,
+            path = CALLBACK_PATH,
+        )
+        every {
+            CustomTabsClient.isAuthTabSupported(activity, PROVIDER_PACKAGE_NAME)
+        } returns true
+
+        intentManager.startAuthTab(uri, authTabData, launcher)
+
+        verify(exactly = 1) {
+            authTabIntent.launch(launcher, uri, CALLBACK_HOST, "\\$CALLBACK_PATH")
+        }
+        verify(exactly = 0) { activity.startActivity(any<Intent>()) }
+    }
+
+    @Test
+    fun `startAuthTab with supported provider and CustomScheme launches Auth Tab`() {
+        val uri = Uri.parse(CONNECTOR_URL)
+        val authTabData = AuthTabData.CustomScheme(callbackUrl = CUSTOM_CALLBACK_URL)
+        every {
+            CustomTabsClient.isAuthTabSupported(activity, PROVIDER_PACKAGE_NAME)
+        } returns true
+
+        intentManager.startAuthTab(uri, authTabData, launcher)
+
+        verify(exactly = 1) {
+            authTabIntent.launch(launcher, uri, authTabData.callbackScheme)
+        }
+        verify(exactly = 0) { activity.startActivity(any<Intent>()) }
+    }
+
+    @Test
+    fun `startAuthTab with unsupported provider and HttpsScheme launches browser intent`() {
+        val uri = Uri.parse(CONNECTOR_URL_WITH_UPPERCASE_SCHEME)
+        val startedIntent = mutableListOf<Intent>()
+        every { activity.startActivity(capture(startedIntent)) } just runs
+        every {
+            CustomTabsClient.isAuthTabSupported(activity, PROVIDER_PACKAGE_NAME)
+        } returns false
+
+        intentManager.startAuthTab(
+            uri = uri,
+            authTabData = AuthTabData.HttpsScheme(
+                host = CALLBACK_HOST,
+                path = CALLBACK_PATH,
+            ),
+            launcher = launcher,
+        )
+
+        assertEquals(Intent.ACTION_VIEW, startedIntent.single().action)
+        assertEquals(Uri.parse(CONNECTOR_URL), startedIntent.single().data)
+        verify(exactly = 0) { customTabsIntent.launchUrl(any(), any()) }
+        verify(exactly = 0) { launcher.launch(any()) }
+    }
+
+    @Test
+    fun `startAuthTab with unsupported provider and CustomScheme launches Custom Tab`() {
+        val uri = Uri.parse(CONNECTOR_URL)
+        every {
+            CustomTabsClient.isAuthTabSupported(activity, PROVIDER_PACKAGE_NAME)
+        } returns false
+
+        intentManager.startAuthTab(
+            uri = uri,
+            authTabData = AuthTabData.CustomScheme(callbackUrl = CUSTOM_CALLBACK_URL),
+            launcher = launcher,
+        )
+
+        verify(exactly = 1) { customTabsIntent.launchUrl(activity, uri) }
+        verify(exactly = 0) { activity.startActivity(any<Intent>()) }
+        verify(exactly = 0) { launcher.launch(any()) }
+    }
+
+    @Test
+    fun `startAuthTab with unsupported provider and unavailable browser does not crash`() {
+        every { activity.startActivity(any<Intent>()) } throws ActivityNotFoundException()
+        every {
+            CustomTabsClient.isAuthTabSupported(activity, PROVIDER_PACKAGE_NAME)
+        } returns false
+
+        intentManager.startAuthTab(
+            uri = Uri.parse(CONNECTOR_URL),
+            authTabData = AuthTabData.HttpsScheme(
+                host = CALLBACK_HOST,
+                path = CALLBACK_PATH,
+            ),
+            launcher = launcher,
+        )
+
+        verify(exactly = 0) { launcher.launch(any()) }
+    }
+}
+
+private const val PROVIDER_PACKAGE_NAME: String = "com.example.browser"
+private const val CONNECTOR_URL: String = "https://vault.bitwarden.com/webauthn-connector.html"
+private const val CONNECTOR_URL_WITH_UPPERCASE_SCHEME: String =
+    "HTTPS://vault.bitwarden.com/webauthn-connector.html"
+private const val CALLBACK_HOST: String = "bitwarden.com"
+private const val CALLBACK_PATH: String = "webauthn-callback"
+private const val CUSTOM_CALLBACK_URL: String = "bitwarden://webauthn-callback"


### PR DESCRIPTION
## 🎟️ Tracking

Change the unsupported-Authentication-Tab branch in `IntentManagerImpl.startAuthTab` to select its fallback from the existing `AuthTabData` type. For `HttpsScheme`, use the existing external-browser launch path so Android can resolve the verified callback App Link back to Bitwarden; for `CustomScheme`, retain the current Custom Tab fallback so self-hosted and other custom-scheme flows keep their established behavior. Keep the supported-provider `AuthTabIntent` path unchanged, including its host/path and custom-scheme callback registration.

Fixes #7205

## 📔 Objective

Not applicable to this change.

## 📸 Screenshots

No user-visible surface changes in this PR, so there is nothing to show.
