### PR TITLE
[QA-2428] Add testTag to the Make a copy button on the View Send screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
@@ -257,6 +257,7 @@ private fun ViewStateContent(
                 actionButton = BitwardenButtonData(
                     label = BitwardenString.make_a_copy.asText(),
                     onClick = onMakeACopyClick,
+                    testTag = "SendMakeACopyButton",
                 )
                     .takeIf { _ -> it.isCopyable },
                 leadingContent = {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/QA-2428

## 📔 Objective

The "Make a copy" action on the View Send policy-restriction banner had no stable identifier, so QA automation (QA-2416, Testmo 10268506) currently locates it by its localized English content-desc ("Make a copy") — fragile under a non-English locale or a wording change.

This adds a static `testTag = "SendMakeACopyButton"` to the existing `BitwardenButtonData`, surfaced as an Appium `resource-id` via `testTagsAsResourceId`, matching the sibling `SendPolicyRestrictionBanner` tag on the same card. No behavioral or visual change.

## 📸 Screenshots

N/A — no UI change (adds a test identifier only).