### PR TITLE
llm: Exclude claude-code-action's restored config paths from the SDK-update push guard

### DIFF
--- a/.github/workflows/sdlc-sdk-update-evaluate.yml
+++ b/.github/workflows/sdlc-sdk-update-evaluate.yml
@@ -168,9 +168,17 @@ jobs:
         env:
           _BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
+          # claude-code-action treats the PR head as untrusted and restores these exact paths from
+          # origin/main before running Claude, regardless of whether this branch's copy is stale.
+          # This job never has a legitimate reason to change them, so a diff here is that restore,
+          # not Claude — exclude them rather than flag it.
+          _TRUSTED_CONFIG_PATHSPEC=(
+            ':!.claude' ':!.mcp.json' ':!.claude.json' ':!.gitmodules' ':!.ripgreprc'
+            ':!CLAUDE.md' ':!CLAUDE.local.md' ':!.husky'
+          )
+          if [ -n "$(git status --porcelain -- . "${_TRUSTED_CONFIG_PATHSPEC[@]}")" ]; then
             echo "::error::Claude left uncommitted changes; nothing was pushed."
-            git status --porcelain
+            git status --porcelain -- . "${_TRUSTED_CONFIG_PATHSPEC[@]}"
             exit 1
           fi
 


### PR DESCRIPTION
## 🎟️ Tracking

No tracking ticket — a correctness fix to the SDK-update-evaluation workflow's push guard, ported from an equivalent bitwarden/ios fix found while investigating a failed run there.

## 📔 Objective

The push guard treats any working-tree diff as an uncommitted Claude edit and fails the job, but **claude-code-action** restores `.claude`, `.mcp.json`, `CLAUDE.md`, and a few other sensitive paths from `origin/main` before running Claude, since the PR head is untrusted — and the long-lived `sdlc/sdk-update` branch can go stale relative to `main` for those paths. The guard now excludes the exact restore list `claude-code-action` pulls from base, since this workflow never has a legitimate reason to touch those paths itself.
