### PR TITLE
[PM-36378] fix: Remove the period from the new folder created snackbar

### DIFF
--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="enter_pin">Enter your PIN code</string>
     <string name="favorites">Favorites</string>
     <string name="folder">Folder</string>
-    <string name="folder_created">New folder created.</string>
+    <string name="folder_created">New folder created</string>
     <string name="folder_deleted">Folder deleted.</string>
     <string name="folder_none">No Folder</string>
     <string name="folder_updated">Folder saved</string>


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-36378

## 📔 Objective
QA found that the "New folder created" snackbar ends with a period, while the design does not include one. This affects both paths that show the snackbar:

- Creating a new folder from the main vault screen via the "+" FAB (`FolderAddEditViewModel).
- Creating a new folder during cipher creation/edit (VaultAddEditViewModel).
