### PR TITLE
[PM-42198] feat: Send encryptedByKeyId on cipher requests

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
@@ -43,12 +43,14 @@ import com.bitwarden.vault.UriMatchType
 
 /**
  * Converts a Bitwarden SDK [Cipher] object to a corresponding
- * [SyncResponseJson.Cipher] object.
+ * [CipherJsonRequest] object.
  *
  * @param encryptedFor The ID of the user who this cipher is encrypted by.
+ * @param encryptedByKeyId The ID of the key this cipher is encrypted by.
  */
 fun Cipher.toEncryptedNetworkCipher(
     encryptedFor: String,
+    encryptedByKeyId: String?,
 ): CipherJsonRequest =
     CipherJsonRequest(
         notes = notes,
@@ -76,6 +78,7 @@ fun Cipher.toEncryptedNetworkCipher(
         archivedDate = archivedDate,
         data = data,
         encryptedFor = encryptedFor,
+        encryptedByKeyId = encryptedByKeyId,
     )
 
 /**
@@ -810,7 +813,10 @@ fun List<CipherListView>.sortAlphabetically(): List<CipherListView> {
  * object.
  */
 fun EncryptionContext.toEncryptedNetworkCipher(): CipherJsonRequest =
-    cipher.toEncryptedNetworkCipher(encryptedFor = encryptedFor)
+    cipher.toEncryptedNetworkCipher(
+        encryptedFor = encryptedFor,
+        encryptedByKeyId = encryptedByKeyId,
+    )
 
 /**
  * Converts a Bitwarden SDK [EncryptionContext] object to a corresponding [SyncResponseJson.Cipher]

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/VaultSdkEncryptionContextUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/VaultSdkEncryptionContextUtil.kt
@@ -24,5 +24,6 @@ fun createMockEncryptionContext(
 ): EncryptionContext =
     EncryptionContext(
         encryptedFor = "mockEncryptedFor-$number",
+        encryptedByKeyId = "mockEncryptedByKeyId-$number",
         cipher = cipher,
     )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerTest.kt
@@ -136,6 +136,31 @@ class CredentialExchangeImportManagerTest {
         }
 
         @Test
+        fun `importCiphers request should carry the encryption metadata from the SDK`() = runTest {
+            coEvery {
+                vaultSdkSource.importCxf(
+                    userId = DEFAULT_USER_ID,
+                    payload = DEFAULT_ACCOUNT_JSON,
+                )
+            } returns DEFAULT_CIPHER_LIST.asSuccess()
+
+            val capturedRequest = slot<ImportCiphersJsonRequest>()
+            coEvery {
+                ciphersService.importCiphers(capture(capturedRequest))
+            } returns ImportCiphersResponseJson.Success.asSuccess()
+
+            coEvery {
+                vaultSyncManager.syncForResult(forced = true)
+            } returns SyncVaultDataResult.Success(itemsAvailable = true)
+
+            importManager.importCxfPayload(DEFAULT_USER_ID, DEFAULT_PAYLOAD)
+
+            val cipher = capturedRequest.captured.ciphers.first()
+            assertEquals(DEFAULT_CIPHER.encryptedFor, cipher.encryptedFor)
+            assertEquals(DEFAULT_CIPHER.encryptedByKeyId, cipher.encryptedByKeyId)
+        }
+
+        @Test
         fun `when ciphersService importCiphers returns Invalid, should return Error`() = runTest {
             coEvery {
                 vaultSdkSource.importCxf(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CredentialExchangeImportManagerTest.kt
@@ -8,6 +8,8 @@ import com.bitwarden.cxf.model.CredentialExchangePayload
 import com.bitwarden.cxf.parser.CredentialExchangePayloadParser
 import com.bitwarden.network.model.ImportCiphersJsonRequest
 import com.bitwarden.network.model.ImportCiphersResponseJson
+import com.bitwarden.network.model.createMockCipherJsonRequest
+import com.bitwarden.network.model.createMockLogin
 import com.bitwarden.network.service.CiphersService
 import com.bitwarden.policies.PolicyType
 import com.bitwarden.vault.EncryptionContext
@@ -128,36 +130,19 @@ class CredentialExchangeImportManagerTest {
             val result = importManager.importCxfPayload(DEFAULT_USER_ID, DEFAULT_PAYLOAD)
 
             assertEquals(ImportCxfPayloadResult.Error(exception), result)
-            assertEquals(1, capturedRequest.captured.ciphers.size)
+            assertEquals(
+                listOf(
+                    createMockCipherJsonRequest(
+                        number = 1,
+                        login = createMockLogin(number = 1, uri = null),
+                    ),
+                ),
+                capturedRequest.captured.ciphers,
+            )
             coVerify(exactly = 1) {
                 vaultSdkSource.importCxf(DEFAULT_USER_ID, DEFAULT_ACCOUNT_JSON)
                 ciphersService.importCiphers(any())
             }
-        }
-
-        @Test
-        fun `importCiphers request should carry the encryption metadata from the SDK`() = runTest {
-            coEvery {
-                vaultSdkSource.importCxf(
-                    userId = DEFAULT_USER_ID,
-                    payload = DEFAULT_ACCOUNT_JSON,
-                )
-            } returns DEFAULT_CIPHER_LIST.asSuccess()
-
-            val capturedRequest = slot<ImportCiphersJsonRequest>()
-            coEvery {
-                ciphersService.importCiphers(capture(capturedRequest))
-            } returns ImportCiphersResponseJson.Success.asSuccess()
-
-            coEvery {
-                vaultSyncManager.syncForResult(forced = true)
-            } returns SyncVaultDataResult.Success(itemsAvailable = true)
-
-            importManager.importCxfPayload(DEFAULT_USER_ID, DEFAULT_PAYLOAD)
-
-            val cipher = capturedRequest.captured.ciphers.first()
-            assertEquals(DEFAULT_CIPHER.encryptedFor, cipher.encryptedFor)
-            assertEquals(DEFAULT_CIPHER.encryptedByKeyId, cipher.encryptedByKeyId)
         }
 
         @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensionsTest.kt
@@ -82,6 +82,7 @@ class VaultSdkCipherExtensionsTest {
         val sdkCipher = createMockSdkCipher(number = 1, clock = FIXED_CLOCK)
         val syncCipher = sdkCipher.toEncryptedNetworkCipher(
             encryptedFor = "mockEncryptedFor-1",
+            encryptedByKeyId = "mockEncryptedByKeyId-1",
         )
         assertEquals(
             createMockCipherJsonRequest(
@@ -219,7 +220,10 @@ class VaultSdkCipherExtensionsTest {
         )
             .copy(bankAccount = null)
 
-        val request = sdkCipher.toEncryptedNetworkCipher(encryptedFor = "mockEncryptedFor-1")
+        val request = sdkCipher.toEncryptedNetworkCipher(
+            encryptedFor = "mockEncryptedFor-1",
+            encryptedByKeyId = "mockEncryptedByKeyId-1",
+        )
 
         assertNull(request.bankAccount)
     }
@@ -228,7 +232,10 @@ class VaultSdkCipherExtensionsTest {
     fun `toEncryptedNetworkCipher should map driversLicense and passport`() {
         val sdkCipher = createMockSdkCipher(number = 1, clock = FIXED_CLOCK)
 
-        val request = sdkCipher.toEncryptedNetworkCipher(encryptedFor = "mockEncryptedFor-1")
+        val request = sdkCipher.toEncryptedNetworkCipher(
+            encryptedFor = "mockEncryptedFor-1",
+            encryptedByKeyId = "mockEncryptedByKeyId-1",
+        )
 
         assertEquals(createMockDriversLicense(number = 1), request.driversLicense)
         assertEquals(createMockPassport(number = 1), request.passport)

--- a/network/src/main/kotlin/com/bitwarden/network/model/CipherJsonRequest.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/CipherJsonRequest.kt
@@ -25,6 +25,7 @@ import java.time.Instant
  * @property key The key of the cipher (nullable).
  * @property archivedDate The archived date of the cipher (nullable).
  * @property encryptedFor ID of the user who the cipher is encrypted by.
+ * @property encryptedByKeyId ID of the key the cipher is encrypted by (nullable).
  */
 @Serializable
 data class CipherJsonRequest(
@@ -98,4 +99,7 @@ data class CipherJsonRequest(
 
     @SerialName("encryptedFor")
     val encryptedFor: String?,
+
+    @SerialName("encryptedByKeyId")
+    val encryptedByKeyId: String?,
 )

--- a/network/src/main/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequest.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequest.kt
@@ -74,6 +74,9 @@ data class CipherWithIdJsonRequest(
 
     @SerialName("encryptedFor")
     val encryptedFor: String?,
+
+    @SerialName("encryptedByKeyId")
+    val encryptedByKeyId: String?,
 )
 
 /**
@@ -101,4 +104,5 @@ fun CipherJsonRequest.toCipherWithIdJsonRequest(id: String): CipherWithIdJsonReq
         key = key,
         data = data,
         encryptedFor = encryptedFor,
+        encryptedByKeyId = encryptedByKeyId,
     )

--- a/network/src/test/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequestTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequestTest.kt
@@ -1,0 +1,18 @@
+package com.bitwarden.network.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CipherWithIdJsonRequestTest {
+
+    @Test
+    fun `toCipherWithIdJsonRequest should carry over the encryption metadata`() {
+        val request = createMockCipherJsonRequest(number = 1)
+
+        val result = request.toCipherWithIdJsonRequest(id = "mockId-1")
+
+        assertEquals("mockId-1", result.id)
+        assertEquals(request.encryptedFor, result.encryptedFor)
+        assertEquals(request.encryptedByKeyId, result.encryptedByKeyId)
+    }
+}

--- a/network/src/test/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequestTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequestTest.kt
@@ -6,13 +6,16 @@ import org.junit.jupiter.api.Test
 class CipherWithIdJsonRequestTest {
 
     @Test
-    fun `toCipherWithIdJsonRequest should carry over the encryption metadata`() {
-        val request = createMockCipherJsonRequest(number = 1)
+    fun `toCipherWithIdJsonRequest should convert a CipherJsonRequest and an ID`() {
+        val result = createMockCipherJsonRequest(number = 1)
+            .toCipherWithIdJsonRequest(id = "mockId-1")
 
-        val result = request.toCipherWithIdJsonRequest(id = "mockId-1")
-
-        assertEquals("mockId-1", result.id)
-        assertEquals(request.encryptedFor, result.encryptedFor)
-        assertEquals(request.encryptedByKeyId, result.encryptedByKeyId)
+        assertEquals(
+            createMockCipherWithIdJsonRequest(
+                number = 1,
+                id = "mockId-1",
+            ),
+            result,
+        )
     }
 }

--- a/network/src/testFixtures/kotlin/com/bitwarden/network/model/CipherJsonRequestUtil.kt
+++ b/network/src/testFixtures/kotlin/com/bitwarden/network/model/CipherJsonRequestUtil.kt
@@ -37,6 +37,7 @@ fun createMockCipherJsonRequest(
     archivedDate: Instant? = Instant.parse("2023-10-27T12:00:00Z"),
     data: String? = "mockData-$number",
     encryptedFor: String? = "mockEncryptedFor-$number",
+    encryptedByKeyId: String? = "mockEncryptedByKeyId-$number",
 ): CipherJsonRequest =
     CipherJsonRequest(
         attachments = attachments,
@@ -62,4 +63,5 @@ fun createMockCipherJsonRequest(
         archivedDate = archivedDate,
         data = data,
         encryptedFor = encryptedFor,
+        encryptedByKeyId = encryptedByKeyId,
     )

--- a/network/src/testFixtures/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequestUtil.kt
+++ b/network/src/testFixtures/kotlin/com/bitwarden/network/model/CipherWithIdJsonRequestUtil.kt
@@ -1,0 +1,59 @@
+package com.bitwarden.network.model
+
+import java.time.Instant
+
+/**
+ * Create a mock [CipherWithIdJsonRequest] with a given [number].
+ */
+@Suppress("LongParameterList")
+fun createMockCipherWithIdJsonRequest(
+    number: Int,
+    id: String = "mockId-$number",
+    attachments: Map<String, AttachmentJsonRequest>? = mapOf(
+        "mockId-$number" to createMockAttachmentJsonRequest(number = 1),
+    ),
+    organizationId: String? = "mockOrganizationId-$number",
+    folderId: String? = "mockFolderId-$number",
+    name: String? = "mockName-$number",
+    notes: String? = "mockNotes-$number",
+    type: CipherTypeJson = CipherTypeJson.LOGIN,
+    login: SyncResponseJson.Cipher.Login? = createMockLogin(number = number),
+    card: SyncResponseJson.Cipher.Card? = createMockCard(number = number),
+    sshKey: SyncResponseJson.Cipher.SshKey? = createMockSshKey(number = number),
+    identity: SyncResponseJson.Cipher.Identity? = createMockIdentity(number = number),
+    secureNote: SyncResponseJson.Cipher.SecureNote? = createMockSecureNote(),
+    fields: List<SyncResponseJson.Cipher.Field>? = listOf(createMockField(number = number)),
+    isFavorite: Boolean = false,
+    passwordHistory: List<SyncResponseJson.Cipher.PasswordHistory>? = listOf(
+        createMockPasswordHistory(number = number),
+    ),
+    reprompt: CipherRepromptTypeJson = CipherRepromptTypeJson.NONE,
+    lastKnownRevisionDate: Instant? = Instant.parse("2023-10-27T12:00:00Z"),
+    key: String? = "mockKey-$number",
+    data: String? = "mockData-$number",
+    encryptedFor: String? = "mockEncryptedFor-$number",
+    encryptedByKeyId: String? = "mockEncryptedByKeyId-$number",
+): CipherWithIdJsonRequest =
+    CipherWithIdJsonRequest(
+        id = id,
+        attachments = attachments,
+        organizationId = organizationId,
+        folderId = folderId,
+        name = name,
+        notes = notes,
+        type = type,
+        login = login,
+        card = card,
+        sshKey = sshKey,
+        identity = identity,
+        secureNote = secureNote,
+        fields = fields,
+        isFavorite = isFavorite,
+        passwordHistory = passwordHistory,
+        reprompt = reprompt,
+        lastKnownRevisionDate = lastKnownRevisionDate,
+        key = key,
+        data = data,
+        encryptedFor = encryptedFor,
+        encryptedByKeyId = encryptedByKeyId,
+    )


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42198

Reference: bitwarden/clients#22444 (wiring only — the enrolment migration in
that PR is out of scope here).

## 📔 Objective

The SDK reports the id of the key it used to encrypt a vault item. Sending
that to the server allows the write to be validated against the expected key.

The value comes from the SDK's `EncryptionContext` and should not be
synthesised from app state.

This mirrors the existing `encryptedFor` plumbing, so every write path that
already carries an `EncryptionContext` picks it up with no call-site change:
create, create in organization, update, cipher key migration, share, bulk
share and CXF import. The new parameter is required with no default, so future
callers have to decide explicitly rather than silently omit the field.

### Notes for reviewers

- **Share and bulk share include the id**, matching the SDK's own
  `From<EncryptionContext>` conversions. The web client's `CipherShareRequest`
  drops it, which looks unintentional — worth confirming with the author of
  clients#22444.
- **Nothing is persisted.** `SyncResponseJson.Cipher` and
  `toEncryptedNetworkCipherResponse` are untouched.
- Verified against US dev: the field is sent and writes are accepted.

## 📸 Screenshots

N/A — no UI changes.
