### PR TITLE
[PM-41836] fix: Promote Plan screen off Free view without requiring an in-flight checkout

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -605,12 +605,12 @@ class PlanViewModel @Inject constructor(
     // Fires the celebration event only when isConfirmedPremium and a checkout was actually
     // in flight; otherwise this is a silent state recovery.
     private fun promoteFreeCloudToPremiumView(isConfirmedPremium: Boolean) {
-        val isAwaitingPremiumStatus = (state.viewState as? PlanState.ViewState.Content.Free.Cloud)
-            ?.isAwaitingPremiumStatus == true
-        if (isConfirmedPremium && isAwaitingPremiumStatus) {
-            onPremiumUpgradeSuccess()
-        } else {
-            promoteToPremiumView()
+        onFreeCloudContent { freeState ->
+            if (isConfirmedPremium && freeState.isAwaitingPremiumStatus) {
+                onPremiumUpgradeSuccess()
+            } else {
+                promoteToPremiumView()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -483,14 +483,14 @@ class PlanViewModel @Inject constructor(
         action: PlanAction.Internal.UserStateUpdateReceive,
     ) {
         val isPremium = action.userState?.activeAccount?.isPremium == true
+        val wasShowingPremiumView = state.showsPremiumView
         mutableStateFlow.update {
             it.copy(
                 showsPremiumView = isPremium ||
                     premiumStateManager.subscriptionStatusStateFlow.value.isPremiumViewEligible(),
             )
         }
-        // Promote unconditionally, not only while `isAwaitingPremiumStatus`.
-        if (isPremium) {
+        if (isPremium && !wasShowingPremiumView) {
             promoteFreeCloudToPremiumView(isConfirmedPremium = true)
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -466,24 +466,13 @@ class PlanViewModel @Inject constructor(
         action: PlanAction.Internal.SubscriptionStatusUpdateReceive,
     ) {
         val status = (action.state as? SubscriptionStatusState.Available)?.status ?: return
-        if (!status.isPremiumViewEligible()) return
-        onFreeCloudContent { freeState ->
-            if (freeState.isAwaitingPremiumStatus) return@onFreeCloudContent
-            mutableStateFlow.update {
-                it.copy(
-                    viewState = PlanState.ViewState.Loading(
-                        message = BitwardenString.loading_subscription.asText(),
-                    ),
-                )
-            }
-            viewModelScope.launch {
-                sendAction(
-                    PlanAction.Internal.SubscriptionResultReceive(
-                        result = billingRepository.getSubscription(),
-                    ),
-                )
-            }
+        // ACTIVE status for a premium account must promote too, not just trouble statuses.
+        val isPremium = authRepository.userStateFlow.value?.activeAccount?.isPremium == true
+        if (!isPremium && !status.isPremiumViewEligible()) {
+            return
         }
+        // Only a confirmed-premium signal celebrates; a trouble status promotes silently.
+        promoteFreeCloudToPremiumView(isConfirmedPremium = isPremium)
     }
 
     // endregion Premium user handlers
@@ -500,11 +489,9 @@ class PlanViewModel @Inject constructor(
                     premiumStateManager.subscriptionStatusStateFlow.value.isPremiumViewEligible(),
             )
         }
-        onFreeCloudContent { freeState ->
-            if (!freeState.isAwaitingPremiumStatus) return@onFreeCloudContent
-            if (isPremium) {
-                onPremiumUpgradeSuccess()
-            }
+        // Promote unconditionally, not only while `isAwaitingPremiumStatus`.
+        if (isPremium) {
+            promoteFreeCloudToPremiumView(isConfirmedPremium = true)
         }
     }
 
@@ -615,7 +602,19 @@ class PlanViewModel @Inject constructor(
         }
     }
 
-    private fun onPremiumUpgradeSuccess() {
+    // Fires the celebration event only when isConfirmedPremium and a checkout was actually
+    // in flight; otherwise this is a silent state recovery.
+    private fun promoteFreeCloudToPremiumView(isConfirmedPremium: Boolean) {
+        val isAwaitingPremiumStatus = (state.viewState as? PlanState.ViewState.Content.Free.Cloud)
+            ?.isAwaitingPremiumStatus == true
+        if (isConfirmedPremium && isAwaitingPremiumStatus) {
+            onPremiumUpgradeSuccess()
+        } else {
+            promoteToPremiumView()
+        }
+    }
+
+    private fun promoteToPremiumView() {
         onFreeCloudContent {
             mutableStateFlow.update {
                 it.copy(
@@ -632,9 +631,10 @@ class PlanViewModel @Inject constructor(
                 )
             }
         }
-        // The Upgraded to Premium route uses `launchSingleTop = true` so a duplicate event is a
-        // no-op for the user. The event itself is harmless to re-emit; the state mutation above
-        // is what's guarded by `onFreeCloudContent`.
+    }
+
+    private fun onPremiumUpgradeSuccess() {
+        promoteToPremiumView()
         sendEvent(PlanEvent.NavigateToUpgradedToPremium)
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -579,22 +579,6 @@ class PlanViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `premium status flip should not emit event when not in WaitingForPayment`() =
-        runTest {
-            val viewModel = createViewModel()
-
-            viewModel.eventFlow.test {
-                // Flip premium while in Content state.
-                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                    accounts = listOf(
-                        DEFAULT_ACCOUNT.copy(isPremium = true),
-                    ),
-                )
-                expectNoEvents()
-            }
-        }
-
-    @Test
     fun `premium status flip should promote off Free view when not awaiting checkout`() =
         runTest {
             val viewModel = createViewModel(subscriptionResult = SUBSCRIPTION_SUCCESS_ACTIVE)
@@ -995,6 +979,43 @@ class PlanViewModelTest : BaseViewModelTest() {
                     ),
                     loadedState.viewState,
                 )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `SubscriptionStatusUpdateReceive with ACTIVE status promotes premium account off Free view`() =
+        runTest {
+            markUserPremium()
+            val viewModel = createViewModel(subscriptionResult = SubscriptionResult.NotFound)
+
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
+                // The NotFound fallback leaves the account premium while the view is still
+                // showing Free.Cloud content.
+                assertEquals(
+                    DEFAULT_FREE_STATE.copy(showsPremiumView = true),
+                    stateFlow.awaitItem(),
+                )
+
+                coEvery {
+                    mockBillingRepository.getSubscription()
+                } returns SUBSCRIPTION_SUCCESS_ACTIVE
+                mutableSubscriptionStatusStateFlow.value = SubscriptionStatusState.Available(
+                    status = PremiumSubscriptionStatus.ACTIVE,
+                )
+
+                assertEquals(
+                    DEFAULT_FREE_STATE.copy(
+                        viewState = PlanState.ViewState.Loading(
+                            message = BitwardenString.loading_subscription.asText(),
+                        ),
+                        showsPremiumView = true,
+                    ),
+                    stateFlow.awaitItem(),
+                )
+                assertEquals(DEFAULT_PREMIUM_LOADED_STATE, stateFlow.awaitItem())
+
+                eventFlow.expectNoEvents()
             }
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -436,37 +436,6 @@ class PlanViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `premium status flip should show snackbar when in WaitingForPayment`() =
-        runTest {
-            val viewModel = createViewModel(
-                initialState = DEFAULT_FREE_STATE.copy(
-                    viewState = PlanState.ViewState.Content.Free.Cloud(
-                        rate = "$1.67",
-                        checkoutUrl = null,
-                        isAwaitingPremiumStatus = true,
-                        isPremiumUpgradePending = false,
-                    ),
-                    dialogState = PlanState.DialogState.WaitingForPayment,
-                ),
-                pricingResult = null,
-            )
-
-            viewModel.eventFlow.test {
-                // Simulate premium status flip while WaitingForPayment.
-                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                    accounts = listOf(
-                        DEFAULT_ACCOUNT.copy(isPremium = true),
-                    ),
-                )
-
-                assertEquals(
-                    PlanEvent.NavigateToUpgradedToPremium,
-                    awaitItem(),
-                )
-            }
-        }
-
-    @Test
     fun `premium flip via canceled special circumstance should navigate to UpgradedToPremium`() =
         runTest {
             val viewModel = createViewModel()
@@ -610,38 +579,6 @@ class PlanViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `UserStateUpdateReceive premium during Loading should navigate to UpgradedToPremium`() =
-        runTest {
-            val viewModel = createViewModel(
-                initialState = DEFAULT_FREE_STATE.copy(
-                    viewState = PlanState.ViewState.Content.Free.Cloud(
-                        rate = "$1.67",
-                        checkoutUrl = null,
-                        isAwaitingPremiumStatus = true,
-                        isPremiumUpgradePending = false,
-                    ),
-                    dialogState = PlanState.DialogState.Loading(
-                        message = BitwardenString.confirming_your_upgrade.asText(),
-                    ),
-                ),
-                pricingResult = null,
-            )
-
-            viewModel.eventFlow.test {
-                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                    accounts = listOf(
-                        DEFAULT_ACCOUNT.copy(isPremium = true),
-                    ),
-                )
-
-                assertEquals(
-                    PlanEvent.NavigateToUpgradedToPremium,
-                    awaitItem(),
-                )
-            }
-        }
-
-    @Test
     fun `premium status flip should not emit event when not in WaitingForPayment`() =
         runTest {
             val viewModel = createViewModel()
@@ -654,6 +591,92 @@ class PlanViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `premium status flip should promote off Free view when not awaiting checkout`() =
+        runTest {
+            val viewModel = createViewModel(subscriptionResult = SUBSCRIPTION_SUCCESS_ACTIVE)
+
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
+                assertEquals(DEFAULT_FREE_STATE, stateFlow.awaitItem())
+
+                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+                    accounts = listOf(
+                        DEFAULT_ACCOUNT.copy(isPremium = true),
+                    ),
+                )
+
+                assertEquals(
+                    DEFAULT_FREE_STATE.copy(
+                        viewState = PlanState.ViewState.Loading(
+                            message = BitwardenString.loading_subscription.asText(),
+                        ),
+                        showsPremiumView = true,
+                    ),
+                    stateFlow.awaitItem(),
+                )
+                assertEquals(DEFAULT_PREMIUM_LOADED_STATE, stateFlow.awaitItem())
+
+                eventFlow.expectNoEvents()
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `SubscriptionStatusUpdateReceive with trouble status while awaiting checkout should promote without celebration event`() =
+        runTest {
+            val viewModel = createViewModel(
+                initialState = DEFAULT_FREE_STATE.copy(
+                    viewState = PlanState.ViewState.Content.Free.Cloud(
+                        rate = "$1.67",
+                        checkoutUrl = null,
+                        isAwaitingPremiumStatus = true,
+                        isPremiumUpgradePending = false,
+                    ),
+                    dialogState = PlanState.DialogState.WaitingForPayment,
+                ),
+                pricingResult = null,
+                subscriptionResult = SubscriptionResult.Success(
+                    subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
+                        status = PremiumSubscriptionStatus.CANCELED,
+                        canceledDate = Instant.parse("2026-04-21T00:00:00Z"),
+                    ),
+                ),
+            )
+
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
+                assertEquals(
+                    PlanState.DialogState.WaitingForPayment,
+                    stateFlow.awaitItem().dialogState,
+                )
+
+                mutableSubscriptionStatusStateFlow.value = SubscriptionStatusState.Available(
+                    status = PremiumSubscriptionStatus.CANCELED,
+                )
+
+                val loadingState = stateFlow.awaitItem()
+                assertEquals(
+                    PlanState.ViewState.Loading(
+                        message = BitwardenString.loading_subscription.asText(),
+                    ),
+                    loadingState.viewState,
+                )
+                assertEquals(PlanState.DialogState.WaitingForPayment, loadingState.dialogState)
+
+                val loadedState = stateFlow.awaitItem()
+                assertEquals(
+                    DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
+                        status = PremiumSubscriptionStatus.CANCELED,
+                        canceledDateText = "April 21, 2026",
+                        showCancelButton = false,
+                    ),
+                    loadedState.viewState,
+                )
+                assertEquals(null, loadedState.dialogState)
+
+                eventFlow.expectNoEvents()
             }
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -627,16 +627,17 @@ class PlanViewModelTest : BaseViewModelTest() {
     @Test
     fun `SubscriptionStatusUpdateReceive with trouble status while awaiting checkout should promote without celebration event`() =
         runTest {
-            val viewModel = createViewModel(
-                initialState = DEFAULT_FREE_STATE.copy(
-                    viewState = PlanState.ViewState.Content.Free.Cloud(
-                        rate = "$1.67",
-                        checkoutUrl = null,
-                        isAwaitingPremiumStatus = true,
-                        isPremiumUpgradePending = false,
-                    ),
-                    dialogState = PlanState.DialogState.WaitingForPayment,
+            val initialState = DEFAULT_FREE_STATE.copy(
+                viewState = PlanState.ViewState.Content.Free.Cloud(
+                    rate = "$1.67",
+                    checkoutUrl = null,
+                    isAwaitingPremiumStatus = true,
+                    isPremiumUpgradePending = false,
                 ),
+                dialogState = PlanState.DialogState.WaitingForPayment,
+            )
+            val viewModel = createViewModel(
+                initialState = initialState,
                 pricingResult = null,
                 subscriptionResult = SubscriptionResult.Success(
                     subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
@@ -647,34 +648,32 @@ class PlanViewModelTest : BaseViewModelTest() {
             )
 
             viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
-                assertEquals(
-                    PlanState.DialogState.WaitingForPayment,
-                    stateFlow.awaitItem().dialogState,
-                )
+                assertEquals(initialState, stateFlow.awaitItem())
 
                 mutableSubscriptionStatusStateFlow.value = SubscriptionStatusState.Available(
                     status = PremiumSubscriptionStatus.CANCELED,
                 )
 
-                val loadingState = stateFlow.awaitItem()
                 assertEquals(
-                    PlanState.ViewState.Loading(
-                        message = BitwardenString.loading_subscription.asText(),
+                    initialState.copy(
+                        viewState = PlanState.ViewState.Loading(
+                            message = BitwardenString.loading_subscription.asText(),
+                        ),
                     ),
-                    loadingState.viewState,
+                    stateFlow.awaitItem(),
                 )
-                assertEquals(PlanState.DialogState.WaitingForPayment, loadingState.dialogState)
 
-                val loadedState = stateFlow.awaitItem()
                 assertEquals(
-                    DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
-                        status = PremiumSubscriptionStatus.CANCELED,
-                        canceledDateText = "April 21, 2026",
-                        showCancelButton = false,
+                    initialState.copy(
+                        viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
+                            status = PremiumSubscriptionStatus.CANCELED,
+                            canceledDateText = "April 21, 2026",
+                            showCancelButton = false,
+                        ),
+                        dialogState = null,
                     ),
-                    loadedState.viewState,
+                    stateFlow.awaitItem(),
                 )
-                assertEquals(null, loadedState.dialogState)
 
                 eventFlow.expectNoEvents()
             }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41836

## 📔 Objective

The Plan screen only promoted a premium account off the Free-upgrade view while `isAwaitingPremiumStatus` was true (immediately after a Stripe checkout round-trip), and `handleSubscriptionStatusUpdateReceive` only reacted to trouble-status subscription updates, never a healthy `ACTIVE` one. A premium account reaching the screen outside that narrow window — via a push notification, a background sync, or simply reopening the screen later — stayed stuck on the Free-upgrade UI despite already being premium.

Both signal handlers (`handleUserStateUpdateReceive`, `handleSubscriptionStatusUpdateReceive`) now promote unconditionally whenever the account is premium. The upgrade-celebration event (`NavigateToUpgradedToPremium`) still only fires when a checkout was genuinely in flight (`isAwaitingPremiumStatus`), so a stale trouble-status update arriving mid-checkout can't fire a false celebration.

**Out of scope, tracked separately:** the `isPremium` vs. org-granted-premium (`isPremiumFromSelf`) distinction, and a client-side wiring gap in the Stripe checkout callback (a missing `AndroidManifest.xml` intent-filter affecting devices without Auth Tab support) — both real findings from this investigation, but independent of this fix and better reviewed on their own.

**Review note:** a local review caught that an early version of this change promoted unconditionally on every `UserStateUpdateReceive`, including for non-premium accounts — a regression, since fixed and verified against the full `PlanViewModelTest` suite.
