### PR TITLE
[PM-36379] fix: Show the item type in the save snackbar

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -2033,7 +2033,7 @@ class VaultAddEditViewModel @Inject constructor(
                     sendEvent(event = VaultAddEditEvent.ExitApp)
                 } else {
                     snackbarRelayManager.sendSnackbarData(
-                        data = BitwardenSnackbarData(BitwardenString.new_item_created.asText()),
+                        data = BitwardenSnackbarData(state.savedSnackbarMessage),
                         relay = SnackbarRelay.CIPHER_CREATED,
                     )
                     sendEvent(event = VaultAddEditEvent.NavigateBack)
@@ -2066,7 +2066,7 @@ class VaultAddEditViewModel @Inject constructor(
                     sendEvent(event = VaultAddEditEvent.ExitApp)
                 } else {
                     snackbarRelayManager.sendSnackbarData(
-                        data = BitwardenSnackbarData(BitwardenString.item_updated.asText()),
+                        data = BitwardenSnackbarData(state.savedSnackbarMessage),
                         relay = SnackbarRelay.CIPHER_UPDATED,
                     )
                     sendEvent(event = VaultAddEditEvent.NavigateBack)
@@ -2808,6 +2808,21 @@ data class VaultAddEditState(
                 VaultItemCipherType.DRIVERS_LICENSE -> BitwardenString.edit_license.asText()
                 VaultItemCipherType.PASSPORT -> BitwardenString.edit_passport.asText()
             }
+        }
+
+    /**
+     * Helper to determine the snackbar message shown after the item is successfully saved.
+     */
+    val savedSnackbarMessage: Text
+        get() = when (cipherType) {
+            VaultItemCipherType.LOGIN -> BitwardenString.login_saved.asText()
+            VaultItemCipherType.CARD -> BitwardenString.card_saved.asText()
+            VaultItemCipherType.IDENTITY -> BitwardenString.identity_saved.asText()
+            VaultItemCipherType.SECURE_NOTE -> BitwardenString.secure_note_saved.asText()
+            VaultItemCipherType.SSH_KEY -> BitwardenString.ssh_key_saved.asText()
+            VaultItemCipherType.BANK_ACCOUNT -> BitwardenString.bank_account_saved.asText()
+            VaultItemCipherType.DRIVERS_LICENSE -> BitwardenString.license_saved.asText()
+            VaultItemCipherType.PASSPORT -> BitwardenString.passport_saved.asText()
         }
 
     /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -961,7 +961,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             }
             verify(exactly = 1) {
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.new_item_created.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.login_saved.asText()),
                     relay = SnackbarRelay.CIPHER_CREATED,
                 )
             }
@@ -1131,7 +1131,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             assertNotNull(specialCircumstanceManager.specialCircumstance)
             verify(exactly = 1) {
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.new_item_created.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.login_saved.asText()),
                     relay = SnackbarRelay.CIPHER_CREATED,
                 )
             }
@@ -1514,8 +1514,84 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             }
             verify(exactly = 1) {
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.new_item_created.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.login_saved.asText()),
                     relay = SnackbarRelay.CIPHER_CREATED,
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in add mode with a card, createCipherInOrganization success should send the card saved snackbar`() =
+        runTest {
+            val stateWithName = createVaultAddItemState(
+                vaultItemCipherType = VaultItemCipherType.CARD,
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                ),
+                typeContentViewState = VaultAddEditState.ViewState.Content.ItemType.Card(),
+            )
+
+            mutableVaultDataFlow.value = DataState.Loaded(createVaultData())
+
+            val viewModel = createAddVaultItemViewModel(
+                createSavedStateHandleWithState(
+                    state = stateWithName,
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.CARD,
+                ),
+            )
+
+            coEvery {
+                vaultRepository.createCipherInOrganization(any(), any())
+            } returns CreateCipherResult.Success
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
+                assertEquals(VaultAddEditEvent.NavigateBack, awaitItem())
+            }
+            verify(exactly = 1) {
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(BitwardenString.card_saved.asText()),
+                    relay = SnackbarRelay.CIPHER_CREATED,
+                )
+            }
+        }
+
+    @Test
+    fun `in edit mode with a card, updateCipher success should send the card saved snackbar`() =
+        runTest {
+            val cipherView = createMockCipherListView(1)
+            val stateWithName = createVaultAddItemState(
+                vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID),
+                vaultItemCipherType = VaultItemCipherType.CARD,
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                ),
+                typeContentViewState = VaultAddEditState.ViewState.Content.ItemType.Card(),
+            )
+
+            mutableVaultDataFlow.value =
+                DataState.Loaded(createVaultData(cipherListView = cipherView))
+
+            val viewModel = createAddVaultItemViewModel(
+                createSavedStateHandleWithState(
+                    state = stateWithName,
+                    vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID),
+                    vaultItemCipherType = VaultItemCipherType.CARD,
+                ),
+            )
+
+            coEvery {
+                vaultRepository.updateCipher(any(), any())
+            } returns UpdateCipherResult.Success
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
+                assertEquals(VaultAddEditEvent.NavigateBack, awaitItem())
+            }
+            verify(exactly = 1) {
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(BitwardenString.card_saved.asText()),
+                    relay = SnackbarRelay.CIPHER_UPDATED,
                 )
             }
         }
@@ -1855,7 +1931,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             }
             verify(exactly = 1) {
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.item_updated.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.login_saved.asText()),
                     relay = SnackbarRelay.CIPHER_UPDATED,
                 )
             }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -120,7 +120,6 @@
     <string name="min_numbers">Minimum numbers</string>
     <string name="min_special">Minimum special</string>
     <string name="never">Never</string>
-    <string name="new_item_created">Item added</string>
     <string name="no_cards">There are no cards in your vault.</string>
     <string name="add_card">Add card</string>
     <string name="no_logins">There are no logins in your vault.</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -150,6 +150,14 @@
     <string name="select">Select</string>
     <string name="item_details">Item details</string>
     <string name="item_updated">Item saved</string>
+    <string name="bank_account_saved">Bank account saved</string>
+    <string name="card_saved">Card saved</string>
+    <string name="identity_saved">Identity saved</string>
+    <string name="license_saved">License saved</string>
+    <string name="login_saved">Login saved</string>
+    <string name="passport_saved">Passport saved</string>
+    <string name="secure_note_saved">Secure note saved</string>
+    <string name="ssh_key_saved">SSH key saved</string>
     <string name="submitting">Submitting…</string>
     <string name="syncing">Syncing…</string>
     <string name="syncing_complete">Syncing complete</string>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36379

## 📔 Objective

- Saving a card showed "Item added" or "Item saved", which doesn't tell you what you actually saved.
- The snackbar now names the type, so creating or editing a card reads "Card saved".
- Did the same for the rest: logins, identities, secure notes, SSH keys, bank accounts, licenses, and passports.
- Create and edit share one message now, since "Card saved" reads fine for both.


## 📸 Screenshots
| Before |

<img width="350"  alt="image" src="https://github.com/user-attachments/assets/176d058b-bc04-4b8a-a40b-d61a0079b864" />

| After |

<img width="350" alt="image" src="https://github.com/user-attachments/assets/e078994f-2a28-49cf-87fc-b33997776dbd" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/2090b4d2-1e57-4ae8-8266-e2bd7ec49c2e" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/766112a2-3c81-45af-9c53-ce0dd2510597" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/303d6a51-c08e-4d13-928a-929ca716a9fb" />
<img width="350"alt="image" src="https://github.com/user-attachments/assets/1941135d-d946-4d71-a0d3-00acdef0ecd9" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/cfb55e63-3396-4c51-932c-a2ea1465977d" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/bf84aaab-1964-477a-901e-5634fbea6e16" />



