### PR TITLE
PM-42467: feat: Add debug menu option to share settings

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -71,6 +71,8 @@ import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.garbage.GarbageCollectionManager
 import com.x8bit.bitwarden.data.platform.manager.garbage.GarbageCollectionManagerImpl
+import com.x8bit.bitwarden.data.platform.manager.log.SettingsLogManager
+import com.x8bit.bitwarden.data.platform.manager.log.SettingsLogManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConfigManager
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConfigManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
@@ -504,5 +506,21 @@ object PlatformManagerModule {
     ): NetworkPermissionManager = NetworkPermissionManagerImpl(
         context = context,
         resourceManager = resourceManager,
+    )
+
+    @Provides
+    @Singleton
+    fun provideSettingsLogManager(
+        settingsRepository: SettingsRepository,
+        logsManager: LogsManager,
+        autofillEnabledManager: AutofillEnabledManager,
+        accessibilityEnabledManager: AccessibilityEnabledManager,
+        browserThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager,
+    ): SettingsLogManager = SettingsLogManagerImpl(
+        settingsRepository = settingsRepository,
+        logsManager = logsManager,
+        autofillEnabledManager = autofillEnabledManager,
+        accessibilityEnabledManager = accessibilityEnabledManager,
+        browserThirdPartyAutofillEnabledManager = browserThirdPartyAutofillEnabledManager,
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/log/SettingsLogManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/log/SettingsLogManager.kt
@@ -1,0 +1,11 @@
+package com.x8bit.bitwarden.data.platform.manager.log
+
+/**
+ * Abstracts the collecting of information for sharing.
+ */
+interface SettingsLogManager {
+    /**
+     * A formatted string to be shared for debugging purposes.
+     */
+    val data: String
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/log/SettingsLogManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/log/SettingsLogManagerImpl.kt
@@ -1,0 +1,202 @@
+package com.x8bit.bitwarden.data.platform.manager.log
+
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserThirdPartyAutofillEnabledManager
+import com.x8bit.bitwarden.data.platform.manager.LogsManager
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.browser.util.toBrowserAutoFillSettingsOptions
+
+/**
+ * The default implementation for the [SettingsLogManager].
+ */
+internal class SettingsLogManagerImpl(
+    private val settingsRepository: SettingsRepository,
+    private val logsManager: LogsManager,
+    private val autofillEnabledManager: AutofillEnabledManager,
+    private val accessibilityEnabledManager: AccessibilityEnabledManager,
+    private val browserThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager,
+) : SettingsLogManager {
+    override val data: String
+        get() = StringBuilder()
+            .appendLine("=== Bitwarden Settings ===")
+            .appendLine("Account Security:")
+            .appendLine("  $biometricsString")
+            .appendLine("  $pinString")
+            .apply { pinMpOnRestartString?.let { appendLine("    $it") } }
+            .appendLine("  $authSyncString")
+            .appendLine("  $sessionTimeoutString")
+            .appendLine("  $sessionTimeoutActionString")
+            .appendLine("Autofill:")
+            .appendLine("  $autofillServiceString")
+            .apply { autofillTypeString?.let { appendLine("    $it") } }
+            .apply {
+                browserStrings.takeUnless { it.isEmpty() }?.let { list ->
+                    appendLine("  Browser integration:")
+                    list.forEach { appendLine("    $it") }
+                }
+            }
+            .appendLine("  $accessibilityEnabledString")
+            .appendLine("  $autofillAssistString")
+            .appendLine("  $copyTotpString")
+            .appendLine("  $askToAddItemString")
+            .appendLine("  $defaultUriMatchString")
+            .appendLine("Appearance:")
+            .appendLine("  $languageString")
+            .appendLine("  $themeString")
+            .appendLine("  $dynamicColorsString")
+            .appendLine("  $iconLoadingString")
+            .appendLine("Other:")
+            .appendLine("  $syncOnRefreshString")
+            .appendLine("  $clearClipboardString")
+            .appendLine("  $screenCaptureString")
+            .appendLine("About:")
+            .appendLine("  $crashLogsString")
+            .appendLine("  $flightRecorderString")
+            .toString()
+
+    private val biometricsString: String
+        get() = if (settingsRepository.isUnlockWithBiometricsEnabled) {
+            "Unlock with Biometrics: Enabled"
+        } else {
+            "Unlock with Biometrics: Disabled"
+        }
+
+    private val pinString: String
+        get() = if (settingsRepository.isUnlockWithPinEnabled) {
+            "Unlock with PIN: Enabled"
+        } else {
+            "Unlock with PIN: Disabled"
+        }
+
+    private val pinMpOnRestartString: String?
+        get() = if (settingsRepository.isUnlockWithPinEnabled) {
+            if (settingsRepository.isPasswordOnRestartRequiredWithPin) {
+                "Requires MP on restart: Enabled"
+            } else {
+                "Requires MP on restart: Disabled"
+            }
+        } else {
+            null
+        }
+
+    private val authSyncString: String
+        get() = if (settingsRepository.isAuthenticatorSyncEnabled) {
+            "Allow authenticator sync: Enabled"
+        } else {
+            "Allow authenticator sync: Disabled"
+        }
+
+    private val sessionTimeoutString: String
+        get() = settingsRepository.vaultTimeout.let { "Session timeout: $it" }
+
+    private val sessionTimeoutActionString: String
+        get() = settingsRepository.vaultTimeoutAction.let { "Session timeout action: $it" }
+
+    private val autofillServiceString: String
+        get() = if (autofillEnabledManager.isAutofillEnabled) {
+            "Autofill Service: Enabled"
+        } else {
+            "Autofill Service: Disabled"
+        }
+
+    private val autofillTypeString: String?
+        // Check for autofill service
+        get() = if (autofillEnabledManager.isAutofillEnabled) {
+            if (settingsRepository.isInlineAutofillEnabled) {
+                "Display autofill suggestions: Inline"
+            } else {
+                "Display autofill suggestions: Popup"
+            }
+        } else {
+            null
+        }
+
+    private val browserStrings: List<String>
+        get() = browserThirdPartyAutofillEnabledManager
+            .browserThirdPartyAutofillStatus
+            .toBrowserAutoFillSettingsOptions()
+            .map { "${it.browserPackage}: ${if (it.isEnabled) "On" else "Off"}" }
+
+    private val accessibilityEnabledString: String
+        get() = if (accessibilityEnabledManager.isAccessibilityEnabledStateFlow.value) {
+            "Use accessibility: Enabled"
+        } else {
+            "Use accessibility: Disabled"
+        }
+
+    private val autofillAssistString: String
+        get() = if (settingsRepository.isFillAssistEnabled) {
+            "Autofill assist: Enabled"
+        } else {
+            "Autofill assist: Disabled"
+        }
+
+    private val copyTotpString: String
+        get() = if (settingsRepository.isAutoCopyTotpDisabled) {
+            "Copy TOTP automatically: Disabled"
+        } else {
+            "Copy TOTP automatically: Enabled"
+        }
+
+    private val askToAddItemString: String
+        get() = if (settingsRepository.isAutofillSavePromptDisabled) {
+            "Ask to add item: Disabled"
+        } else {
+            "Ask to add item: Enabled"
+        }
+
+    private val defaultUriMatchString: String
+        get() = settingsRepository.defaultUriMatchType.let { "Default URI match detection: $it" }
+
+    private val languageString: String
+        get() = settingsRepository.appLanguage.let { "Language: $it" }
+
+    private val themeString: String
+        get() = settingsRepository.appTheme.let { "Theme: $it" }
+
+    private val dynamicColorsString: String
+        get() = if (settingsRepository.isDynamicColorsEnabled) {
+            "Use dynamic colors: Enabled"
+        } else {
+            "Use dynamic colors: Disabled"
+        }
+
+    private val iconLoadingString: String
+        get() = if (settingsRepository.isIconLoadingDisabled) {
+            "Show website icons: Disabled"
+        } else {
+            "Show website icons: Enabled"
+        }
+
+    private val syncOnRefreshString: String
+        get() = if (settingsRepository.getPullToRefreshEnabledFlow().value) {
+            "Allow sync on refresh: Enabled"
+        } else {
+            "Allow sync on refresh: Disabled"
+        }
+
+    private val clearClipboardString: String
+        get() = settingsRepository.clearClipboardFrequency.let { "Clear clipboard: $it" }
+
+    private val screenCaptureString: String
+        get() = if (settingsRepository.isScreenCaptureAllowed) {
+            "Allow screen capture: Enabled"
+        } else {
+            "Allow screen capture: Disabled"
+        }
+
+    private val crashLogsString: String
+        get() = if (logsManager.isEnabled) {
+            "Submit crash logs: Enabled"
+        } else {
+            "Submit crash logs: Disabled"
+        }
+
+    private val flightRecorderString: String
+        get() = if (settingsRepository.flightRecorderData.hasActiveFlightRecorderData) {
+            "Flight recorder: On"
+        } else {
+            "Flight recorder: Off"
+        }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -141,6 +141,12 @@ interface SettingsRepository : FlightRecorderManager {
     val isUnlockWithPinEnabledFlow: Flow<Boolean>
 
     /**
+     * Whether Master Password is required on restart when PIN unlocking is enabled for the
+     * current user.
+     */
+    val isPasswordOnRestartRequiredWithPin: Boolean
+
+    /**
      * Whether inline autofill is enabled for the current user.
      */
     var isInlineAutofillEnabled: Boolean

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -306,6 +306,11 @@ class SettingsRepositoryImpl(
             }
             ?: flowOf(false)
 
+    override val isPasswordOnRestartRequiredWithPin: Boolean
+        get() = activeUserId
+            ?.let { authDiskSource.getEphemeralPinProtectedUserKeyEnvelope(userId = it) != null }
+            ?: false
+
     override var isInlineAutofillEnabled: Boolean
         get() = activeUserId
             ?.let { settingsDiskSource.getInlineAutofillEnabled(userId = it) }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -40,6 +40,8 @@ import com.bitwarden.ui.platform.components.segment.BitwardenSegmentedButton
 import com.bitwarden.ui.platform.components.segment.SegmentedButtonState
 import com.bitwarden.ui.platform.components.segment.transition.segmentedContentTransform
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.bitwarden.ui.platform.composition.LocalIntentManager
+import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
@@ -57,6 +59,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 fun DebugMenuScreen(
     onNavigateBack: () -> Unit,
+    intentManager: IntentManager = LocalIntentManager.current,
     viewModel: DebugMenuViewModel = hiltViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
@@ -64,6 +67,7 @@ fun DebugMenuScreen(
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             DebugMenuEvent.NavigateBack -> onNavigateBack()
+            is DebugMenuEvent.ShareText -> intentManager.shareText(text = event.text)
         }
     }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
@@ -321,6 +325,15 @@ private fun ReportsSection(
                 .padding(horizontal = 16.dp),
         )
         Spacer(modifier = Modifier.height(height = 8.dp))
+        BitwardenFilledButton(
+            label = stringResource(id = BitwardenString.share_settings),
+            onClick = handler.onShareSettingsClick,
+            isEnabled = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+        Spacer(modifier = Modifier.height(height = 12.dp))
         BitwardenFilledButton(
             label = stringResource(id = BitwardenString.generate_error_report),
             onClick = handler.onGenerateErrorReportClick,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
@@ -11,6 +11,7 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.CookieAcquisitionRequestManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
+import com.x8bit.bitwarden.data.platform.manager.log.SettingsLogManager
 import com.x8bit.bitwarden.data.platform.manager.model.CookieAcquisitionRequest
 import com.x8bit.bitwarden.data.platform.repository.DebugMenuRepository
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
@@ -30,13 +31,14 @@ import javax.inject.Inject
 /**
  * ViewModel for the [DebugMenuScreen]
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class DebugMenuViewModel @Inject constructor(
     featureFlagManager: FeatureFlagManager,
     private val debugMenuRepository: DebugMenuRepository,
     private val authRepository: AuthRepository,
     private val logsManager: LogsManager,
+    private val settingsLogManager: SettingsLogManager,
     private val cookieAcquisitionRequestManager: CookieAcquisitionRequestManager,
     private val environmentRepository: EnvironmentRepository,
 ) : BaseViewModel<DebugMenuState, DebugMenuEvent, DebugMenuAction>(
@@ -74,6 +76,7 @@ class DebugMenuViewModel @Inject constructor(
             DebugMenuAction.ResetPremiumUpgradeBanner -> handleResetPremiumUpgradeBanner()
             DebugMenuAction.ShowUpgradedToPremiumCard -> handleShowUpgradedToPremiumCard()
             DebugMenuAction.ResetAccessibilityDisclaimer -> handleResetAccessibilityDisclaimer()
+            DebugMenuAction.ShareSettingsClick -> onShareSettingsClick()
             is DebugMenuAction.MainTypeOptionClick -> handleMainTypeOptionClick(action)
         }
     }
@@ -84,6 +87,10 @@ class DebugMenuViewModel @Inject constructor(
 
     private fun handleResetAccessibilityDisclaimer() {
         debugMenuRepository.resetAccessibilityDisclaimer()
+    }
+
+    private fun onShareSettingsClick() {
+        sendEvent(DebugMenuEvent.ShareText(text = settingsLogManager.data))
     }
 
     private fun handleShowUpgradedToPremiumCard() {
@@ -182,6 +189,11 @@ sealed class DebugMenuEvent {
      * Navigates back to previous screen.
      */
     data object NavigateBack : DebugMenuEvent()
+
+    /**
+     * Shares the given [text].
+     */
+    data class ShareText(val text: String) : DebugMenuEvent()
 }
 
 /**
@@ -262,6 +274,11 @@ sealed class DebugMenuAction {
      * User has clicked to force the "Upgraded to Premium" action card to display.
      */
     data object ShowUpgradedToPremiumCard : DebugMenuAction()
+
+    /**
+     * User has clicked the share settings button.
+     */
+    data object ShareSettingsClick : DebugMenuAction()
 
     /**
      * Internal actions not triggered from the UI.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/handler/DebugMenuHandler.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/handler/DebugMenuHandler.kt
@@ -24,6 +24,7 @@ class DebugMenuHandler(
     val onClearSsoCookies: () -> Unit,
     val onResetPremiumUpgradeBanner: () -> Unit,
     val onShowUpgradedToPremiumCard: () -> Unit,
+    val onShareSettingsClick: () -> Unit,
     val onGenerateErrorReportClick: () -> Unit,
     val onGenerateCrashClick: () -> Unit,
 ) {
@@ -63,6 +64,7 @@ class DebugMenuHandler(
             onShowUpgradedToPremiumCard = {
                 viewModel.trySendAction(DebugMenuAction.ShowUpgradedToPremiumCard)
             },
+            onShareSettingsClick = { viewModel.trySendAction(DebugMenuAction.ShareSettingsClick) },
             onGenerateErrorReportClick = {
                 viewModel.trySendAction(DebugMenuAction.GenerateErrorReportClick)
             },
@@ -86,6 +88,7 @@ class DebugMenuHandler(
             onClearSsoCookies = { },
             onResetPremiumUpgradeBanner = { },
             onShowUpgradedToPremiumCard = { },
+            onShareSettingsClick = { },
             onGenerateErrorReportClick = { },
             onGenerateCrashClick = { },
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/log/SettingsLogManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/log/SettingsLogManagerTest.kt
@@ -1,0 +1,389 @@
+package com.x8bit.bitwarden.data.platform.manager.log
+
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
+import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserThirdPartyAutofillEnabledManager
+import com.x8bit.bitwarden.data.autofill.model.browser.BrowserThirdPartyAutoFillData
+import com.x8bit.bitwarden.data.autofill.model.browser.BrowserThirdPartyAutofillStatus
+import com.x8bit.bitwarden.data.platform.manager.LogsManager
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
+import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
+import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
+import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
+import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SettingsLogManagerTest {
+    private val settingsRepository = mockk<SettingsRepository> {
+        every { isUnlockWithBiometricsEnabled } returns false
+        every { isUnlockWithPinEnabled } returns false
+        every { isPasswordOnRestartRequiredWithPin } returns false
+        every { isAuthenticatorSyncEnabled } returns false
+        every { vaultTimeout } returns VaultTimeout.FifteenMinutes
+        every { vaultTimeoutAction } returns VaultTimeoutAction.LOCK
+        every { isInlineAutofillEnabled } returns false
+        every { isFillAssistEnabled } returns false
+        every { isAutoCopyTotpDisabled } returns true
+        every { isAutofillSavePromptDisabled } returns true
+        every { defaultUriMatchType } returns UriMatchType.DOMAIN
+        every { appLanguage } returns AppLanguage.DEFAULT
+        every { appTheme } returns AppTheme.DEFAULT
+        every { isDynamicColorsEnabled } returns false
+        every { isIconLoadingDisabled } returns true
+        every { getPullToRefreshEnabledFlow() } returns MutableStateFlow(false)
+        every { clearClipboardFrequency } returns ClearClipboardFrequency.NEVER
+        every { isScreenCaptureAllowed } returns false
+        every { flightRecorderData } returns FlightRecorderDataSet(data = emptySet())
+    }
+    private val logsManager = mockk<LogsManager> {
+        every { isEnabled } returns false
+    }
+    private val autofillEnabledManager = mockk<AutofillEnabledManager> {
+        every { isAutofillEnabled } returns false
+    }
+    private val accessibilityEnabledManager = mockk<AccessibilityEnabledManager> {
+        every { isAccessibilityEnabledStateFlow } returns MutableStateFlow(false)
+    }
+    private val browserThirdPartyAutofillEnabledManager =
+        mockk<BrowserThirdPartyAutofillEnabledManager> {
+            every { browserThirdPartyAutofillStatus } returns UNAVAILABLE_BROWSER_AUTOFILL_STATUS
+        }
+
+    private val settingsLogManager: SettingsLogManager = SettingsLogManagerImpl(
+        settingsRepository = settingsRepository,
+        logsManager = logsManager,
+        autofillEnabledManager = autofillEnabledManager,
+        accessibilityEnabledManager = accessibilityEnabledManager,
+        browserThirdPartyAutofillEnabledManager = browserThirdPartyAutofillEnabledManager,
+    )
+
+    @Test
+    fun `data should report every setting as disabled when nothing is enabled`() {
+        assertEquals(
+            """
+            === Bitwarden Settings ===
+            Account Security:
+              Unlock with Biometrics: Disabled
+              Unlock with PIN: Disabled
+              Allow authenticator sync: Disabled
+              Session timeout: FifteenMinutes
+              Session timeout action: LOCK
+            Autofill:
+              Autofill Service: Disabled
+              Use accessibility: Disabled
+              Autofill assist: Disabled
+              Copy TOTP automatically: Disabled
+              Ask to add item: Disabled
+              Default URI match detection: DOMAIN
+            Appearance:
+              Language: DEFAULT
+              Theme: DEFAULT
+              Use dynamic colors: Disabled
+              Show website icons: Disabled
+            Other:
+              Allow sync on refresh: Disabled
+              Clear clipboard: NEVER
+              Allow screen capture: Disabled
+            About:
+              Submit crash logs: Disabled
+              Flight recorder: Off
+
+            """.trimIndent(),
+            settingsLogManager.data,
+        )
+    }
+
+    @Test
+    fun `data should report every setting as enabled when everything is enabled`() {
+        every { settingsRepository.isUnlockWithBiometricsEnabled } returns true
+        every { settingsRepository.isUnlockWithPinEnabled } returns true
+        every { settingsRepository.isPasswordOnRestartRequiredWithPin } returns true
+        every { settingsRepository.isAuthenticatorSyncEnabled } returns true
+        every { settingsRepository.vaultTimeout } returns VaultTimeout.Never
+        every { settingsRepository.vaultTimeoutAction } returns VaultTimeoutAction.LOGOUT
+        every { settingsRepository.isInlineAutofillEnabled } returns true
+        every { settingsRepository.isFillAssistEnabled } returns true
+        every { settingsRepository.isAutoCopyTotpDisabled } returns false
+        every { settingsRepository.isAutofillSavePromptDisabled } returns false
+        every { settingsRepository.defaultUriMatchType } returns UriMatchType.EXACT
+        every { settingsRepository.appLanguage } returns AppLanguage.ENGLISH
+        every { settingsRepository.appTheme } returns AppTheme.DARK
+        every { settingsRepository.isDynamicColorsEnabled } returns true
+        every { settingsRepository.isIconLoadingDisabled } returns false
+        every { settingsRepository.getPullToRefreshEnabledFlow() } returns MutableStateFlow(true)
+        every {
+            settingsRepository.clearClipboardFrequency
+        } returns ClearClipboardFrequency.TEN_SECONDS
+        every { settingsRepository.isScreenCaptureAllowed } returns true
+        every { settingsRepository.flightRecorderData } returns ACTIVE_FLIGHT_RECORDER_DATA_SET
+        every { logsManager.isEnabled } returns true
+        every { autofillEnabledManager.isAutofillEnabled } returns true
+        every {
+            accessibilityEnabledManager.isAccessibilityEnabledStateFlow
+        } returns MutableStateFlow(true)
+        every {
+            browserThirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        } returns ENABLED_BROWSER_AUTOFILL_STATUS
+
+        assertEquals(
+            """
+            === Bitwarden Settings ===
+            Account Security:
+              Unlock with Biometrics: Enabled
+              Unlock with PIN: Enabled
+                Requires MP on restart: Enabled
+              Allow authenticator sync: Enabled
+              Session timeout: Never
+              Session timeout action: LOGOUT
+            Autofill:
+              Autofill Service: Enabled
+                Display autofill suggestions: Inline
+              Browser integration:
+                BRAVE_RELEASE: On
+                CHROME_STABLE: On
+                CHROME_BETA: On
+                VIVALDI_STABLE: On
+              Use accessibility: Enabled
+              Autofill assist: Enabled
+              Copy TOTP automatically: Enabled
+              Ask to add item: Enabled
+              Default URI match detection: EXACT
+            Appearance:
+              Language: ENGLISH
+              Theme: DARK
+              Use dynamic colors: Enabled
+              Show website icons: Enabled
+            Other:
+              Allow sync on refresh: Enabled
+              Clear clipboard: TEN_SECONDS
+              Allow screen capture: Enabled
+            About:
+              Submit crash logs: Enabled
+              Flight recorder: On
+
+            """.trimIndent(),
+            settingsLogManager.data,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `data should report requires MP on restart as disabled when PIN unlock does not require it`() {
+        every { settingsRepository.isUnlockWithPinEnabled } returns true
+        every { settingsRepository.isPasswordOnRestartRequiredWithPin } returns false
+
+        assertEquals(
+            """
+            === Bitwarden Settings ===
+            Account Security:
+              Unlock with Biometrics: Disabled
+              Unlock with PIN: Enabled
+                Requires MP on restart: Disabled
+              Allow authenticator sync: Disabled
+              Session timeout: FifteenMinutes
+              Session timeout action: LOCK
+            Autofill:
+              Autofill Service: Disabled
+              Use accessibility: Disabled
+              Autofill assist: Disabled
+              Copy TOTP automatically: Disabled
+              Ask to add item: Disabled
+              Default URI match detection: DOMAIN
+            Appearance:
+              Language: DEFAULT
+              Theme: DEFAULT
+              Use dynamic colors: Disabled
+              Show website icons: Disabled
+            Other:
+              Allow sync on refresh: Disabled
+              Clear clipboard: NEVER
+              Allow screen capture: Disabled
+            About:
+              Submit crash logs: Disabled
+              Flight recorder: Off
+
+            """.trimIndent(),
+            settingsLogManager.data,
+        )
+    }
+
+    @Test
+    fun `data should omit the requires MP on restart entry when PIN unlock is disabled`() {
+        every { settingsRepository.isUnlockWithPinEnabled } returns false
+        every { settingsRepository.isPasswordOnRestartRequiredWithPin } returns true
+
+        assertEquals(
+            """
+            === Bitwarden Settings ===
+            Account Security:
+              Unlock with Biometrics: Disabled
+              Unlock with PIN: Disabled
+              Allow authenticator sync: Disabled
+              Session timeout: FifteenMinutes
+              Session timeout action: LOCK
+            Autofill:
+              Autofill Service: Disabled
+              Use accessibility: Disabled
+              Autofill assist: Disabled
+              Copy TOTP automatically: Disabled
+              Ask to add item: Disabled
+              Default URI match detection: DOMAIN
+            Appearance:
+              Language: DEFAULT
+              Theme: DEFAULT
+              Use dynamic colors: Disabled
+              Show website icons: Disabled
+            Other:
+              Allow sync on refresh: Disabled
+              Clear clipboard: NEVER
+              Allow screen capture: Disabled
+            About:
+              Submit crash logs: Disabled
+              Flight recorder: Off
+
+            """.trimIndent(),
+            settingsLogManager.data,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `data should report the autofill suggestion display as popup when inline autofill is disabled`() {
+        every { autofillEnabledManager.isAutofillEnabled } returns true
+        every { settingsRepository.isInlineAutofillEnabled } returns false
+
+        assertEquals(
+            """
+            === Bitwarden Settings ===
+            Account Security:
+              Unlock with Biometrics: Disabled
+              Unlock with PIN: Disabled
+              Allow authenticator sync: Disabled
+              Session timeout: FifteenMinutes
+              Session timeout action: LOCK
+            Autofill:
+              Autofill Service: Enabled
+                Display autofill suggestions: Popup
+              Use accessibility: Disabled
+              Autofill assist: Disabled
+              Copy TOTP automatically: Disabled
+              Ask to add item: Disabled
+              Default URI match detection: DOMAIN
+            Appearance:
+              Language: DEFAULT
+              Theme: DEFAULT
+              Use dynamic colors: Disabled
+              Show website icons: Disabled
+            Other:
+              Allow sync on refresh: Disabled
+              Clear clipboard: NEVER
+              Allow screen capture: Disabled
+            About:
+              Submit crash logs: Disabled
+              Flight recorder: Off
+
+            """.trimIndent(),
+            settingsLogManager.data,
+        )
+    }
+
+    @Test
+    fun `data should only list the browsers that have third party autofill available`() {
+        every {
+            browserThirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        } returns BrowserThirdPartyAutofillStatus(
+            braveStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
+            chromeStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = true,
+            ),
+            chromeBetaChannelStatusData = UNAVAILABLE_BROWSER_AUTOFILL_DATA,
+            vivaldiStableChannelStatusData = UNAVAILABLE_BROWSER_AUTOFILL_DATA,
+            defaultBrowserPackageName = null,
+        )
+
+        assertEquals(
+            """
+            === Bitwarden Settings ===
+            Account Security:
+              Unlock with Biometrics: Disabled
+              Unlock with PIN: Disabled
+              Allow authenticator sync: Disabled
+              Session timeout: FifteenMinutes
+              Session timeout action: LOCK
+            Autofill:
+              Autofill Service: Disabled
+              Browser integration:
+                BRAVE_RELEASE: Off
+                CHROME_STABLE: On
+              Use accessibility: Disabled
+              Autofill assist: Disabled
+              Copy TOTP automatically: Disabled
+              Ask to add item: Disabled
+              Default URI match detection: DOMAIN
+            Appearance:
+              Language: DEFAULT
+              Theme: DEFAULT
+              Use dynamic colors: Disabled
+              Show website icons: Disabled
+            Other:
+              Allow sync on refresh: Disabled
+              Clear clipboard: NEVER
+              Allow screen capture: Disabled
+            About:
+              Submit crash logs: Disabled
+              Flight recorder: Off
+
+            """.trimIndent(),
+            settingsLogManager.data,
+        )
+    }
+}
+
+private val UNAVAILABLE_BROWSER_AUTOFILL_DATA = BrowserThirdPartyAutoFillData(
+    isAvailable = false,
+    isThirdPartyEnabled = false,
+)
+
+private val ENABLED_BROWSER_AUTOFILL_DATA = BrowserThirdPartyAutoFillData(
+    isAvailable = true,
+    isThirdPartyEnabled = true,
+)
+
+private val UNAVAILABLE_BROWSER_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
+    braveStableStatusData = UNAVAILABLE_BROWSER_AUTOFILL_DATA,
+    chromeStableStatusData = UNAVAILABLE_BROWSER_AUTOFILL_DATA,
+    chromeBetaChannelStatusData = UNAVAILABLE_BROWSER_AUTOFILL_DATA,
+    vivaldiStableChannelStatusData = UNAVAILABLE_BROWSER_AUTOFILL_DATA,
+    defaultBrowserPackageName = null,
+)
+
+private val ENABLED_BROWSER_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
+    braveStableStatusData = ENABLED_BROWSER_AUTOFILL_DATA,
+    chromeStableStatusData = ENABLED_BROWSER_AUTOFILL_DATA,
+    chromeBetaChannelStatusData = ENABLED_BROWSER_AUTOFILL_DATA,
+    vivaldiStableChannelStatusData = ENABLED_BROWSER_AUTOFILL_DATA,
+    defaultBrowserPackageName = null,
+)
+
+private val ACTIVE_FLIGHT_RECORDER_DATA_SET = FlightRecorderDataSet(
+    data = setOf(
+        FlightRecorderDataSet.FlightRecorderData(
+            id = "id",
+            fileName = "fileName",
+            startTimeMs = 0L,
+            durationMs = 100L,
+            isActive = true,
+        ),
+    ),
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -669,6 +669,33 @@ class SettingsRepositoryTest {
         assertTrue(settingsRepository.isUnlockWithPinEnabled)
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `isPasswordOnRestartRequiredWithPin should return a value that tracks the existence of an ephemeral PIN protected user key envelope for the current user`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAuthDiskSource.storeEphemeralPinProtectedUserKeyEnvelope(
+            userId = USER_ID,
+            pinProtectedUserKeyEnvelope = null,
+        )
+        assertFalse(settingsRepository.isPasswordOnRestartRequiredWithPin)
+
+        fakeAuthDiskSource.storeEphemeralPinProtectedUserKeyEnvelope(
+            userId = USER_ID,
+            pinProtectedUserKeyEnvelope = "ephemeralPinProtectedUserKeyEnvelope",
+        )
+        assertTrue(settingsRepository.isPasswordOnRestartRequiredWithPin)
+    }
+
+    @Test
+    fun `isPasswordOnRestartRequiredWithPin should return false when there is no active user`() {
+        fakeAuthDiskSource.storeEphemeralPinProtectedUserKeyEnvelope(
+            userId = USER_ID,
+            pinProtectedUserKeyEnvelope = "ephemeralPinProtectedUserKeyEnvelope",
+        )
+
+        assertFalse(settingsRepository.isPasswordOnRestartRequiredWithPin)
+    }
+
     @Test
     fun `isInlineAutofillEnabled should pull from and update SettingsDiskSource`() {
         fakeAuthDiskSource.userState = MOCK_USER_STATE

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
@@ -7,9 +7,12 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.ui.platform.manager.IntentManager
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,10 +29,15 @@ class DebugMenuScreenTest : BitwardenComposeTest() {
         every { stateFlow } returns mutableStateFlow
         every { eventFlow } returns mutableEventFlow
     }
+    private val intentManager = mockk<IntentManager> {
+        every { shareText(text = any()) } just runs
+    }
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             DebugMenuScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,
@@ -50,6 +58,25 @@ class DebugMenuScreenTest : BitwardenComposeTest() {
             .performClick()
 
         verify { viewModel.trySendAction(DebugMenuAction.NavigateBack) }
+    }
+
+    @Test
+    fun `on ShareText event should share the text via the IntentManager`() {
+        mutableEventFlow.tryEmit(DebugMenuEvent.ShareText(text = "settingsLogData"))
+
+        verify(exactly = 1) { intentManager.shareText(text = "settingsLogData") }
+    }
+
+    @Test
+    fun `on share settings click should send ShareSettingsClick action`() {
+        mutableStateFlow.update { it.copy(mainTypeOption = DebugMenuState.MainTypeOption.OPTIONS) }
+        composeTestRule
+            .onNodeWithText(text = "Share settings")
+            .performScrollTo()
+            .assertIsEnabled()
+            .performClick()
+
+        verify(exactly = 1) { viewModel.trySendAction(DebugMenuAction.ShareSettingsClick) }
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -8,6 +8,7 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.CookieAcquisitionRequestManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
+import com.x8bit.bitwarden.data.platform.manager.log.SettingsLogManager
 import com.x8bit.bitwarden.data.platform.manager.model.CookieAcquisitionRequest
 import com.x8bit.bitwarden.data.platform.repository.DebugMenuRepository
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
@@ -50,6 +51,9 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
 
     private val logsManager = mockk<LogsManager> {
         every { trackNonFatalException(throwable = any()) } just runs
+    }
+    private val settingsLogManager = mockk<SettingsLogManager> {
+        every { data } returns "settingsLogData"
     }
 
     private val mockCookieAcquisitionRequestManager =
@@ -212,11 +216,25 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
             viewModel.eventFlow.test { expectNoEvents() }
         }
 
+    @Test
+    fun `ShareSettingsClick should emit ShareText with the settings log data`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(DebugMenuAction.ShareSettingsClick)
+            assertEquals(
+                DebugMenuEvent.ShareText(text = "settingsLogData"),
+                awaitItem(),
+            )
+        }
+    }
+
     private fun createViewModel(): DebugMenuViewModel = DebugMenuViewModel(
         featureFlagManager = mockFeatureFlagManager,
         debugMenuRepository = mockDebugMenuRepository,
         authRepository = mockAuthRepository,
         logsManager = logsManager,
+        settingsLogManager = settingsLogManager,
         cookieAcquisitionRequestManager = mockCookieAcquisitionRequestManager,
         environmentRepository = fakeEnvironmentRepository,
     )

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -33,6 +33,7 @@
     <string name="generate_crash">Generate crash</string>
     <string name="generate_error_report">Generate error report</string>
     <string name="error_reports">Error reports</string>
+    <string name="share_settings">Share settings</string>
     <string name="cookies">Cookies</string>
     <string name="premium">Premium</string>
     <string name="reset_premium_upgrade_banner">Reset Premium upgrade banner</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42467](https://bitwarden.atlassian.net/browse/PM-42467)

## 📔 Objective

This PR adds a `Share settings` button to the debug menu, allowing testers to share data relevant to the device state.


[PM-42467]: https://bitwarden.atlassian.net/browse/PM-42467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ