### PR TITLE
[PM-36231] fix: Show Select without dashes on vault add edit menus

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/VaultAddEditExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/VaultAddEditExtensions.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.bitwarden.ui.util.concat
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 
@@ -11,10 +10,7 @@ import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
  * Default, "select" Text to show on multi select buttons in the VaultAddEdit package.
  */
 val SELECT_TEXT: Text
-    get() = "-- "
-        .asText()
-        .concat(BitwardenString.select.asText())
-        .concat(" --".asText())
+    get() = BitwardenString.select.asText()
 
 /**
  * Transforms a [VaultItemCipherType] into [VaultAddEditState.ViewState.Content.ItemType].

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/VaultAddEditExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/VaultAddEditExtensions.kt
@@ -1,16 +1,7 @@
 package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 
-import com.bitwarden.ui.platform.resource.BitwardenString
-import com.bitwarden.ui.util.Text
-import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
-
-/**
- * Default, "select" Text to show on multi select buttons in the VaultAddEdit package.
- */
-val SELECT_TEXT: Text
-    get() = BitwardenString.select.asText()
 
 /**
  * Transforms a [VaultItemCipherType] into [VaultAddEditState.ViewState.Content.ItemType].

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/model/VaultCardExpirationMonth.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/model/VaultCardExpirationMonth.kt
@@ -5,7 +5,6 @@ import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.SELECT_TEXT
 
 /**
  * Defines all available expiration month options for cards.
@@ -15,7 +14,7 @@ enum class VaultCardExpirationMonth(
     val number: String,
 ) {
     SELECT(
-        value = SELECT_TEXT,
+        value = BitwardenString.select.asText(),
         number = "0",
     ),
     JANUARY(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/model/VaultIdentityTitle.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/model/VaultIdentityTitle.kt
@@ -3,13 +3,12 @@ package com.x8bit.bitwarden.ui.vault.model
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.SELECT_TEXT
 
 /**
  * Defines all available title options for identities.
  */
 enum class VaultIdentityTitle(val value: Text) {
-    SELECT(value = SELECT_TEXT),
+    SELECT(value = BitwardenString.select.asText()),
     MR(value = BitwardenString.mr.asText()),
     MRS(value = BitwardenString.mrs.asText()),
     MS(value = BitwardenString.ms.asText()),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/util/VaultBankAccountTypeExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/util/VaultBankAccountTypeExtensions.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.vault.util
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.SELECT_TEXT
 import com.x8bit.bitwarden.ui.vault.model.VaultBankAccountType
 
 /**
@@ -11,7 +10,7 @@ import com.x8bit.bitwarden.ui.vault.model.VaultBankAccountType
  */
 val VaultBankAccountType.longName: Text
     get() = when (this) {
-        VaultBankAccountType.SELECT -> SELECT_TEXT
+        VaultBankAccountType.SELECT -> BitwardenString.select.asText()
         VaultBankAccountType.CHECKING -> BitwardenString.checking.asText()
         VaultBankAccountType.SAVINGS -> BitwardenString.savings.asText()
         VaultBankAccountType.CERTIFICATE_OF_DEPOSIT -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/util/VaultCardBrandExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/util/VaultCardBrandExtensions.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.vault.util
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.SELECT_TEXT
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
 
 /**
@@ -11,7 +10,7 @@ import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
  */
 val VaultCardBrand.longName: Text
     get() = when (this) {
-        VaultCardBrand.SELECT -> SELECT_TEXT
+        VaultCardBrand.SELECT -> BitwardenString.select.asText()
         VaultCardBrand.VISA -> "Visa".asText()
         VaultCardBrand.MASTERCARD -> "Mastercard".asText()
         VaultCardBrand.AMEX -> "American Express".asText()
@@ -29,7 +28,7 @@ val VaultCardBrand.longName: Text
  */
 val VaultCardBrand.shortName: Text
     get() = when (this) {
-        VaultCardBrand.SELECT -> SELECT_TEXT
+        VaultCardBrand.SELECT -> BitwardenString.select.asText()
         VaultCardBrand.VISA -> "Visa".asText()
         VaultCardBrand.MASTERCARD -> "Mastercard".asText()
         VaultCardBrand.AMEX -> "Amex".asText()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -1767,7 +1767,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         mutableStateFlow.value = DEFAULT_STATE_IDENTITY
         // Opens the menu
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "-- Select --. Title")
+            .onNodeWithContentDescriptionAfterScroll(label = "Select. Title")
             .performClick()
 
         // Choose the option from the menu
@@ -1790,7 +1790,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
     fun `in ItemType_Identity the Title should display the selected title from the state`() {
         mutableStateFlow.value = DEFAULT_STATE_IDENTITY
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "-- Select --. Title")
+            .onNodeWithContentDescriptionAfterScroll(label = "Select. Title")
             .assertIsDisplayed()
 
         mutableStateFlow.update { currentState ->
@@ -2435,7 +2435,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         mutableStateFlow.value = DEFAULT_STATE_CARD
         // Opens the menu
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "-- Select --. Brand")
+            .onNodeWithContentDescriptionAfterScroll(label = "Select. Brand")
             .performClick()
 
         // Choose the option from the menu
@@ -2458,7 +2458,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
     fun `in ItemType_Card the Brand should display the selected brand from the state`() {
         mutableStateFlow.value = DEFAULT_STATE_CARD
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "-- Select --. Brand")
+            .onNodeWithContentDescriptionAfterScroll(label = "Select. Brand")
             .assertIsDisplayed()
 
         mutableStateFlow.update { currentState ->
@@ -2479,7 +2479,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         mutableStateFlow.value = DEFAULT_STATE_CARD
         // Opens the menu
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "-- Select --. Expiration month")
+            .onNodeWithContentDescriptionAfterScroll(label = "Select. Expiration month")
             .performClick()
 
         // Choose the option from the menu
@@ -2503,7 +2503,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
     fun `in ItemType_Card the Expiration month should display the selected expiration month from the state`() {
         mutableStateFlow.value = DEFAULT_STATE_CARD
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "-- Select --. Expiration month")
+            .onNodeWithContentDescriptionAfterScroll(label = "Select. Expiration month")
             .assertIsDisplayed()
 
         mutableStateFlow.update { currentState ->
@@ -2654,7 +2654,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
         // Opens the menu
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "-- Select --. Account type")
+            .onNodeWithContentDescriptionAfterScroll(label = "Select. Account type")
             .performClick()
 
         // Choose the option from the menu

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/util/VaultBankAccountTypeExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/util/VaultBankAccountTypeExtensionsTest.kt
@@ -2,7 +2,6 @@ package com.x8bit.bitwarden.ui.vault.util
 
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.SELECT_TEXT
 import com.x8bit.bitwarden.ui.vault.model.VaultBankAccountType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -12,7 +11,7 @@ class VaultBankAccountTypeExtensionsTest {
     @Test
     fun `longName should return the correct value for each VaultBankAccountType`() {
         mapOf(
-            VaultBankAccountType.SELECT to SELECT_TEXT,
+            VaultBankAccountType.SELECT to BitwardenString.select.asText(),
             VaultBankAccountType.CHECKING to BitwardenString.checking.asText(),
             VaultBankAccountType.SAVINGS to BitwardenString.savings.asText(),
             VaultBankAccountType.CERTIFICATE_OF_DEPOSIT to

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/util/VaultCardBrandExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/util/VaultCardBrandExtensionsTest.kt
@@ -2,7 +2,6 @@ package com.x8bit.bitwarden.ui.vault.util
 
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.SELECT_TEXT
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -12,7 +11,7 @@ class VaultCardBrandExtensionsTest {
     @Test
     fun `longName should return the correct value for each VaultCardBrand`() {
         mapOf(
-            VaultCardBrand.SELECT to SELECT_TEXT,
+            VaultCardBrand.SELECT to BitwardenString.select.asText(),
             VaultCardBrand.VISA to "Visa".asText(),
             VaultCardBrand.MASTERCARD to "Mastercard".asText(),
             VaultCardBrand.AMEX to "American Express".asText(),
@@ -35,7 +34,7 @@ class VaultCardBrandExtensionsTest {
     @Test
     fun `shortName should return the correct value for each VaultCardBrand`() {
         mapOf(
-            VaultCardBrand.SELECT to SELECT_TEXT,
+            VaultCardBrand.SELECT to BitwardenString.select.asText(),
             VaultCardBrand.VISA to "Visa".asText(),
             VaultCardBrand.MASTERCARD to "Mastercard".asText(),
             VaultCardBrand.AMEX to "Amex".asText(),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36231

## 📔 Objective

- The Brand dropdown showed `-- Select --` as its default, but the designs just ask for `Select`.
- `SELECT_TEXT` is shared, so this also cleans up card expiration month, bank account type, and identity title. Fixing only Brand would have left the app disagreeing with itself.
- Safe to change: nothing keys off the dashes, and the placeholder never reaches the SDK or the API.


## 📸 Screenshots
| Before | After |
|--------|-------|
| <img width="365" src="https://github.com/user-attachments/assets/496b9199-9aec-47ae-8b92-b61c73601304" /> | <img width="365" src="https://github.com/user-attachments/assets/f135a4fd-1cc2-40f2-9cdc-287fb3825e45" /> |
