### PR TITLE
chore: Rollback setpassword API changes

### DIFF
--- a/network/src/main/kotlin/com/bitwarden/network/model/SetPasswordRequestJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/SetPasswordRequestJson.kt
@@ -8,8 +8,12 @@ import kotlinx.serialization.Serializable
  *
  * @property organizationIdentifier The SSO organization identifier.
  * @property passwordHint The hint for the master password (nullable).
- * @property authenticationData The data to authenticate with a master password.
- * @property unlockData The data to unlock with a master password.
+ * @property kdfType The KDF type.
+ * @property kdfIterations The number of iterations when calculating a user's password.
+ * @property kdfMemory The amount of memory to use when calculating a password hash (MB).
+ * @property kdfParallelism The number of threads to use when calculating a password hash.
+ * @property key The user key for the request (encrypted).
+ * @property passwordHash The hash of the user's new password.
  * @property keys A [KeysJson] object containing public and private keys.
  */
 @Serializable
@@ -20,11 +24,23 @@ data class SetPasswordRequestJson(
     @SerialName("masterPasswordHint")
     val passwordHint: String?,
 
-    @SerialName("masterPasswordAuthentication")
-    val authenticationData: MasterPasswordAuthenticationDataJson,
+    @SerialName("kdf")
+    val kdfType: KdfTypeJson? = null,
 
-    @SerialName("masterPasswordUnlock")
-    val unlockData: MasterPasswordUnlockDataJson,
+    @SerialName("kdfIterations")
+    val kdfIterations: Int? = null,
+
+    @SerialName("kdfMemory")
+    val kdfMemory: Int? = null,
+
+    @SerialName("kdfParallelism")
+    val kdfParallelism: Int? = null,
+
+    @SerialName("key")
+    val key: String,
+
+    @SerialName("masterPasswordHash")
+    val passwordHash: String?,
 
     @SerialName("keys")
     val keys: KeysJson?,
@@ -40,17 +56,12 @@ data class SetPasswordRequestJson(
     ) : this(
         organizationIdentifier = organizationIdentifier,
         passwordHint = passwordHint,
-        authenticationData = MasterPasswordAuthenticationDataJson(
-            kdf = kdf,
-            salt = salt,
-            masterPasswordAuthenticationHash = masterPasswordAuthenticationHash,
-        ),
-        unlockData = MasterPasswordUnlockDataJson(
-            kdf = kdf,
-            salt = salt,
-            masterKeyWrappedUserKey = masterKeyWrappedUserKey,
-            containedKeyId = null,
-        ),
+        kdfType = kdf.kdfType,
+        kdfIterations = kdf.iterations,
+        kdfMemory = kdf.memory,
+        kdfParallelism = kdf.parallelism,
+        key = masterKeyWrappedUserKey,
+        passwordHash = masterPasswordAuthenticationHash,
         keys = keys,
     )
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR switches the `SetPasswordRequestJson` model to use the original payload structure because the server updates are not fully ready for use. I have managed to maintain the same constructor signature to make the change very simple,
