### PR TITLE
[PM-36378] fix: Remove "New folder created" snackbar from add/edit cipher flow

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -1994,10 +1994,6 @@ class VaultAddEditViewModel @Inject constructor(
                 selectedFolderId = createdFolder?.id,
             )
         }
-        if (createdFolder == null) return
-        sendEvent(
-            event = VaultAddEditEvent.ShowSnackbar(BitwardenString.folder_created.asText()),
-        )
     }
 
     private fun handleCreateCipherResultReceive(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -4849,17 +4849,14 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         }
 
         @Test
-        fun `AddNewFolder shows the folder created snackbar on success`() = runTest {
+        fun `AddNewFolder does not show the folder created snackbar on success`() = runTest {
             coEvery {
                 vaultRepository.createFolder(any())
             } returns CreateFolderResult.Success(createdFolderView)
 
             viewModel.eventFlow.test {
                 viewModel.trySendAction(VaultAddEditAction.Common.AddNewFolder(newFolderName))
-                assertEquals(
-                    VaultAddEditEvent.ShowSnackbar(BitwardenString.folder_created.asText()),
-                    awaitItem(),
-                )
+                expectNoEvents()
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36378

## 📔 Objective

New requirement change. The "New folder created" snackbar should only show when you create a folder from the vault "+" FAB or from Settings > Vault > Folders. It shouldn't show when you create one inline while adding or editing an item, and right now it does.

- Dropped the snackbar event from `VaultAddEditViewModel.handleAddFolderResult`
- The folder is still created and auto-selected in the dropdown, nothing else changes
- `FolderAddEditViewModel` is untouched, so the FAB and settings paths keep their snackbar
- Updated the matching unit test to expect no event

