### PR TITLE
[PM-40535] fix: Organization policy restriction notice padding and icon

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -263,8 +262,7 @@ private fun ViewStateContent(
                 leadingContent = {
                     BitwardenIcon(
                         iconData = IconData.Local(iconRes = BitwardenDrawable.ic_info_circle),
-                        tint = BitwardenTheme.colorScheme.text.primary,
-                        modifier = Modifier.size(size = 16.dp),
+                        tint = BitwardenTheme.colorScheme.icon.secondary,
                     )
                 },
                 modifier = Modifier

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
@@ -44,9 +44,9 @@ import com.bitwarden.ui.util.asText
  * button, and leading icon content.
  *
  * @param cardTitle The title of the card.
+ * @param modifier The [Modifier] to be applied to the card.
  * @param actionButton The data for the CTA button, or `null` to omit it, which suits a card that
  * only explains something.
- * @param modifier The [Modifier] to be applied to the card.
  * @param onDismissClick Optional action to perform when the dismiss button is clicked.
  * @param cardSubtitle The subtitle of the card.
  * @param secondaryButton The optional data for a secondary button.

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
@@ -118,12 +118,16 @@ fun BitwardenActionCard(
                     }
                 }
             }
-            onDismissClick?.let {
+            if (onDismissClick != null) {
                 BitwardenStandardIconButton(
                     painter = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                     contentDescription = stringResource(id = BitwardenString.close),
-                    onClick = it,
+                    onClick = onDismissClick,
                 )
+            } else {
+                // The dismiss button normally supplies the trailing inset, so without it the
+                // content would otherwise run to the edge of the card.
+                Spacer(modifier = Modifier.width(width = 16.dp))
             }
         }
         if (actionButton != null || secondaryButton != null) {

--- a/ui/src/test/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCardTest.kt
+++ b/ui/src/test/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCardTest.kt
@@ -1,13 +1,18 @@
 package com.bitwarden.ui.platform.components.card
 
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.bitwarden.ui.platform.base.BaseComposeTest
 import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.util.asText
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class BitwardenActionCardTest : BaseComposeTest() {
@@ -86,5 +91,30 @@ class BitwardenActionCardTest : BaseComposeTest() {
         composeTestRule
             .onNodeWithText(text = "Learn more")
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun `content is inset from the trailing edge when the dismiss button is omitted`() {
+        setTestContent {
+            BitwardenTheme {
+                BitwardenActionCard(
+                    cardTitle = "Title",
+                    cardSubtitle = "Subtitle",
+                    modifier = Modifier.testTag(tag = "ActionCard"),
+                )
+            }
+        }
+
+        val cardRight = composeTestRule
+            .onNodeWithTag(testTag = "ActionCard")
+            .getUnclippedBoundsInRoot()
+            .right
+        val subtitleRight = composeTestRule
+            .onNodeWithText(text = "Subtitle")
+            .getUnclippedBoundsInRoot()
+            .right
+        // Without a dismiss button there is nothing else to inset the text, so the card itself
+        // must keep the content 16dp away from its trailing edge.
+        assertEquals(16f, (cardRight - subtitleRight).value, 0.5f)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40535

## 📔 Objective

QA sent this back for two design mismatches on the "Organization policy
restriction" notice on text Sends.

- Text ran to the edge of the card. `BitwardenActionCard` only got its trailing
  padding from the dismiss button, and this card has none, so it now adds the
  16dp inset itself.
- The info icon was near-black at 16dp instead of the blue 24dp in the designs.

The padding fix is in the shared card, so it also covers three other cards with
no dismiss button.

## 📸 Screenshots
| Before | After |
|--------|-------|
| <img width="365" src="https://github.com/user-attachments/assets/74b642d1-9c0b-45f9-aaf2-e12cd6b4eca7" /> | <img width="365" src="https://github.com/user-attachments/assets/38b3c891-06bb-4500-a315-79aa07c86f8c" /> |
| <img width="365" src="https://github.com/user-attachments/assets/d529d55a-9590-49ee-b695-e7a30b56c6f2" /> | <img width="365" src="https://github.com/user-attachments/assets/8eeb0189-e13f-4c19-88e7-3e5569f24c63" /> |
