### PR TITLE
fix: Pin release candidate to Source Fastlane track to prevent stale promotions

### DIFF
--- a/.github/workflows/build-authenticator.yml
+++ b/.github/workflows/build-authenticator.yml
@@ -239,7 +239,12 @@ jobs:
           serviceCredentialsFile:"$PLAY_STORE_CREDS_FILE" \
 
       - name: Pin release to Source Fastlane track
-        if: ${{ matrix.variant == 'aab' && env.PUBLISH_TO_PLAY_STORE == 'true' }}
+        # Gated to release/* branches only: main pushes build continuously and would
+        # otherwise overwrite this track just as often as "internal" does, reintroducing
+        # the exact staleness bug this step exists to fix. Release candidates are cut on
+        # dedicated release/<version>-rcN branches, so pinning only there keeps the
+        # candidate stable on Source Fastlane until the next RC is cut.
+        if: ${{ matrix.variant == 'aab' && env.PUBLISH_TO_PLAY_STORE == 'true' && startsWith(github.ref, 'refs/heads/release/') }}
         env:
           PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/authenticator_play_store-creds.json
           VERSION_CODE: ${{ needs.version.outputs.version_number || github.run_number }}

--- a/.github/workflows/build-authenticator.yml
+++ b/.github/workflows/build-authenticator.yml
@@ -237,3 +237,19 @@ jobs:
         run: |
           bundle exec fastlane publishAuthenticatorReleaseToGooglePlayStore \
           serviceCredentialsFile:"$PLAY_STORE_CREDS_FILE" \
+
+      - name: Pin release to Source Fastlane track
+        if: ${{ matrix.variant == 'aab' && env.PUBLISH_TO_PLAY_STORE == 'true' }}
+        env:
+          PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/authenticator_play_store-creds.json
+          VERSION_CODE: ${{ needs.version.outputs.version_number || github.run_number }}
+          VERSION_NAME: ${{ needs.version.outputs.version_name }}
+        run: |
+          bundle exec fastlane promoteToProduction \
+          packageName:"com.bitwarden.authenticator" \
+          serviceCredentialsFile:"$PLAY_STORE_CREDS_FILE" \
+          track:"internal" \
+          trackPromoteTo:"Source Fastlane" \
+          versionCode:"$VERSION_CODE" \
+          versionName:"$VERSION_NAME" \
+          rolloutPercentage:"1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -334,6 +334,22 @@ jobs:
           bundle exec fastlane publishProdToPlayStore
           bundle exec fastlane publishBetaToPlayStore
 
+      - name: Pin release to Source Fastlane track
+        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' && env.PUBLISH_TO_PLAY_STORE == 'true' }}
+        env:
+          PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/play_creds.json
+          VERSION_CODE: ${{ needs.version.outputs.version_number || github.run_number }}
+          VERSION_NAME: ${{ needs.version.outputs.version_name }}
+        run: |
+          bundle exec fastlane promoteToProduction \
+          packageName:"com.x8bit.bitwarden" \
+          serviceCredentialsFile:"$PLAY_STORE_CREDS_FILE" \
+          track:"internal" \
+          trackPromoteTo:"Source Fastlane" \
+          versionCode:"$VERSION_CODE" \
+          versionName:"$VERSION_NAME" \
+          rolloutPercentage:"1"
+
   publish_fdroid:
     name: Publish F-Droid artifacts
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,7 +335,12 @@ jobs:
           bundle exec fastlane publishBetaToPlayStore
 
       - name: Pin release to Source Fastlane track
-        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' && env.PUBLISH_TO_PLAY_STORE == 'true' }}
+        # Gated to release/* branches only: main pushes build continuously and would
+        # otherwise overwrite this track just as often as "internal" does, reintroducing
+        # the exact staleness bug this step exists to fix. Release candidates are cut on
+        # dedicated release/<version>-rcN branches, so pinning only there keeps the
+        # candidate stable on Source Fastlane until the next RC is cut.
+        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' && env.PUBLISH_TO_PLAY_STORE == 'true' && startsWith(github.ref, 'refs/heads/release/') }}
         env:
           PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/play_creds.json
           VERSION_CODE: ${{ needs.version.outputs.version_number || github.run_number }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -570,12 +570,18 @@ platform :android do
       release_options[:version_name] = options[:versionName]
     end
 
-    # Only override json_key if an explicit credentials file is provided (e.g. when this
-    # lane is invoked for a package whose credentials aren't at the Appfile default path,
-    # such as com.bitwarden.authenticator). When omitted, supply() falls back to the
-    # Appfile default (secrets/play_creds.json), preserving existing behavior.
+    # Resolve json_key the same way getLivePlayStoreVersion/getLatestPlayStoreVersion do:
+    # honor an explicit override, otherwise map from packageName. Needed so existing callers
+    # that never pass serviceCredentialsFile (e.g. bitwarden/deploy's production-promotion
+    # workflow) still authenticate with the right key for com.bitwarden.authenticator instead
+    # of silently falling through to the Appfile default (secrets/play_creds.json).
     if options[:serviceCredentialsFile]
       release_options[:json_key] = options[:serviceCredentialsFile]
+    else
+      case options[:packageName]
+      when "com.bitwarden.authenticator"
+        release_options[:json_key] = "secrets/authenticator_play_store-creds.json"
+      end
     end
 
     if options[:releaseNotes].nil? or options[:releaseNotes].to_s.empty?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -570,6 +570,14 @@ platform :android do
       release_options[:version_name] = options[:versionName]
     end
 
+    # Only override json_key if an explicit credentials file is provided (e.g. when this
+    # lane is invoked for a package whose credentials aren't at the Appfile default path,
+    # such as com.bitwarden.authenticator). When omitted, supply() falls back to the
+    # Appfile default (secrets/play_creds.json), preserving existing behavior.
+    if options[:serviceCredentialsFile]
+      release_options[:json_key] = options[:serviceCredentialsFile]
+    end
+
     if options[:releaseNotes].nil? or options[:releaseNotes].to_s.empty?
       release_options[:skip_upload_metadata] = true
     else


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket — this comes from investigating recurring "Cannot find release with version code" failures observed in bitwarden/deploy's Android production-promotion workflow runs on 2026-09-03 (Authenticator) and 2026-08-20 (Password Manager).

## 📔 Objective

Promoting a build from Play Store `internal` → `production` intermittently fails because Google's Play API only returns the latest release per track, and continuous `main`-branch builds supersede the release candidate before someone runs the promotion workflow. There's an existing manual workaround (a second track named `Source Fastlane`) but nothing keeps it fresh, so it goes stale too.

This adds a new CI step — gated to `release/*` branch builds only, not every `main` push — that pins the just-uploaded `internal` release onto `Source Fastlane` immediately after upload, before any later build can supersede it. Reuses the existing `promoteToProduction` fastlane lane.

Also fixes a credentials-resolution gap: `promoteToProduction`'s new `serviceCredentialsFile` override now falls back to the correct Authenticator credentials file by package name (matching the pattern already used by `getLivePlayStoreVersion`), so the real `bitwarden/deploy` caller — which never passes this override — authenticates correctly for `com.bitwarden.authenticator` instead of silently using the Password Manager's credentials.

Reviewed locally via `/bitwarden-code-review:code-review-local`. Addressed the important finding (pin was originally unscoped to release branches, which would have made it just as volatile as `internal`) and the suggested finding (credentials fallback) before opening this PR.

## 📸 Screenshots

N/A — CI workflow / Fastfile change only.
