### PR TITLE
[PM-36376] fix: Clear folder and owner dropdown lag after a card scan

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -92,6 +93,7 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
         },
     )
 
+    val focusManager = LocalFocusManager.current
     val isAdditionalOptionsExpanded = rememberSaveable { mutableStateOf(value = false) }
     val windowAdaptiveInfo = currentWindowAdaptiveInfo()
     LazyColumn(modifier = modifier, state = lazyListState) {
@@ -193,7 +195,12 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
                     id = vfo1Foundation(BitwardenString.my_folder, BitwardenString.folder),
                 ),
                 selectedOption = state.common.selectedFolder?.name,
-                onClick = commonTypeHandlers.onSelectOrAddFolderForItem,
+                onClick = {
+                    // Clear any current focused item, such as an unrelated text field, so the
+                    // soft keyboard is not animating away while the bottom sheet animates in.
+                    focusManager.clearFocus()
+                    commonTypeHandlers.onSelectOrAddFolderForItem()
+                },
                 cardStyle = if (isAddItemMode && state.common.hasOrganizations) {
                     CardStyle.Top(dividerPadding = 0.dp)
                 } else {
@@ -214,7 +221,12 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
                         id = vfo1Foundation(BitwardenString.vault, BitwardenString.owner),
                     ),
                     selectedOption = state.common.selectedOwner?.name?.invoke(),
-                    onClick = commonTypeHandlers.onPresentOwnerOptions,
+                    onClick = {
+                        // Clear any current focused item, such as an unrelated text field, so the
+                        // soft keyboard is not animating away while the bottom sheet animates in.
+                        focusManager.clearFocus()
+                        commonTypeHandlers.onPresentOwnerOptions()
+                    },
                     cardStyle = if (collections.isNotEmpty()) {
                         CardStyle.Middle()
                     } else {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertTextContains
@@ -3419,6 +3420,30 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `clicking a Ownership option should clear focus from the focused text field`() {
+        mutableStateFlow.value = DEFAULT_STATE_CARD
+        updateStateWithOwners()
+        composeTestRule.waitForIdle()
+        mutableEventFlow.tryEmit(VaultAddEditEvent.FocusCardHolderName)
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithTag("CardholderNameEntry")
+            .performScrollTo()
+            .assertIsFocused()
+
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(
+                label = "My vault. Vault",
+            )
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag("CardholderNameEntry")
+            .performScrollTo()
+            .assertIsNotFocused()
+    }
+
+    @Test
     fun `should show owner selection bottom sheet when state updates to OwnerSelection`() {
         mutableStateFlow.update {
             it.copy(bottomSheetState = VaultAddEditState.BottomSheetState.OwnerSelection)
@@ -3617,6 +3642,28 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
                 VaultAddEditAction.Common.SelectOrAddFolderForItem,
             )
         }
+    }
+
+    @Test
+    fun `clicking a Folder Option should clear focus from the focused text field`() {
+        mutableStateFlow.value = DEFAULT_STATE_CARD
+        updateStateWithFolders()
+        composeTestRule.waitForIdle()
+        mutableEventFlow.tryEmit(VaultAddEditEvent.FocusCardHolderName)
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithTag("CardholderNameEntry")
+            .performScrollTo()
+            .assertIsFocused()
+
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "No Folder. My folder")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag("CardholderNameEntry")
+            .performScrollTo()
+            .assertIsNotFocused()
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36376

## 📔 Objective

- Scanning a card auto-focuses the cardholder name field, so the keyboard is up. Tapping
  the folder dropdown then made the sheet stutter on its way in.
- The folder and owner selectors now clear focus first, like the "Add field" button in
  this screen already does.
- Added two regression tests. Both fail without the fix.

