### PR TITLE
llm: Dispatch bitwarden-software-engineer as a subagent for SDK-update evaluation

### DIFF
--- a/.github/workflows/sdlc-sdk-update-evaluate.yml
+++ b/.github/workflows/sdlc-sdk-update-evaluate.yml
@@ -133,6 +133,7 @@ jobs:
           plugin_marketplaces: "https://github.com/bitwarden/ai-plugins.git"
           plugins: |
             bitwarden-delivery-tools@bitwarden-marketplace
+            bitwarden-software-engineer@bitwarden-marketplace
           prompt: |
             PR #${{ github.event.pull_request.number }} in ${{ github.repository }} bumps the
             Bitwarden SDK. Evaluate it using the `evaluating-sdk-internal-updates` skill and
@@ -152,6 +153,7 @@ jobs:
             that nothing needs fixing — the comment is the audit trail that the check ran.
           claude_args: |
             --model opus
+            --agent bitwarden-software-engineer
             --allowedTools "Bash(gh pr diff:*),Bash(git -C * log *),Bash(git -C * show *),Bash(git add:*),Bash(git commit:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(grep:*),Bash(./gradlew *),Read,Grep,Glob,Edit,Write,Skill,mcp__github_comment__update_claude_comment"
 
       - name: Push any resolved fix

--- a/.github/workflows/sdlc-sdk-update-evaluate.yml
+++ b/.github/workflows/sdlc-sdk-update-evaluate.yml
@@ -142,13 +142,14 @@ jobs:
             prerequisite — use it directly.
 
             If step 7 turns up anything to resolve, dispatch a single subagent on the
-            `bitwarden-software-engineer` agent to carry out the skill's Resolve steps (8-10) for
-            every finding in one pass — decide the fix, implement it, and commit on the current
-            branch (already checked out) using `Skill(bitwarden-delivery-tools:committing-changes)`
-            for the message. Hand the subagent all the findings (commit, symbol, call sites for
-            each) rather than having it redo the investigation, and rather than spawning one
-            subagent per finding. Do not push; the workflow pushes separately. Skip the subagent
-            entirely if step 7 finds nothing to resolve.
+            `bitwarden-software-engineer` agent to invoke `Skill(evaluating-sdk-internal-updates)`
+            itself and carry out its Resolve steps (8-10) for every finding in one pass — decide
+            the fix, implement it, and commit on the current branch (already checked out) using
+            `Skill(bitwarden-delivery-tools:committing-changes)` for the message. Hand the
+            subagent all the findings (commit, symbol, call sites for each) so it doesn't redo the
+            investigation, dispatching it once for every finding rather than once per finding. Do
+            not push; the workflow pushes separately. Have it report back the commit SHA and each
+            finding's disposition. Skip the subagent entirely if step 7 finds nothing to resolve.
 
             Once the subagent has reported back — or immediately, if there was nothing to resolve —
             update the sticky PR comment yourself with the step 7 report,

--- a/.github/workflows/sdlc-sdk-update-evaluate.yml
+++ b/.github/workflows/sdlc-sdk-update-evaluate.yml
@@ -136,25 +136,31 @@ jobs:
             bitwarden-software-engineer@bitwarden-marketplace
           prompt: |
             PR #${{ github.event.pull_request.number }} in ${{ github.repository }} bumps the
-            Bitwarden SDK. Evaluate it using the `evaluating-sdk-internal-updates` skill and
-            resolve anything within scope that needs resolving, per the skill's own Resolve
-            steps. `bitwarden/sdk-internal` is already cloned as a sibling directory at
-            `${{ github.workspace }}/../sdk-internal`, satisfying step 1's prerequisite — use it
-            directly. Commit any fix on the current branch (already checked out) using
-            `Skill(bitwarden-delivery-tools:committing-changes)` for the message — do not push;
-            the workflow pushes separately.
+            Bitwarden SDK. Evaluate it yourself using the `evaluating-sdk-internal-updates`
+            skill's Identify steps (1-7). `bitwarden/sdk-internal` is already cloned as a sibling
+            directory at `${{ github.workspace }}/../sdk-internal`, satisfying step 1's
+            prerequisite — use it directly.
 
-            When done, update the sticky PR comment with the step 7 report, structured as:
-            "## SDK bump evaluated" (old → new version, commit count), "## Compile-time breaks"
-            (found-and-fixed, or "none found"), "## Runtime considerations" (any behavioral notes
-            worth flagging, or omit the section if there are none), "## Everything else in range
-            — confirmed safe" (brief, one line per commit or group), and "## Commit" (the SHA, or
-            "no commit — nothing needed fixing"). Always post this, even when the conclusion is
+            If step 7 turns up anything to resolve, dispatch a single subagent on the
+            `bitwarden-software-engineer` agent to carry out the skill's Resolve steps (8-10) for
+            every finding in one pass — decide the fix, implement it, and commit on the current
+            branch (already checked out) using `Skill(bitwarden-delivery-tools:committing-changes)`
+            for the message. Hand the subagent all the findings (commit, symbol, call sites for
+            each) rather than having it redo the investigation, and rather than spawning one
+            subagent per finding. Do not push; the workflow pushes separately. Skip the subagent
+            entirely if step 7 finds nothing to resolve.
+
+            Once the subagent has reported back — or immediately, if there was nothing to resolve —
+            update the sticky PR comment yourself with the step 7 report,
+            structured as: "## SDK bump evaluated" (old → new version, commit count), "## Compile-time
+            breaks" (found-and-fixed, or "none found"), "## Runtime considerations" (any behavioral
+            notes worth flagging, or omit the section if there are none), "## Everything else in
+            range — confirmed safe" (brief, one line per commit or group), and "## Commit" (the SHA,
+            or "no commit — nothing needed fixing"). Always post this, even when the conclusion is
             that nothing needs fixing — the comment is the audit trail that the check ran.
           claude_args: |
             --model opus
-            --agent bitwarden-software-engineer
-            --allowedTools "Bash(gh pr diff:*),Bash(git -C * log *),Bash(git -C * show *),Bash(git add:*),Bash(git commit:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(grep:*),Bash(./gradlew *),Read,Grep,Glob,Edit,Write,Skill,mcp__github_comment__update_claude_comment"
+            --allowedTools "Agent,Bash(gh pr diff:*),Bash(git -C * log *),Bash(git -C * show *),Bash(git add:*),Bash(git commit:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(grep:*),Bash(./gradlew *),Read,Grep,Glob,Edit,Write,Skill,mcp__github_comment__update_claude_comment"
 
       - name: Push any resolved fix
         if: steps.gate.outputs.skip == 'false'


### PR DESCRIPTION
## 🎟️ Tracking

No tracking ticket — a correctness fix to the SDK-update-evaluation workflow's Claude Code configuration, found while testing it locally.

## 📔 Objective

The SDK-bump evaluation workflow needs the **bitwarden-software-engineer** agent's engineering process for landing fixes, but running the whole session under that persona restricts it to the persona's own declared tool set — which excludes the MCP tool the workflow uses to post its audit-trail comment. We keep the top-level session on the default agent, evaluate the bump ourselves through the skill's Identify steps, and dispatch the persona as a single subagent only when there's something to resolve, handing it every finding at once and having it invoke the skill itself so it picks up the Resolve steps' guardrails.


## Process

```mermaid
flowchart TD
    A[Primary agent: evaluate via skill's Identify steps] --> B{Anything to resolve?}
    B -- Yes --> C[Dispatch bitwarden-software-engineer subagent: Resolve all findings]
    C --> D[Post sticky PR comment with report]
    B -- No --> D
```
