### PR TITLE
PM-33857: feat: Add User Notification Policy banner

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -11,6 +11,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.CredentialExchangeRegistryManager
+import com.x8bit.bitwarden.data.platform.manager.policy.UserNotificationPolicyManager
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.GeneratorDiskSource
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.PasswordHistoryDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
@@ -26,7 +27,7 @@ import timber.log.Timber
  * Primary implementation of [UserLogoutManager].
  */
 @Suppress("LongParameterList")
-class UserLogoutManagerImpl(
+internal class UserLogoutManagerImpl(
     private val authDiskSource: AuthDiskSource,
     private val generatorDiskSource: GeneratorDiskSource,
     private val passwordHistoryDiskSource: PasswordHistoryDiskSource,
@@ -36,6 +37,7 @@ class UserLogoutManagerImpl(
     private val vaultDiskSource: VaultDiskSource,
     private val vaultSdkSource: VaultSdkSource,
     private val credentialExchangeRegistryManager: CredentialExchangeRegistryManager,
+    private val userNotificationPolicyManager: UserNotificationPolicyManager,
     dispatcherManager: DispatcherManager,
 ) : UserLogoutManager {
     private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
@@ -86,6 +88,10 @@ class UserLogoutManagerImpl(
             .getEphemeralPinProtectedUserKeyEnvelope(userId = userId)
         val persistentPinProtectedUserKeyEnvelope = authDiskSource
             .getPersistentPinProtectedUserKeyEnvelope(userId = userId)
+        val shouldClearOnSoftLogout = userNotificationPolicyManager
+            .shouldClearOnSoftLogout(userId = userId)
+        val vaultPolicyBannerDismissedDate = settingsDiskSource
+            .getVaultPolicyBannerDismissedDate(userId = userId)
 
         clearData(userId = userId)
         mutableLogoutEventFlow.tryEmit(LogoutEvent(loggedOutUserId = userId))
@@ -100,6 +106,13 @@ class UserLogoutManagerImpl(
                 userId = userId,
                 vaultTimeoutAction = vaultTimeoutAction,
             )
+            if (!shouldClearOnSoftLogout) {
+                // We make sure the data is preserved if it should not be cleared.
+                storeVaultPolicyBannerDismissedDate(
+                    userId = userId,
+                    dismissalRevisionDate = vaultPolicyBannerDismissedDate,
+                )
+            }
         }
         authDiskSource.apply {
             storeEncryptedPin(userId = userId, encryptedPin = encryptedPin)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
@@ -39,6 +39,7 @@ import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.manager.policy.UserNotificationPolicyManager
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.GeneratorDiskSource
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.PasswordHistoryDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
@@ -144,6 +145,7 @@ object AuthManagerModule {
         vaultSdkSource: VaultSdkSource,
         dispatcherManager: DispatcherManager,
         credentialExchangeRegistryManager: CredentialExchangeRegistryManager,
+        userNotificationPolicyManager: UserNotificationPolicyManager,
     ): UserLogoutManager =
         UserLogoutManagerImpl(
             authDiskSource = authDiskSource,
@@ -156,6 +158,7 @@ object AuthManagerModule {
             vaultSdkSource = vaultSdkSource,
             dispatcherManager = dispatcherManager,
             credentialExchangeRegistryManager = credentialExchangeRegistryManager,
+            userNotificationPolicyManager = userNotificationPolicyManager,
         )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformation.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.auth.repository.model
 
-import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.network.model.SendAccessTypeJson
+import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -198,4 +198,28 @@ sealed class PolicyInformation {
             CUSTOM,
         }
     }
+
+    /**
+     * Represents a policy to display a user notification banner on the main vault screen.
+     *
+     * @property headerText The text to be displayed on the banner header.
+     * @property descriptionText The text to be displayed on the banner description.
+     * @property buttonText The text to be displayed in the banner button.
+     * @property showAfterEveryLogin Indicates if the dismissed status of the banner should persist
+     * after a soft-logout. When `true` the dismissal is not persisted, otherwise, it is persisted.
+     */
+    @Serializable
+    data class OrganizationUserNotification(
+        @SerialName("header")
+        val headerText: String?,
+
+        @SerialName("description")
+        val descriptionText: String,
+
+        @SerialName("buttonText")
+        val buttonText: String?,
+
+        @SerialName("showAfterEveryLogin")
+        val showAfterEveryLogin: Boolean,
+    ) : PolicyInformation()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensions.kt
@@ -157,7 +157,28 @@ val PolicyView.policyInformation: PolicyInformation?
                 JSON.decodeFromStringOrNull<PolicyInformation.SendControls>(it)
             }
 
-            else -> null
+            PolicyType.ORGANIZATION_USER_NOTIFICATION -> {
+                JSON.decodeFromStringOrNull<PolicyInformation.OrganizationUserNotification>(it)
+            }
+
+            PolicyType.TWO_FACTOR_AUTHENTICATION,
+            PolicyType.SINGLE_ORG,
+            PolicyType.REQUIRE_SSO,
+            PolicyType.ORGANIZATION_DATA_OWNERSHIP,
+            PolicyType.DISABLE_SEND,
+            PolicyType.RESET_PASSWORD,
+            PolicyType.DISABLE_PERSONAL_VAULT_EXPORT,
+            PolicyType.ACTIVATE_AUTOFILL,
+            PolicyType.AUTOMATIC_APP_LOG_IN,
+            PolicyType.FREE_FAMILIES_SPONSORSHIP,
+            PolicyType.REMOVE_UNLOCK_WITH_PIN,
+            PolicyType.RESTRICTED_ITEM_TYPES,
+            PolicyType.URI_MATCH_DEFAULTS,
+            PolicyType.AUTOTYPE_DEFAULT_SETTING,
+            PolicyType.AUTOMATIC_USER_CONFIRMATION,
+            PolicyType.BLOCK_CLAIMED_DOMAIN_ACCOUNT_CREATION,
+            PolicyType.FILL_ASSIST,
+                -> null
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -153,6 +153,24 @@ interface SettingsDiskSource : FlightRecorderDiskSource {
     fun getPremiumUpgradeBannerDismissedFlow(userId: String): Flow<Boolean?>
 
     /**
+     * Retrieves the stored value of whether the vault policy banner has been dismissed.
+     */
+    fun getVaultPolicyBannerDismissedDate(userId: String): Instant?
+
+    /**
+     * Stores whether the vault policy banner has been dismissed.
+     */
+    fun storeVaultPolicyBannerDismissedDate(
+        userId: String,
+        dismissalRevisionDate: Instant?,
+    )
+
+    /**
+     * Emits updates that track [getVaultPolicyBannerDismissedDate] for the given [userId].
+     */
+    fun getVaultPolicyBannerDismissedDateFlow(userId: String): Flow<Instant?>
+
+    /**
      * Retrieves the stored value of whether the "Upgraded to Premium" action card has been
      * consumed (either dismissed via the close icon or actioned via the Learn more CTA).
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -53,14 +53,11 @@ private const val IS_DYNAMIC_COLORS_ENABLED = "isDynamicColorsEnabled"
 private const val BROWSER_AUTOFILL_DIALOG_RESHOW_TIME = "browserAutofillDialogReshowTime"
 private const val INTRODUCING_ARCHIVE_ACTION_CARD_DISMISSED =
     "introducingArchiveActionCardDismissed"
-private const val PREMIUM_UPGRADE_BANNER_DISMISSED =
-    "premiumUpgradeBannerDismissed"
-private const val UPGRADED_TO_PREMIUM_CARD_CONSUMED =
-    "upgradedToPremiumCardConsumed"
-private const val UPGRADED_TO_PREMIUM_CARD_PENDING =
-    "upgradedToPremiumCardPending"
-private const val PREMIUM_UPGRADE_PENDING =
-    "premiumUpgradePending"
+private const val PREMIUM_UPGRADE_BANNER_DISMISSED = "premiumUpgradeBannerDismissed"
+private const val VAULT_POLICY_BANNER_DISMISSED_DATE = "vaultPolicyBannerDismissedDate"
+private const val UPGRADED_TO_PREMIUM_CARD_CONSUMED = "upgradedToPremiumCardConsumed"
+private const val UPGRADED_TO_PREMIUM_CARD_PENDING = "upgradedToPremiumCardPending"
+private const val PREMIUM_UPGRADE_PENDING = "premiumUpgradePending"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -107,6 +104,9 @@ class SettingsDiskSourceImpl(
 
     private val mutablePremiumUpgradeBannerDismissedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutableVaultPolicyBannerDismissedDateFlowMap =
+        mutableMapOf<String, MutableSharedFlow<Instant?>>()
 
     private val mutableUpgradedToPremiumCardConsumedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -276,6 +276,7 @@ class SettingsDiskSourceImpl(
         storeClearClipboardFrequencySeconds(userId = userId, frequency = null)
         removeWithPrefix(prefix = ACCOUNT_BIOMETRIC_INTEGRITY_VALID_KEY.appendIdentifier(userId))
         storeAppResumeScreen(userId = userId, screenData = null)
+        storeVaultPolicyBannerDismissedDate(userId = userId, dismissalRevisionDate = null)
 
         // The following are intentionally not cleared so they can be
         // restored after logging out and back in:
@@ -331,6 +332,28 @@ class SettingsDiskSourceImpl(
     override fun getPremiumUpgradeBannerDismissedFlow(userId: String): Flow<Boolean?> =
         getMutablePremiumUpgradeBannerDismissedFlow(userId = userId)
             .onSubscription { emit(getPremiumUpgradeBannerDismissed(userId = userId)) }
+
+    override fun getVaultPolicyBannerDismissedDate(
+        userId: String,
+    ): Instant? =
+        getLong(key = VAULT_POLICY_BANNER_DISMISSED_DATE.appendIdentifier(identifier = userId))
+            ?.let { Instant.ofEpochMilli(it) }
+
+    override fun storeVaultPolicyBannerDismissedDate(
+        userId: String,
+        dismissalRevisionDate: Instant?,
+    ) {
+        putLong(
+            key = VAULT_POLICY_BANNER_DISMISSED_DATE.appendIdentifier(identifier = userId),
+            value = dismissalRevisionDate?.toEpochMilli(),
+        )
+        getMutableVaultPolicyBannerDismissedDateFlow(userId = userId).tryEmit(dismissalRevisionDate)
+    }
+
+    override fun getVaultPolicyBannerDismissedDateFlow(
+        userId: String,
+    ): Flow<Instant?> = getMutableVaultPolicyBannerDismissedDateFlow(userId = userId)
+        .onSubscription { emit(getVaultPolicyBannerDismissedDate(userId = userId)) }
 
     override fun getUpgradedToPremiumCardConsumed(userId: String): Boolean? =
         getBoolean(
@@ -755,6 +778,13 @@ class SettingsDiskSourceImpl(
         userId: String,
     ): MutableSharedFlow<Boolean?> =
         mutablePremiumUpgradeBannerDismissedFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutableVaultPolicyBannerDismissedDateFlow(
+        userId: String,
+    ): MutableSharedFlow<Instant?> =
+        mutableVaultPolicyBannerDismissedDateFlowMap.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -81,6 +81,8 @@ import com.x8bit.bitwarden.data.platform.manager.network.NetworkPermissionManage
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkPermissionManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManager
 import com.x8bit.bitwarden.data.platform.manager.policy.PasswordPolicyManagerImpl
+import com.x8bit.bitwarden.data.platform.manager.policy.UserNotificationPolicyManager
+import com.x8bit.bitwarden.data.platform.manager.policy.UserNotificationPolicyManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.restriction.RestrictionManager
 import com.x8bit.bitwarden.data.platform.manager.restriction.RestrictionManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.sdk.SdkPlatformApiFactory
@@ -291,6 +293,20 @@ object PlatformManagerModule {
         authDiskSource = authDiskSource,
         authSdkSource = authSdkSource,
         policyManager = policyManager,
+    )
+
+    @Provides
+    @Singleton
+    fun provideUserNotificationPolicyManager(
+        authDiskSource: AuthDiskSource,
+        settingsDiskSource: SettingsDiskSource,
+        policyManager: PolicyManager,
+        dispatcherManager: DispatcherManager,
+    ): UserNotificationPolicyManager = UserNotificationPolicyManagerImpl(
+        authDiskSource = authDiskSource,
+        settingsDiskSource = settingsDiskSource,
+        policyManager = policyManager,
+        dispatcherManager = dispatcherManager,
     )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEvent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEvent.kt
@@ -141,4 +141,15 @@ sealed class OrganizationEvent {
         override val type: OrganizationEventType
             get() = OrganizationEventType.ORGANIZATION_ITEM_ORGANIZATION_ACCEPTED
     }
+
+    /**
+     * Tracks when user's notification banner has the action button clicked.
+     */
+    data class OrganizationUserNotificationBannerActionClicked(
+        override val organizationId: String,
+    ) : OrganizationEvent() {
+        override val cipherId: String? = null
+        override val type: OrganizationEventType
+            get() = OrganizationEventType.ORGANIZATION_USER_NOTIFICATION_BANNER_ACTION_CLICKED
+    }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/UserNotificationPolicyManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/UserNotificationPolicyManager.kt
@@ -1,0 +1,33 @@
+package com.x8bit.bitwarden.data.platform.manager.policy
+
+import com.x8bit.bitwarden.data.platform.manager.policy.model.UserNotificationPolicyData
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Manages the organization user notification policy, exposing the data required to display the
+ * notification banner on the vault screen and tracking whether the active user has dismissed it.
+ */
+interface UserNotificationPolicyManager {
+    /**
+     * The data required to display the notification banner for the active user, or `null` if there
+     * is no active policy or the active user has already dismissed the banner.
+     */
+    val displayData: UserNotificationPolicyData?
+
+    /**
+     * Emits updates that track [displayData].
+     */
+    val displayDataFlow: StateFlow<UserNotificationPolicyData?>
+
+    /**
+     * Marks the notification banner as dismissed for the active user, preventing it from being
+     * displayed again.
+     */
+    fun dismissBanner()
+
+    /**
+     * Indicates whether the dismissed state of the banner should be cleared when the user
+     * is soft-logged out. When `true` the banner is displayed again after the next login.
+     */
+    fun shouldClearOnSoftLogout(userId: String): Boolean
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/UserNotificationPolicyManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/UserNotificationPolicyManagerImpl.kt
@@ -1,0 +1,109 @@
+package com.x8bit.bitwarden.data.platform.manager.policy
+
+import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
+import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
+import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.policy.model.UserNotificationPolicyData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The default implementation of the [UserNotificationPolicyManager].
+ */
+internal class UserNotificationPolicyManagerImpl(
+    private val authDiskSource: AuthDiskSource,
+    private val settingsDiskSource: SettingsDiskSource,
+    private val policyManager: PolicyManager,
+    dispatcherManager: DispatcherManager,
+) : UserNotificationPolicyManager {
+    private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
+    private val activeUserId: String? get() = authDiskSource.userState?.activeUserId
+
+    override val displayData: UserNotificationPolicyData?
+        get() = activeUserId?.let { userId ->
+            policyManager
+                .getActivePolicies(type = PolicyType.ORGANIZATION_USER_NOTIFICATION)
+                .firstOrNull()
+                ?.let { policy ->
+                    val revisionDate = settingsDiskSource
+                        .getVaultPolicyBannerDismissedDate(userId = userId)
+                    policy.userNotificationPolicyData?.takeIf {
+                        policy.revisionDate?.toEpochMilli() != revisionDate?.toEpochMilli() ||
+                            revisionDate == null
+                    }
+                }
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override val displayDataFlow: StateFlow<UserNotificationPolicyData?>
+        get() = authDiskSource
+            .activeUserIdChangesFlow
+            .flatMapLatest { userId ->
+                userId ?: return@flatMapLatest flowOf(null)
+                combine(
+                    settingsDiskSource.getVaultPolicyBannerDismissedDateFlow(userId = userId),
+                    policyManager
+                        .getActivePoliciesFlow(type = PolicyType.ORGANIZATION_USER_NOTIFICATION)
+                        .map { it.firstOrNull() },
+                ) { revisionDate, policy ->
+                    (policy?.userNotificationPolicyData)?.takeIf {
+                        policy.revisionDate?.toEpochMilli() != revisionDate?.toEpochMilli() ||
+                            revisionDate == null
+                    }
+                }
+            }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Lazily,
+                initialValue = displayData,
+            )
+
+    override fun dismissBanner() {
+        policyManager
+            .getActivePolicies(type = PolicyType.ORGANIZATION_USER_NOTIFICATION)
+            .firstOrNull()
+            ?.let { dismissBanner(policy = it) }
+    }
+
+    override fun shouldClearOnSoftLogout(
+        userId: String,
+    ): Boolean =
+        policyManager
+            .getUserPolicies(userId = userId, type = PolicyType.ORGANIZATION_USER_NOTIFICATION)
+            .firstNotNullOfOrNull {
+                it.policyInformation as? PolicyInformation.OrganizationUserNotification
+            }
+            ?.showAfterEveryLogin != false
+
+    private fun dismissBanner(policy: PolicyView) {
+        activeUserId?.let { userId ->
+            settingsDiskSource.storeVaultPolicyBannerDismissedDate(
+                userId = userId,
+                dismissalRevisionDate = policy.revisionDate,
+            )
+        }
+    }
+}
+
+private val PolicyView.userNotificationPolicyData: UserNotificationPolicyData?
+    get() = (this.policyInformation as? PolicyInformation.OrganizationUserNotification)?.let {
+        UserNotificationPolicyData(
+            organizationId = this.organizationId,
+            headerText = it.headerText,
+            descriptionText = it.descriptionText,
+            buttonText = it.buttonText,
+        )
+    }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/model/UserNotificationPolicyData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/model/UserNotificationPolicyData.kt
@@ -1,0 +1,12 @@
+package com.x8bit.bitwarden.data.platform.manager.policy.model
+
+/**
+ * Models all the relevant information required to display a Notification from an organization
+ * policy.
+ */
+data class UserNotificationPolicyData(
+    val organizationId: String,
+    val headerText: String?,
+    val descriptionText: String,
+    val buttonText: String?,
+)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/util/PolicyManagerExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/util/PolicyManagerExtensions.kt
@@ -36,6 +36,9 @@ inline fun <reified T : PolicyInformation> getPolicyType(): PolicyType =
         PolicyInformation.SendOptions::class.java -> PolicyType.SEND_OPTIONS
         PolicyInformation.SendControls::class.java -> PolicyType.SEND_CONTROLS
         PolicyInformation.VaultTimeout::class.java -> PolicyType.MAXIMUM_VAULT_TIMEOUT
+        PolicyInformation.OrganizationUserNotification::class.java -> {
+            PolicyType.ORGANIZATION_USER_NOTIFICATION
+        }
 
         else -> {
             throw IllegalStateException(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultActionCard.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultActionCard.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.card.BitwardenActionCard
+import com.bitwarden.ui.platform.components.icon.BitwardenIcon
+import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -108,6 +110,28 @@ fun VaultActionCard(
                     onClick = { vaultHandlers.actionCardClick(actionCardState) },
                 ),
                 onDismissClick = { vaultHandlers.dismissActionCardClick(actionCardState) },
+                modifier = modifier,
+            )
+        }
+
+        is VaultState.ActionCardState.VaultPolicyBanner -> {
+            BitwardenActionCard(
+                cardTitle = actionCardState.title?.invoke(),
+                cardSubtitle = actionCardState.message(),
+                actionButton = actionCardState.button?.let {
+                    BitwardenButtonData(
+                        label = it,
+                        onClick = { vaultHandlers.actionCardClick(actionCardState) },
+                    )
+                },
+                onDismissClick = { vaultHandlers.dismissActionCardClick(actionCardState) }
+                    .takeIf { actionCardState.button == null },
+                leadingContent = {
+                    BitwardenIcon(
+                        iconData = IconData.Local(iconRes = BitwardenDrawable.ic_info_circle),
+                        tint = BitwardenTheme.colorScheme.icon.secondary,
+                    )
+                },
                 modifier = modifier,
             )
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -48,6 +48,8 @@ import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
+import com.x8bit.bitwarden.data.platform.manager.policy.UserNotificationPolicyManager
+import com.x8bit.bitwarden.data.platform.manager.policy.model.UserNotificationPolicyData
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.util.userFriendlyMessage
@@ -61,6 +63,7 @@ import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import com.x8bit.bitwarden.ui.vault.components.model.CreateVaultItemType
 import com.x8bit.bitwarden.ui.vault.components.util.toVaultItemCipherTypeOrNull
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
+import com.x8bit.bitwarden.ui.vault.feature.vault.VaultState.PolicyBanner
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterData
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.toAccountSummaries
@@ -121,6 +124,7 @@ class VaultViewModel @Inject constructor(
     private val networkConnectionManager: NetworkConnectionManager,
     private val browserAutofillDialogManager: BrowserAutofillDialogManager,
     private val credentialExchangeRegistryManager: CredentialExchangeRegistryManager,
+    private val userNotificationPolicyManager: UserNotificationPolicyManager,
     buildInfoManager: BuildInfoManager,
     featureFlagManager: FeatureFlagManager,
     snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
@@ -165,6 +169,14 @@ class VaultViewModel @Inject constructor(
                 .getIntroducingArchiveActionCardDismissedFlow()
                 .value,
             validTotpIds = persistentSetOf(),
+            policyBanner = userNotificationPolicyManager.displayData?.let {
+                PolicyBanner(
+                    organizationId = it.organizationId,
+                    header = it.headerText?.asText(),
+                    message = it.descriptionText.asText(),
+                    buttonText = it.buttonText?.asText(),
+                )
+            },
         )
     },
 ) {
@@ -265,6 +277,12 @@ class VaultViewModel @Inject constructor(
         settingsRepository
             .getIntroducingArchiveActionCardDismissedFlow()
             .map { VaultAction.Internal.IntroducingArchiveActionCardDismissedFlowReceive(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
+        userNotificationPolicyManager
+            .displayDataFlow
+            .map { VaultAction.Internal.UserNotificationPolicyReceive(policyInfo = it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -463,11 +481,15 @@ class VaultViewModel @Inject constructor(
                 if (!state.showImportActionCard) return
                 firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
             }
+
+            is VaultState.ActionCardState.VaultPolicyBanner -> {
+                userNotificationPolicyManager.dismissBanner()
+            }
         }
     }
 
     private fun handleActionCardClick(action: VaultAction.ActionCardClick) {
-        when (action.actionCard) {
+        when (val actionCard = action.actionCard) {
             VaultState.ActionCardState.UpgradedToPremium -> {
                 premiumStateManager.dismissUpgradedToPremiumCard()
                 sendEvent(VaultEvent.NavigateToUrl(url = UPGRADED_TO_PREMIUM_LEARN_MORE_URL))
@@ -488,6 +510,15 @@ class VaultViewModel @Inject constructor(
 
             VaultState.ActionCardState.ImportItems -> {
                 sendEvent(VaultEvent.NavigateToImportLogins)
+            }
+
+            is VaultState.ActionCardState.VaultPolicyBanner -> {
+                organizationEventManager.trackEvent(
+                    event = OrganizationEvent.OrganizationUserNotificationBannerActionClicked(
+                        organizationId = actionCard.organizationId,
+                    ),
+                )
+                userNotificationPolicyManager.dismissBanner()
             }
         }
     }
@@ -1087,6 +1118,7 @@ class VaultViewModel @Inject constructor(
         }
     }
 
+    @Suppress("LongMethod")
     private fun handleInternalAction(action: VaultAction.Internal) {
         when (action) {
             is VaultAction.Internal.GenerateTotpResultReceive -> {
@@ -1157,6 +1189,10 @@ class VaultViewModel @Inject constructor(
 
             is VaultAction.Internal.UpgradedToPremiumCardEligibilityReceive -> {
                 handleUpgradedToPremiumCardEligibilityReceive(action)
+            }
+
+            is VaultAction.Internal.UserNotificationPolicyReceive -> {
+                handleUserNotificationPolicyReceive(action)
             }
         }
     }
@@ -1312,6 +1348,23 @@ class VaultViewModel @Inject constructor(
     ) {
         mutableStateFlow.update {
             it.copy(isUpgradedToPremiumCardEligible = action.isEligible)
+        }
+    }
+
+    private fun handleUserNotificationPolicyReceive(
+        action: VaultAction.Internal.UserNotificationPolicyReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(
+                policyBanner = action.policyInfo?.let { policy ->
+                    PolicyBanner(
+                        organizationId = policy.organizationId,
+                        header = policy.headerText?.asText(),
+                        message = policy.descriptionText.asText(),
+                        buttonText = policy.buttonText?.asText(),
+                    )
+                },
+            )
         }
     }
 
@@ -1805,6 +1858,7 @@ data class VaultState(
     val validTotpIds: ImmutableSet<String>,
     val isNewItemTypesEnabled: Boolean = false,
     val isVfo1FoundationEnabled: Boolean = false,
+    val policyBanner: PolicyBanner?,
 ) : Parcelable {
 
     /**
@@ -1813,8 +1867,17 @@ data class VaultState(
     val actionCard: ActionCardState?
         get() = when (viewState) {
             is ViewState.Content -> {
-                ActionCardState.UpgradedToPremium
-                    .takeIf { isUpgradedToPremiumCardEligible }
+                policyBanner
+                    ?.let {
+                        ActionCardState.VaultPolicyBanner(
+                            organizationId = it.organizationId,
+                            title = it.header,
+                            message = it.message,
+                            button = it.buttonText,
+                        )
+                    }
+                    ?: ActionCardState.UpgradedToPremium
+                        .takeIf { isUpgradedToPremiumCardEligible }
                     ?: ActionCardState.UpgradePremium.takeIf { premiumCard == PremiumCard.UPGRADE }
                     ?: ActionCardState.PremiumNeedsAttention.takeIf {
                         premiumCard == PremiumCard.NEEDS_ATTENTION
@@ -1825,7 +1888,16 @@ data class VaultState(
             }
 
             ViewState.NoItems -> {
-                ActionCardState.UpgradePremium.takeIf { premiumCard == PremiumCard.UPGRADE }
+                policyBanner
+                    ?.let {
+                        ActionCardState.VaultPolicyBanner(
+                            organizationId = it.organizationId,
+                            title = it.header,
+                            message = it.message,
+                            button = it.buttonText,
+                        )
+                    }
+                    ?: ActionCardState.UpgradePremium.takeIf { premiumCard == PremiumCard.UPGRADE }
                     ?: ActionCardState.PremiumNeedsAttention.takeIf {
                         premiumCard == PremiumCard.NEEDS_ATTENTION
                     }
@@ -2228,6 +2300,16 @@ data class VaultState(
      */
     sealed class ActionCardState {
         /**
+         * Indicates that the user has a Vault Policy Banner that need to be displayed.
+         */
+        data class VaultPolicyBanner(
+            val organizationId: String,
+            val title: Text?,
+            val message: Text,
+            val button: Text?,
+        ) : ActionCardState()
+
+        /**
          * Indicates that the user has been upgraded to Premium and should be congratulated with
          * a link to learn more about Premium features.
          */
@@ -2340,6 +2422,17 @@ data class VaultState(
             val message: Text,
         ) : DialogState()
     }
+
+    /**
+     * Represents a policy banner action card with the given [header], [message], and [buttonText].
+     */
+    @Parcelize
+    data class PolicyBanner(
+        val organizationId: String,
+        val header: Text?,
+        val message: Text,
+        val buttonText: Text?,
+    ) : Parcelable
 }
 
 /**
@@ -2698,6 +2791,13 @@ sealed class VaultAction {
      * Models actions that the [VaultViewModel] itself might send.
      */
     sealed class Internal : VaultAction() {
+
+        /**
+         * Indicates that the user notification policy has changed.
+         */
+        data class UserNotificationPolicyReceive(
+            val policyInfo: UserNotificationPolicyData?,
+        ) : Internal()
 
         /**
          * Indicates that the icon loading setting has been changed.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
@@ -14,6 +14,7 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.CredentialExchangeRegistryManager
 import com.x8bit.bitwarden.data.platform.manager.model.UnregisterExportResult
+import com.x8bit.bitwarden.data.platform.manager.policy.UserNotificationPolicyManager
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.GeneratorDiskSource
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.PasswordHistoryDiskSource
@@ -44,6 +45,10 @@ class UserLogoutManagerTest {
         every { storeVaultTimeoutInMinutes(any(), any()) } just runs
         every { storeVaultTimeoutAction(any(), any()) } just runs
         every { storeAppRegisteredForExport(any()) } just runs
+        every { getVaultPolicyBannerDismissedDate(userId = any()) } returns null
+        every {
+            storeVaultPolicyBannerDismissedDate(userId = any(), dismissalRevisionDate = any())
+        } just runs
     }
     private val pushDiskSource: PushDiskSource = mockk {
         coEvery { clearData(any()) } just runs
@@ -63,6 +68,9 @@ class UserLogoutManagerTest {
     private val credentialExchangeRegistryManager: CredentialExchangeRegistryManager = mockk {
         coEvery { unregister() } returns UnregisterExportResult.Success
     }
+    private val userNotificationPolicyManager: UserNotificationPolicyManager = mockk {
+        every { shouldClearOnSoftLogout(userId = any()) } returns true
+    }
 
     private val userLogoutManager: UserLogoutManager =
         UserLogoutManagerImpl(
@@ -76,6 +84,7 @@ class UserLogoutManagerTest {
             vaultSdkSource = vaultSdkSource,
             dispatcherManager = FakeDispatcherManager(),
             credentialExchangeRegistryManager = credentialExchangeRegistryManager,
+            userNotificationPolicyManager = userNotificationPolicyManager,
         )
 
     @Suppress("MaxLineLength")
@@ -290,6 +299,125 @@ class UserLogoutManagerTest {
         }
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `softLogout when shouldClearOnSoftLogout is true should not restore the vault policy banner dismissed date`() {
+        val userId = USER_ID_1
+        setupSoftLogoutStubs(userId = userId)
+        every {
+            userNotificationPolicyManager.shouldClearOnSoftLogout(userId = userId)
+        } returns true
+        every {
+            settingsDiskSource.getVaultPolicyBannerDismissedDate(userId = userId)
+        } returns DISMISSAL_REVISION_DATE
+
+        userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
+
+        assertDataCleared(userId = userId)
+        verify(exactly = 0) {
+            settingsDiskSource.storeVaultPolicyBannerDismissedDate(
+                userId = any(),
+                dismissalRevisionDate = any(),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `softLogout when shouldClearOnSoftLogout is false should restore the vault policy banner dismissed date`() {
+        val userId = USER_ID_1
+        setupSoftLogoutStubs(userId = userId)
+        every {
+            userNotificationPolicyManager.shouldClearOnSoftLogout(userId = userId)
+        } returns false
+        every {
+            settingsDiskSource.getVaultPolicyBannerDismissedDate(userId = userId)
+        } returns DISMISSAL_REVISION_DATE
+
+        userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
+
+        assertDataCleared(userId = userId)
+        verify(exactly = 1) {
+            userNotificationPolicyManager.shouldClearOnSoftLogout(userId = userId)
+            settingsDiskSource.storeVaultPolicyBannerDismissedDate(
+                userId = userId,
+                dismissalRevisionDate = DISMISSAL_REVISION_DATE,
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `softLogout when shouldClearOnSoftLogout is false and there is no dismissed date should restore a null vault policy banner dismissed date`() {
+        val userId = USER_ID_1
+        setupSoftLogoutStubs(userId = userId)
+        every {
+            userNotificationPolicyManager.shouldClearOnSoftLogout(userId = userId)
+        } returns false
+        every { settingsDiskSource.getVaultPolicyBannerDismissedDate(userId = userId) } returns null
+
+        userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
+
+        assertDataCleared(userId = userId)
+        verify(exactly = 1) {
+            settingsDiskSource.storeVaultPolicyBannerDismissedDate(
+                userId = userId,
+                dismissalRevisionDate = null,
+            )
+        }
+    }
+
+    @Test
+    fun `logout should not restore the vault policy banner dismissed date`() {
+        val userId = USER_ID_1
+        every { authDiskSource.userState } returns SINGLE_USER_STATE_1
+
+        userLogoutManager.logout(userId = userId, reason = LogoutReason.Timeout)
+
+        assertDataCleared(userId = userId)
+        verify(exactly = 0) {
+            userNotificationPolicyManager.shouldClearOnSoftLogout(userId = any())
+            settingsDiskSource.getVaultPolicyBannerDismissedDate(userId = any())
+            settingsDiskSource.storeVaultPolicyBannerDismissedDate(
+                userId = any(),
+                dismissalRevisionDate = any(),
+            )
+        }
+    }
+
+    private fun setupSoftLogoutStubs(userId: String) {
+        every { settingsDiskSource.getVaultTimeoutInMinutes(userId = userId) } returns 360
+        every {
+            settingsDiskSource.getVaultTimeoutAction(userId = userId)
+        } returns VaultTimeoutAction.LOGOUT
+        every { authDiskSource.getEncryptedPin(userId = userId) } returns "encryptedPin"
+        every {
+            authDiskSource.getPinProtectedUserKey(userId = userId)
+        } returns "pinProtectedUserKey"
+        every {
+            authDiskSource.getEphemeralPinProtectedUserKeyEnvelope(userId = userId)
+        } returns "pinProtectedUserKeyEnvelope"
+        every {
+            authDiskSource.getPersistentPinProtectedUserKeyEnvelope(userId = userId)
+        } returns "pinProtectedUserKeyEnvelope"
+        every { authDiskSource.storeEncryptedPin(userId = userId, encryptedPin = any()) } just runs
+        every {
+            authDiskSource.storePinProtectedUserKey(userId = userId, pinProtectedUserKey = any())
+        } just runs
+        every {
+            authDiskSource.storeEphemeralPinProtectedUserKeyEnvelope(
+                userId = userId,
+                pinProtectedUserKeyEnvelope = any(),
+            )
+        } just runs
+        every {
+            authDiskSource.storePersistentPinProtectedUserKeyEnvelope(
+                userId = userId,
+                pinProtectedUserKeyEnvelope = any(),
+            )
+        } just runs
+    }
+
     private fun assertDataCleared(userId: String) {
         verify { vaultSdkSource.clearCrypto(userId = userId) }
         verify { authDiskSource.clearData(userId = userId) }
@@ -303,6 +431,7 @@ class UserLogoutManagerTest {
     }
 }
 
+private val DISMISSAL_REVISION_DATE: Instant = Instant.parse("2024-09-13T01:00:00.00Z")
 private const val EMAIL_2 = "test2@bitwarden.com"
 private const val ACCESS_TOKEN = "accessToken"
 private const val ACCESS_TOKEN_2 = "accessToken2"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensionsTest.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.auth.repository.util
 
 import com.bitwarden.network.model.OrganizationType
-import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.network.model.SendAccessTypeJson
+import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.createMockOrganizationNetwork
 import com.bitwarden.network.model.createMockPermissions
@@ -186,6 +186,26 @@ class SyncResponseJsonExtensionsTest {
         )
         val policy = createMockPolicyView(
             type = PolicyType.SEND_CONTROLS,
+            data = Json.encodeToString(policyInformation),
+        )
+
+        assertEquals(
+            policyInformation,
+            policy.policyInformation,
+        )
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `policyInformation converts the OrganizationUserNotification Json data to policy information`() {
+        val policyInformation = PolicyInformation.OrganizationUserNotification(
+            headerText = "headerText",
+            descriptionText = "descriptionText",
+            buttonText = "buttonText",
+            showAfterEveryLogin = true,
+        )
+        val policy = createMockPolicyView(
+            type = PolicyType.ORGANIZATION_USER_NOTIFICATION,
             data = Json.encodeToString(policyInformation),
         )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -146,6 +146,10 @@ class SettingsDiskSourceTest {
             userId = userId,
             isDismissed = true,
         )
+        settingsDiskSource.storeVaultPolicyBannerDismissedDate(
+            userId = userId,
+            dismissalRevisionDate = Instant.parse("2023-10-27T12:00:00Z"),
+        )
         settingsDiskSource.storeUpgradedToPremiumCardConsumed(
             userId = userId,
             isConsumed = true,
@@ -221,6 +225,7 @@ class SettingsDiskSourceTest {
                 systemBioIntegrityState = systemBioIntegrityState,
             ),
         )
+        assertNull(settingsDiskSource.getVaultPolicyBannerDismissedDate(userId = userId))
     }
 
     @Suppress("MaxLineLength")
@@ -947,6 +952,67 @@ class SettingsDiskSourceTest {
                         isDismissed = true,
                     )
                     assertEquals(true, awaitItem())
+                }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getVaultPolicyBannerDismissedDate when values are present should pull from SharedPreferences`() {
+        val baseKey = "bwPreferencesStorage:vaultPolicyBannerDismissedDate"
+        val mockUserId = "mockUserId"
+        val key = "${baseKey}_$mockUserId"
+        val instantLong = 1_698_408_000_000L
+        val instant = Instant.ofEpochMilli(instantLong)
+        assertNull(settingsDiskSource.getVaultPolicyBannerDismissedDate(userId = mockUserId))
+        fakeSharedPreferences.edit { putLong(key, instantLong) }
+        assertEquals(
+            instant,
+            settingsDiskSource.getVaultPolicyBannerDismissedDate(userId = mockUserId),
+        )
+    }
+
+    @Test
+    fun `storeVaultPolicyBannerDismissedDate should update SharedPreferences`() {
+        val baseKey = "bwPreferencesStorage:vaultPolicyBannerDismissedDate"
+        val mockUserId = "mockUserId"
+        val key = "${baseKey}_$mockUserId"
+        val instantLong = 1_698_408_000_000L
+        val instant = Instant.ofEpochMilli(instantLong)
+        settingsDiskSource.storeVaultPolicyBannerDismissedDate(
+            userId = mockUserId,
+            dismissalRevisionDate = instant,
+        )
+        assertEquals(instantLong, fakeSharedPreferences.getLong(key, 0L))
+
+        // A null value clears the stored key
+        settingsDiskSource.storeVaultPolicyBannerDismissedDate(
+            userId = mockUserId,
+            dismissalRevisionDate = null,
+        )
+        assertFalse(fakeSharedPreferences.contains(key))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getVaultPolicyBannerDismissedDateFlow should react to changes in storeVaultPolicyBannerDismissed`() =
+        runTest {
+            val mockUserId = "mockUserId"
+            val instant = Instant.ofEpochMilli(1_698_408_000_000L)
+            settingsDiskSource
+                .getVaultPolicyBannerDismissedDateFlow(userId = mockUserId)
+                .test {
+                    // The initial values of the Flow and the property are in sync
+                    assertNull(
+                        settingsDiskSource.getVaultPolicyBannerDismissedDate(userId = mockUserId),
+                    )
+                    assertNull(awaitItem())
+
+                    // Updating the disk source updates shared preferences
+                    settingsDiskSource.storeVaultPolicyBannerDismissedDate(
+                        userId = mockUserId,
+                        dismissalRevisionDate = instant,
+                    )
+                    assertEquals(instant, awaitItem())
                 }
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -71,6 +71,7 @@ class FakeSettingsDiskSource(
     private val storedPullToRefreshEnabled = mutableMapOf<String, Boolean?>()
     private var storedIntroducingArchiveActionCardDismissed = mutableMapOf<String, Boolean?>()
     private var storedPremiumUpgradeBannerDismissed = mutableMapOf<String, Boolean?>()
+    private val storedVaultPolicyBannerDismissedDate = mutableMapOf<String, Instant?>()
     private val storedUpgradedToPremiumCardConsumed = mutableMapOf<String, Boolean?>()
     private val storedUpgradedToPremiumCardPending = mutableMapOf<String, Boolean?>()
     private val storedPremiumUpgradePending = mutableMapOf<String, Boolean?>()
@@ -125,6 +126,9 @@ class FakeSettingsDiskSource(
 
     private val mutablePremiumUpgradeBannerDismissedFlow =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutableVaultPolicyBannerDismissedFlow =
+        mutableMapOf<String, MutableSharedFlow<Instant?>>()
 
     private val mutableUpgradedToPremiumCardConsumedFlow =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -269,6 +273,7 @@ class FakeSettingsDiskSource(
         storedFillAssistEnabled.remove(userId)
         storedBlockedAutofillUris.remove(userId)
         storedClearClipboardFrequency.remove(userId)
+        storedVaultPolicyBannerDismissedDate.remove(userId)
 
         mutableVaultTimeoutActionsFlowMap.remove(userId)
         mutableVaultTimeoutInMinutesFlowMap.remove(userId)
@@ -387,6 +392,23 @@ class FakeSettingsDiskSource(
     override fun storePremiumUpgradeBannerDismissed(userId: String, isDismissed: Boolean?) {
         storedPremiumUpgradeBannerDismissed[userId] = isDismissed
         getMutablePremiumUpgradeBannerDismissedFlow(userId = userId).tryEmit(isDismissed)
+    }
+
+    override fun getVaultPolicyBannerDismissedDate(
+        userId: String,
+    ): Instant? = storedVaultPolicyBannerDismissedDate[userId]
+
+    override fun getVaultPolicyBannerDismissedDateFlow(
+        userId: String,
+    ): Flow<Instant?> = getMutableVaultPolicyBannerDismissedFlow(userId = userId)
+        .onSubscription { emit(getVaultPolicyBannerDismissedDate(userId = userId)) }
+
+    override fun storeVaultPolicyBannerDismissedDate(
+        userId: String,
+        dismissalRevisionDate: Instant?,
+    ) {
+        storedVaultPolicyBannerDismissedDate[userId] = dismissalRevisionDate
+        getMutableVaultPolicyBannerDismissedFlow(userId = userId).tryEmit(dismissalRevisionDate)
     }
 
     override fun getUpgradedToPremiumCardConsumed(userId: String): Boolean? =
@@ -602,6 +624,13 @@ class FakeSettingsDiskSource(
     }
 
     /**
+     * Asserts that the stored vault policy banner dismissed value matches the [expected] one.
+     */
+    fun assertVaultPolicyBannerDismissedDate(userId: String, expected: Instant?) {
+        assertEquals(expected, storedVaultPolicyBannerDismissedDate[userId])
+    }
+
+    /**
      * Asserts that the stored "Upgraded to Premium" card consumed value matches the [expected] one.
      */
     fun assertUpgradedToPremiumCardConsumed(userId: String, expected: Boolean?) {
@@ -697,6 +726,13 @@ class FakeSettingsDiskSource(
         userId: String,
     ): MutableSharedFlow<Boolean?> =
         mutablePremiumUpgradeBannerDismissedFlow.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutableVaultPolicyBannerDismissedFlow(
+        userId: String,
+    ): MutableSharedFlow<Instant?> =
+        mutableVaultPolicyBannerDismissedFlow.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/UserNotificationPolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/policy/UserNotificationPolicyManagerTest.kt
@@ -1,0 +1,417 @@
+package com.x8bit.bitwarden.data.platform.manager.policy
+
+import app.cash.turbine.test
+import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
+import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
+import com.bitwarden.network.model.KdfTypeJson
+import com.bitwarden.policies.PolicyType
+import com.bitwarden.policies.PolicyView
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.policy.model.UserNotificationPolicyData
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPolicyView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class UserNotificationPolicyManagerTest {
+
+    private val fakeAuthDiskSource = FakeAuthDiskSource()
+    private val fakeSettingsDiskSource = FakeSettingsDiskSource()
+    private val mutablePoliciesFlow = MutableStateFlow(emptyList<PolicyView>())
+    private val userPolicies = mutableMapOf<String, List<PolicyView>>()
+    private val policyManager: PolicyManager = mockk {
+        every {
+            getActivePolicies(type = PolicyType.ORGANIZATION_USER_NOTIFICATION)
+        } answers { mutablePoliciesFlow.value }
+        every {
+            getActivePoliciesFlow(type = PolicyType.ORGANIZATION_USER_NOTIFICATION)
+        } returns mutablePoliciesFlow
+        every {
+            getUserPolicies(userId = any(), type = PolicyType.ORGANIZATION_USER_NOTIFICATION)
+        } answers { userPolicies[firstArg<String>()].orEmpty() }
+    }
+
+    private val userNotificationPolicyManager: UserNotificationPolicyManager =
+        UserNotificationPolicyManagerImpl(
+            authDiskSource = fakeAuthDiskSource,
+            settingsDiskSource = fakeSettingsDiskSource,
+            policyManager = policyManager,
+            dispatcherManager = FakeDispatcherManager(),
+        )
+
+    @Test
+    fun `shouldClearOnSoftLogout should return true when the user has no policies`() {
+        assertTrue(userNotificationPolicyManager.shouldClearOnSoftLogout(userId = USER_ID_1))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `shouldClearOnSoftLogout should return true when the user policy shows after every login`() {
+        setUserPolicies(
+            userId = USER_ID_1,
+            createPolicy(data = createPolicyJson(showAfterEveryLogin = true)),
+        )
+
+        assertTrue(userNotificationPolicyManager.shouldClearOnSoftLogout(userId = USER_ID_1))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `shouldClearOnSoftLogout should return false when the user policy does not show after every login`() {
+        setUserPolicies(
+            userId = USER_ID_1,
+            createPolicy(data = createPolicyJson(showAfterEveryLogin = false)),
+        )
+
+        assertFalse(userNotificationPolicyManager.shouldClearOnSoftLogout(userId = USER_ID_1))
+    }
+
+    @Test
+    fun `shouldClearOnSoftLogout should return true when the user policy has no data`() {
+        setUserPolicies(userId = USER_ID_1, createPolicy(data = null))
+
+        assertTrue(userNotificationPolicyManager.shouldClearOnSoftLogout(userId = USER_ID_1))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `shouldClearOnSoftLogout should use the first user policy that has data`() {
+        setUserPolicies(
+            userId = USER_ID_1,
+            createPolicy(number = 1, data = null),
+            createPolicy(number = 2, data = createPolicyJson(showAfterEveryLogin = false)),
+        )
+
+        assertFalse(userNotificationPolicyManager.shouldClearOnSoftLogout(userId = USER_ID_1))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `shouldClearOnSoftLogout should use the policies of the given user instead of the active user`() {
+        fakeAuthDiskSource.userState = MULTI_USER_STATE_ACTIVE_USER_2
+        setUserPolicies(
+            userId = USER_ID_1,
+            createPolicy(data = createPolicyJson(showAfterEveryLogin = false)),
+        )
+        setUserPolicies(
+            userId = USER_ID_2,
+            createPolicy(data = createPolicyJson(showAfterEveryLogin = true)),
+        )
+
+        assertFalse(userNotificationPolicyManager.shouldClearOnSoftLogout(userId = USER_ID_1))
+        assertTrue(userNotificationPolicyManager.shouldClearOnSoftLogout(userId = USER_ID_2))
+        verify(exactly = 0) {
+            policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_USER_NOTIFICATION)
+        }
+    }
+
+    @Test
+    fun `displayData should return null when there is no active user`() {
+        setPolicies(createPolicy())
+
+        assertNull(userNotificationPolicyManager.displayData)
+        verify(exactly = 0) {
+            policyManager.getActivePolicies(type = PolicyType.ORGANIZATION_USER_NOTIFICATION)
+        }
+    }
+
+    @Test
+    fun `displayData should return null when there are no active policies`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+
+        assertNull(userNotificationPolicyManager.displayData)
+    }
+
+    @Test
+    fun `displayData should return null when the active policy has no data`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+        setPolicies(createPolicy(data = null))
+
+        assertNull(userNotificationPolicyManager.displayData)
+    }
+
+    @Test
+    fun `displayData should return the policy data when the banner has not been dismissed`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+        setPolicies(createPolicy())
+
+        assertEquals(EXPECTED_DISPLAY_DATA, userNotificationPolicyManager.displayData)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `displayData should return null when the banner has been dismissed for the policy revision date`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+        fakeSettingsDiskSource.storeVaultPolicyBannerDismissedDate(
+            userId = USER_ID_1,
+            dismissalRevisionDate = REVISION_DATE,
+        )
+        setPolicies(createPolicy(revisionDate = REVISION_DATE))
+
+        assertNull(userNotificationPolicyManager.displayData)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `displayData should return the policy data when the policy revision date differs from the dismissed date`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+        fakeSettingsDiskSource.storeVaultPolicyBannerDismissedDate(
+            userId = USER_ID_1,
+            dismissalRevisionDate = REVISION_DATE,
+        )
+        setPolicies(createPolicy(revisionDate = OTHER_REVISION_DATE))
+
+        assertEquals(EXPECTED_DISPLAY_DATA, userNotificationPolicyManager.displayData)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `displayData should return the policy data when the policy has no revision date and the banner has been dismissed`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+        fakeSettingsDiskSource.storeVaultPolicyBannerDismissedDate(
+            userId = USER_ID_1,
+            dismissalRevisionDate = REVISION_DATE,
+        )
+        setPolicies(createPolicy(revisionDate = null))
+
+        assertEquals(EXPECTED_DISPLAY_DATA, userNotificationPolicyManager.displayData)
+    }
+
+    @Test
+    fun `displayData should return the data of the first active policy`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+        setPolicies(
+            createPolicy(number = 1),
+            createPolicy(number = 2, data = createPolicyJson(descriptionText = "otherDescription")),
+        )
+
+        assertEquals(EXPECTED_DISPLAY_DATA, userNotificationPolicyManager.displayData)
+    }
+
+    @Test
+    fun `displayDataFlow should have an initial value matching displayData`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+        setPolicies(createPolicy())
+
+        assertEquals(EXPECTED_DISPLAY_DATA, userNotificationPolicyManager.displayDataFlow.value)
+    }
+
+    @Test
+    fun `displayDataFlow should emit null when there is no active user`() = runTest {
+        setPolicies(createPolicy())
+
+        userNotificationPolicyManager.displayDataFlow.test {
+            assertNull(awaitItem())
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE
+            assertEquals(EXPECTED_DISPLAY_DATA, awaitItem())
+        }
+    }
+
+    @Test
+    fun `displayDataFlow should emit when the active policies change`() = runTest {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+
+        userNotificationPolicyManager.displayDataFlow.test {
+            assertNull(awaitItem())
+            setPolicies(createPolicy())
+            assertEquals(EXPECTED_DISPLAY_DATA, awaitItem())
+            setPolicies()
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `displayDataFlow should emit null when the banner is dismissed`() = runTest {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+        setPolicies(createPolicy(revisionDate = REVISION_DATE))
+
+        userNotificationPolicyManager.displayDataFlow.test {
+            assertEquals(EXPECTED_DISPLAY_DATA, awaitItem())
+            userNotificationPolicyManager.dismissBanner()
+            assertNull(awaitItem())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `displayDataFlow should emit the policy data when the revision date changes after a dismissal`() =
+        runTest {
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE
+            setPolicies(createPolicy(revisionDate = REVISION_DATE))
+
+            userNotificationPolicyManager.displayDataFlow.test {
+                assertEquals(EXPECTED_DISPLAY_DATA, awaitItem())
+                userNotificationPolicyManager.dismissBanner()
+                assertNull(awaitItem())
+                setPolicies(createPolicy(revisionDate = OTHER_REVISION_DATE))
+                assertEquals(EXPECTED_DISPLAY_DATA, awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `displayDataFlow should emit null when switching to a user that has dismissed the banner`() =
+        runTest {
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE
+            fakeSettingsDiskSource.storeVaultPolicyBannerDismissedDate(
+                userId = USER_ID_2,
+                dismissalRevisionDate = REVISION_DATE,
+            )
+            setPolicies(createPolicy(revisionDate = REVISION_DATE))
+
+            userNotificationPolicyManager.displayDataFlow.test {
+                assertEquals(EXPECTED_DISPLAY_DATA, awaitItem())
+                fakeAuthDiskSource.userState = MULTI_USER_STATE_ACTIVE_USER_2
+                assertNull(awaitItem())
+            }
+        }
+
+    @Test
+    fun `dismissBanner should do nothing when there are no active policies`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+
+        userNotificationPolicyManager.dismissBanner()
+
+        fakeSettingsDiskSource.assertVaultPolicyBannerDismissedDate(
+            userId = USER_ID_1,
+            expected = null,
+        )
+    }
+
+    @Test
+    fun `dismissBanner should do nothing when there is no active user`() {
+        setPolicies(createPolicy(revisionDate = REVISION_DATE))
+
+        userNotificationPolicyManager.dismissBanner()
+
+        fakeSettingsDiskSource.assertVaultPolicyBannerDismissedDate(
+            userId = USER_ID_1,
+            expected = null,
+        )
+    }
+
+    @Test
+    fun `dismissBanner should store the revision date of the active policy for the active user`() {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE
+        setPolicies(createPolicy(revisionDate = REVISION_DATE))
+
+        userNotificationPolicyManager.dismissBanner()
+
+        fakeSettingsDiskSource.assertVaultPolicyBannerDismissedDate(
+            userId = USER_ID_1,
+            expected = REVISION_DATE,
+        )
+    }
+
+    /**
+     * Sets the active organization user notification [policies], each of which should be created
+     * via [createPolicy].
+     */
+    private fun setPolicies(vararg policies: PolicyView) {
+        mutablePoliciesFlow.value = policies.toList()
+    }
+
+    /**
+     * Sets the organization user notification [policies] applicable to the given [userId], each of
+     * which should be created via [createPolicy].
+     */
+    private fun setUserPolicies(userId: String, vararg policies: PolicyView) {
+        userPolicies[userId] = policies.toList()
+    }
+}
+
+/**
+ * Creates an active organization user notification [PolicyView].
+ */
+private fun createPolicy(
+    number: Int = 1,
+    data: String? = createPolicyJson(),
+    revisionDate: Instant? = REVISION_DATE,
+): PolicyView = createMockPolicyView(
+    number = number,
+    type = PolicyType.ORGANIZATION_USER_NOTIFICATION,
+    enabled = true,
+    data = data,
+    revisionDate = revisionDate,
+)
+
+/**
+ * Builds the `data` payload of an organization user notification [PolicyView].
+ */
+private fun createPolicyJson(
+    headerText: String? = "mockHeaderText",
+    descriptionText: String = "mockDescriptionText",
+    buttonText: String? = "mockButtonText",
+    showAfterEveryLogin: Boolean = true,
+): String =
+    """
+    {
+      "header":${headerText?.let { "\"$it\"" }},
+      "description":"$descriptionText",
+      "buttonText":${buttonText?.let { "\"$it\"" }},
+      "showAfterEveryLogin":$showAfterEveryLogin
+    }
+    """
+
+private const val USER_ID_1 = "2a135b23-e1fb-42c9-bec3-573857bc8181"
+private const val USER_ID_2 = "b9d32ec0-6497-4582-9798-b350f53bfa02"
+
+private val REVISION_DATE: Instant = Instant.parse("2024-09-13T01:00:00.00Z")
+private val OTHER_REVISION_DATE: Instant = Instant.parse("2025-01-27T12:00:00.00Z")
+
+private val EXPECTED_DISPLAY_DATA = UserNotificationPolicyData(
+    organizationId = "mockOrganizationId-1",
+    headerText = "mockHeaderText",
+    descriptionText = "mockDescriptionText",
+    buttonText = "mockButtonText",
+)
+
+private fun createAccount(userId: String): AccountJson = AccountJson(
+    profile = AccountJson.Profile(
+        userId = userId,
+        email = "test@bitwarden.com",
+        isEmailVerified = true,
+        name = "Bitwarden Tester",
+        hasPremiumPersonally = false,
+        hasPremiumFromOrganization = null,
+        stamp = null,
+        organizationId = null,
+        avatarColorHex = null,
+        forcePasswordResetReason = null,
+        kdfType = KdfTypeJson.ARGON2_ID,
+        kdfIterations = 600000,
+        kdfMemory = 16,
+        kdfParallelism = 4,
+        userDecryptionOptions = null,
+        isTwoFactorEnabled = false,
+        creationDate = Instant.parse("2024-09-13T01:00:00.00Z"),
+    ),
+    settings = AccountJson.Settings(
+        environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+    ),
+)
+
+private val SINGLE_USER_STATE = UserStateJson(
+    activeUserId = USER_ID_1,
+    accounts = mapOf(USER_ID_1 to createAccount(userId = USER_ID_1)),
+)
+
+private val MULTI_USER_STATE_ACTIVE_USER_2 = UserStateJson(
+    activeUserId = USER_ID_2,
+    accounts = mapOf(
+        USER_ID_1 to createAccount(userId = USER_ID_1),
+        USER_ID_2 to createAccount(userId = USER_ID_2),
+    ),
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -2990,6 +2990,7 @@ private val DEFAULT_STATE: VaultState = VaultState(
     restrictItemTypesPolicyOrgIds = emptyList(),
     isIntroducingArchiveActionCardDismissed = false,
     validTotpIds = persistentSetOf(),
+    policyBanner = null,
 )
 
 private val DEFAULT_CONTENT_VIEW_STATE: VaultState.ViewState.Content = VaultState.ViewState.Content(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -46,6 +46,8 @@ import com.x8bit.bitwarden.data.platform.manager.model.RegisterExportResult
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.manager.model.UnregisterExportResult
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
+import com.x8bit.bitwarden.data.platform.manager.policy.UserNotificationPolicyManager
+import com.x8bit.bitwarden.data.platform.manager.policy.model.UserNotificationPolicyData
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockBankAccountView
@@ -233,6 +235,13 @@ class VaultViewModelTest : BaseViewModelTest() {
     private val credentialExchangeRegistryManager: CredentialExchangeRegistryManager = mockk {
         coEvery { register() } returns RegisterExportResult.Success
         coEvery { unregister() } returns UnregisterExportResult.Success
+    }
+    private val mutableUserNotificationPolicyDataFlow =
+        MutableStateFlow<UserNotificationPolicyData?>(null)
+    private val userNotificationPolicyManager: UserNotificationPolicyManager = mockk {
+        every { displayData } returns null
+        every { displayDataFlow } returns mutableUserNotificationPolicyDataFlow
+        every { dismissBanner() } just runs
     }
     private val mutableNewItemTypesFlagFlow = MutableStateFlow(false)
     private val mutableVfo1FoundationFlagFlow = MutableStateFlow(false)
@@ -588,6 +597,128 @@ class VaultViewModelTest : BaseViewModelTest() {
         )
 
         assertNull(state.actionCard)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `initial state should include a policy banner when the user notification policy manager has display data`() {
+        every { userNotificationPolicyManager.displayData } returns USER_NOTIFICATION_POLICY_DATA
+        mutableUserNotificationPolicyDataFlow.value = USER_NOTIFICATION_POLICY_DATA
+
+        val viewModel = createViewModel()
+
+        assertEquals(
+            DEFAULT_STATE.copy(policyBanner = POLICY_BANNER),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `UserNotificationPolicyReceive should update the policy banner in the state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.stateFlow.test {
+            assertEquals(DEFAULT_STATE, awaitItem())
+
+            mutableUserNotificationPolicyDataFlow.value = USER_NOTIFICATION_POLICY_DATA
+            assertEquals(DEFAULT_STATE.copy(policyBanner = POLICY_BANNER), awaitItem())
+
+            mutableUserNotificationPolicyDataFlow.value = null
+            assertEquals(DEFAULT_STATE, awaitItem())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `UserNotificationPolicyReceive should update the policy banner in the state when optional text is null`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_STATE, awaitItem())
+
+                mutableUserNotificationPolicyDataFlow.value = USER_NOTIFICATION_POLICY_DATA.copy(
+                    headerText = null,
+                    buttonText = null,
+                )
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        policyBanner = POLICY_BANNER.copy(header = null, buttonText = null),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `DismissActionCardClick with VaultPolicyBanner should call dismissBanner`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.trySendAction(
+            VaultAction.DismissActionCardClick(VAULT_POLICY_BANNER_ACTION_CARD),
+        )
+
+        verify(exactly = 1) {
+            userNotificationPolicyManager.dismissBanner()
+        }
+        verify(exactly = 0) {
+            organizationEventManager.trackEvent(event = any())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `ActionCardClick with VaultPolicyBanner should track the banner action click and call dismissBanner`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(
+                    VaultAction.ActionCardClick(VAULT_POLICY_BANNER_ACTION_CARD),
+                )
+                expectNoEvents()
+            }
+
+            verify(exactly = 1) {
+                organizationEventManager.trackEvent(
+                    event = OrganizationEvent.OrganizationUserNotificationBannerActionClicked(
+                        organizationId = "mockOrganizationId",
+                    ),
+                )
+                userNotificationPolicyManager.dismissBanner()
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `actionCard should return VaultPolicyBanner when a policy banner is present and content is showing`() {
+        val state = createMockVaultState(viewState = DEFAULT_CONTENT_VIEW_STATE).copy(
+            policyBanner = POLICY_BANNER,
+            isUpgradedToPremiumCardEligible = true,
+            premiumCard = PremiumCard.UPGRADE,
+            showImportActionCard = true,
+        )
+
+        assertEquals(
+            VAULT_POLICY_BANNER_ACTION_CARD,
+            state.actionCard,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `actionCard should return VaultPolicyBanner when a policy banner is present and NoItems is showing`() {
+        val state = createMockVaultState(viewState = VaultState.ViewState.NoItems).copy(
+            policyBanner = POLICY_BANNER,
+            premiumCard = PremiumCard.UPGRADE,
+            showImportActionCard = true,
+        )
+
+        assertEquals(
+            VAULT_POLICY_BANNER_ACTION_CARD,
+            state.actionCard,
+        )
     }
 
     @Test
@@ -4648,6 +4779,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             networkConnectionManager = networkConnectionManager,
             browserAutofillDialogManager = browserAutofillDialogManager,
             credentialExchangeRegistryManager = credentialExchangeRegistryManager,
+            userNotificationPolicyManager = userNotificationPolicyManager,
             buildInfoManager = buildInfoManager,
             featureFlagManager = featureFlagManager,
         )
@@ -4666,6 +4798,29 @@ private val VAULT_FILTER_DATA = VaultFilterData(
         ORGANIZATION_VAULT_FILTER,
     ),
 )
+
+private val USER_NOTIFICATION_POLICY_DATA: UserNotificationPolicyData =
+    UserNotificationPolicyData(
+        organizationId = "mockOrganizationId",
+        headerText = "mockHeaderText",
+        descriptionText = "mockDescriptionText",
+        buttonText = "mockButtonText",
+    )
+
+private val POLICY_BANNER: VaultState.PolicyBanner = VaultState.PolicyBanner(
+    organizationId = "mockOrganizationId",
+    header = "mockHeaderText".asText(),
+    message = "mockDescriptionText".asText(),
+    buttonText = "mockButtonText".asText(),
+)
+
+private val VAULT_POLICY_BANNER_ACTION_CARD: VaultState.ActionCardState.VaultPolicyBanner =
+    VaultState.ActionCardState.VaultPolicyBanner(
+        organizationId = "mockOrganizationId",
+        title = "mockHeaderText".asText(),
+        message = "mockDescriptionText".asText(),
+        button = "mockButtonText".asText(),
+    )
 
 private val DEFAULT_STATE: VaultState =
     createMockVaultState(viewState = VaultState.ViewState.Loading)
@@ -4776,6 +4931,7 @@ private fun createMockVaultState(
         isIntroducingArchiveActionCardDismissed = false,
         premiumCard = PremiumCard.NONE,
         validTotpIds = validTotpIds.toImmutableSet(),
+        policyBanner = null,
     )
 
 private val DEFAULT_CONTENT_VIEW_STATE = VaultState.ViewState.Content(

--- a/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventType.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventType.kt
@@ -121,6 +121,9 @@ enum class OrganizationEventType {
     @SerialName("1504")
     ORGANIZATION_USER_UPDATED_GROUPS,
 
+    @SerialName("1522")
+    ORGANIZATION_USER_NOTIFICATION_BANNER_ACTION_CLICKED,
+
     @SerialName("1600")
     ORGANIZATION_UPDATED,
 

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
@@ -55,9 +55,9 @@ import com.bitwarden.ui.util.asText
 @Suppress("LongMethod")
 @Composable
 fun BitwardenActionCard(
-    cardTitle: String,
-    actionButton: BitwardenButtonData? = null,
+    cardTitle: String?,
     modifier: Modifier = Modifier,
+    actionButton: BitwardenButtonData? = null,
     onDismissClick: (() -> Unit)? = null,
     cardSubtitle: String? = null,
     secondaryButton: BitwardenButtonData? = null,
@@ -92,17 +92,24 @@ fun BitwardenActionCard(
                 Column(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text(
-                        text = cardTitle,
-                        style = BitwardenTheme.typography.titleMedium,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .onGloballyPositioned {
-                                titleBottomPx = it.positionInParent().y.toInt() + it.size.height
-                            },
-                    )
+                    cardTitle?.let {
+                        Text(
+                            text = it,
+                            style = BitwardenTheme.typography.titleMedium,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .onGloballyPositioned { coordinates ->
+                                    titleBottomPx = coordinates.positionInParent().y.toInt() +
+                                        coordinates.size.height
+                                },
+                        )
+                    }
                     cardSubtitle?.let {
-                        Spacer(modifier = Modifier.height(height = 4.dp))
+                        cardTitle?.let { _ ->
+                            // We only need this to create a gap between the title and subtitle.
+                            // So if the title is not present, we can skip the spacer.
+                            Spacer(modifier = Modifier.height(height = 4.dp))
+                        }
                         Text(
                             text = it,
                             style = BitwardenTheme.typography.bodyMedium,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33857](https://bitwarden.atlassian.net/browse/PM-33857)

## 📔 Objective

This PR adds support for the User Notification Policy banner on the Vault Screen.

## 📸 Screenshots

<img width="350" src="https://github.com/user-attachments/assets/c5e80f67-aff6-4a75-b25c-218714c6b51e" />


[PM-33857]: https://bitwarden.atlassian.net/browse/PM-33857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ