### PR TITLE
[PM-43126] Add NixgramX to FIDO2 community privileged allow list

### DIFF
--- a/app/src/main/assets/fido2_privileged_community.json
+++ b/app/src/main/assets/fido2_privileged_community.json
@@ -3,6 +3,18 @@
     {
       "type": "android",
       "info": {
+        "package_name": "app.nixgramx.android",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "52:54:81:59:97:91:41:62:6E:E5:B4:07:B8:4E:E7:0A:33:44:ED:91:29:7F:5F:BE:8E:91:DF:8F:0C:29:A3:1C"
+          }
+        ]
+      }
+    },
+    {
+      "type": "android",
+      "info": {
         "package_name": "com.iode.firefox",
         "signatures": [
           {


### PR DESCRIPTION
## Summary
Adds `app.nixgramx.android` to `fido2_privileged_community.json` so Bitwarden can honor Credential Manager `setOrigin(https://telegram.org)` from this open-source Telegram client fork.

Official Telegram uses `telegram.org` Digital Asset Links (unavailable to forks). Without an allowlist entry, passkeys fail with origin/signature errors unless the user somehow trusts the caller.

## App details
- Package: `app.nixgramx.android`
- Release cert SHA-256: `52:54:81:59:97:91:41:62:6E:E5:B4:07:B8:4E:E7:0A:33:44:ED:91:29:7F:5F:BE:8E:91:DF:8F:0C:29:A3:1C`
- Source: https://github.com/Anndy999/NixgramX

## Test plan
- [ ] Asset/JSON CI checks pass
- [ ] Bitwarden build with this entry: NixgramX passkey flow with preferred provider Bitwarden