### PR TITLE
[PM-43134] Match the WebAuthn spec when parsing passkey creation options

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/model/PasskeyAttestationOptions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/model/PasskeyAttestationOptions.kt
@@ -4,15 +4,17 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Models FIDO 2 credential creation request options received from a Relying Party (RP).
+ * Models FIDO 2 credential creation request options received from a Relying Party (RP),
+ * based off the spec found at:
+ * https://www.w3.org/TR/webauthn-2/#dictionary-makecredentialoptions
  */
 @Serializable
 data class PasskeyAttestationOptions(
     @SerialName("authenticatorSelection")
-    val authenticatorSelection: AuthenticatorSelectionCriteria,
+    val authenticatorSelection: AuthenticatorSelectionCriteria? = null,
     @SerialName("challenge")
     val challenge: String,
-    @SerialName("excludedCredentials")
+    @SerialName("excludeCredentials")
     val excludeCredentials: List<PublicKeyCredentialDescriptor> = emptyList(),
     @SerialName("pubKeyCredParams")
     val pubKeyCredParams: List<PublicKeyCredentialParameters>,
@@ -42,7 +44,7 @@ data class PasskeyAttestationOptions(
             @SerialName("platform")
             PLATFORM,
 
-            @SerialName("cross_platform")
+            @SerialName("cross-platform")
             CROSS_PLATFORM,
         }
 
@@ -51,6 +53,12 @@ data class PasskeyAttestationOptions(
          */
         @Serializable
         enum class ResidentKeyRequirement {
+            /**
+             * Resident keys are not preferred during selection.
+             */
+            @SerialName("discouraged")
+            DISCOURAGED,
+
             /**
              * Resident keys are preferred during selection, if supported.
              */

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/model/PasskeyAttestationOptionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/model/PasskeyAttestationOptionsTest.kt
@@ -1,0 +1,197 @@
+package com.x8bit.bitwarden.data.credentials.model
+
+import com.bitwarden.core.data.util.decodeFromStringOrNull
+import com.bitwarden.core.di.CoreModule
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+
+class PasskeyAttestationOptionsTest {
+
+    private val json = CoreModule.providesJson(buildInfoManager = mockk(relaxed = true))
+
+    @Test
+    fun `options without authenticatorSelection should be deserialized`() {
+        val result = json.decodeFromStringOrNull<PasskeyAttestationOptions>(
+            OPTIONS_WITHOUT_AUTHENTICATOR_SELECTION_JSON,
+        )
+
+        assertNotNull(result)
+        assertEquals(RELYING_PARTY_ID, result.relyingParty.id)
+    }
+
+    @Test
+    fun `excludeCredentials should be deserialized from the spec member name`() {
+        val result = json.decodeFromStringOrNull<PasskeyAttestationOptions>(OPTIONS_JSON)
+
+        assertNotNull(result)
+        assertEquals(
+            listOf(EXCLUDED_CREDENTIAL_ID),
+            result.excludeCredentials.map { it.id },
+        )
+    }
+
+    @Test
+    fun `excludeCredentials should be serialized with the spec member name`() {
+        val options = createOptions(
+            excludeCredentials = listOf(
+                PublicKeyCredentialDescriptor(
+                    type = "public-key",
+                    id = EXCLUDED_CREDENTIAL_ID,
+                    transports = null,
+                ),
+            ),
+        )
+
+        val result = json.encodeToString(options)
+
+        assertTrue(result.contains("\"excludeCredentials\""))
+        assertFalse(result.contains("\"excludedCredentials\""))
+    }
+
+    @Test
+    fun `cross-platform attachment should be deserialized from the spec value`() {
+        val result = json.decodeFromStringOrNull<PasskeyAttestationOptions>(OPTIONS_JSON)
+
+        assertNotNull(result)
+        assertEquals(
+            PasskeyAttestationOptions
+                .AuthenticatorSelectionCriteria
+                .AuthenticatorAttachment
+                .CROSS_PLATFORM,
+            result.authenticatorSelection?.authenticatorAttachment,
+        )
+    }
+
+    @Test
+    fun `cross-platform attachment should be serialized with the spec value`() {
+        val options = createOptions(
+            authenticatorSelection = PasskeyAttestationOptions.AuthenticatorSelectionCriteria(
+                authenticatorAttachment = PasskeyAttestationOptions
+                    .AuthenticatorSelectionCriteria
+                    .AuthenticatorAttachment
+                    .CROSS_PLATFORM,
+            ),
+        )
+
+        val result = json.encodeToString(options)
+
+        assertTrue(result.contains("\"cross-platform\""))
+        assertFalse(result.contains("\"cross_platform\""))
+    }
+
+    @Test
+    fun `discouraged residentKey should be deserialized from the spec value`() {
+        val result = json.decodeFromStringOrNull<PasskeyAttestationOptions>(OPTIONS_JSON)
+
+        assertNotNull(result)
+        assertEquals(
+            PasskeyAttestationOptions
+                .AuthenticatorSelectionCriteria
+                .ResidentKeyRequirement
+                .DISCOURAGED,
+            result.authenticatorSelection?.residentKeyRequirement,
+        )
+    }
+
+    @Test
+    fun `discouraged residentKey should be serialized with the spec value`() {
+        val options = createOptions(
+            authenticatorSelection = PasskeyAttestationOptions.AuthenticatorSelectionCriteria(
+                residentKeyRequirement = PasskeyAttestationOptions
+                    .AuthenticatorSelectionCriteria
+                    .ResidentKeyRequirement
+                    .DISCOURAGED,
+            ),
+        )
+
+        val result = json.encodeToString(options)
+
+        assertTrue(result.contains("\"discouraged\""))
+    }
+}
+
+private const val RELYING_PARTY_ID = "www.bitwarden.com"
+private const val EXCLUDED_CREDENTIAL_ID = "mockCredentialId"
+
+private fun createOptions(
+    authenticatorSelection: PasskeyAttestationOptions.AuthenticatorSelectionCriteria? = null,
+    excludeCredentials: List<PublicKeyCredentialDescriptor> = emptyList(),
+): PasskeyAttestationOptions = PasskeyAttestationOptions(
+    authenticatorSelection = authenticatorSelection,
+    challenge = "tZ1rLJ_paLC8IMmg",
+    excludeCredentials = excludeCredentials,
+    pubKeyCredParams = listOf(
+        PasskeyAttestationOptions.PublicKeyCredentialParameters(
+            type = "public-key",
+            alg = -7.0,
+        ),
+    ),
+    relyingParty = PasskeyAttestationOptions.PublicKeyCredentialRpEntity(
+        id = RELYING_PARTY_ID,
+        name = "mockRpName",
+    ),
+    user = PasskeyAttestationOptions.PublicKeyCredentialUserEntity(
+        id = "UmhpTE9NOUY",
+        name = "mockUserName",
+        displayName = "mockDisplayName",
+    ),
+)
+
+private val OPTIONS_JSON = """
+{
+  "authenticatorSelection": {
+    "authenticatorAttachment": "cross-platform",
+    "residentKey": "discouraged",
+    "userVerification": "preferred"
+  },
+  "challenge": "tZ1rLJ_paLC8IMmg",
+  "excludeCredentials": [
+    {
+      "type": "public-key",
+      "id": "$EXCLUDED_CREDENTIAL_ID"
+    }
+  ],
+  "pubKeyCredParams": [
+    {
+      "alg": -7,
+      "type": "public-key"
+    }
+  ],
+  "rp": {
+    "id": "$RELYING_PARTY_ID",
+    "name": "mockRpName"
+  },
+  "user": {
+    "displayName": "mockDisplayName",
+    "id": "UmhpTE9NOUY",
+    "name": "mockUserName"
+  }
+}
+"""
+    .trimIndent()
+
+private val OPTIONS_WITHOUT_AUTHENTICATOR_SELECTION_JSON = """
+{
+  "challenge": "tZ1rLJ_paLC8IMmg",
+  "pubKeyCredParams": [
+    {
+      "alg": -7,
+      "type": "public-key"
+    }
+  ],
+  "rp": {
+    "id": "$RELYING_PARTY_ID",
+    "name": "mockRpName"
+  },
+  "user": {
+    "displayName": "mockDisplayName",
+    "id": "UmhpTE9NOUY",
+    "name": "mockUserName"
+  }
+}
+"""
+    .trimIndent()


### PR DESCRIPTION
## 🎟️ Tracking

#7359

## 📔 Objective

`PasskeyAttestationOptions` does not match `PublicKeyCredentialCreationOptionsJSON`. There are four mismatches. One breaks registration outright, the other three lose data without an error.

**`authenticatorSelection` was required.** The spec marks only `rp`, `user`, `challenge` and `pubKeyCredParams` as required. A request that omits `authenticatorSelection` currently fails to deserialize with `MissingFieldException`, so `getPasskeyAttestationOptionsOrNull` returns null and registration ends in `Error.MissingHostUrl` for an unprivileged caller, or `Error.InternalError` for a privileged one. `VaultAddEditViewModel` also falls back to the package name and an empty username. `explicitNulls = false` does not cover this, since it only relaxes nullable properties, and `coerceInputValues` only rewrites values that are present but invalid.

**Three name mismatches.** `excludedCredentials` should be `excludeCredentials`, `cross_platform` should be `cross-platform`, and `ResidentKeyRequirement` was missing `discouraged`. These are not only parsing details, because `registerFido2CredentialInternal` re-serializes this model and passes the result to the SDK. Anything the model cannot name is dropped before the authenticator sees it, so the relying party's exclusion list never arrives and duplicate passkeys are not prevented. `ignoreUnknownKeys` hides the first one and `coerceInputValues` hides the other two, which is why none of this surfaced as an error.

Fixtures in this repo already use the spec spelling `excludeCredentials`, at `RelyingPartyParserTest.kt:105` and `:139` and `BitwardenCredentialManagerTest.kt:1520`, but always with an empty array. That is why the existing tests stayed green.

Nothing else needed to change. There are no main source construction sites for this model, both test construction sites use named arguments, and the only read of `authenticatorSelection` is already a null safe call in `BitwardenCredentialManagerImpl.getUserVerificationRequirement`, which falls back to the same value as before.

### Testing

New `PasskeyAttestationOptionsTest` with 7 tests. I checked each fix separately rather than all at once:

* reverting only the two `@SerialName` renames fails exactly the 4 tests that cover them and leaves the other 3 passing
* `authenticatorSelection` is covered by the decode test, which fails with `expected: not <null>` on the old model
* the `DISCOURAGED` member does not exist on the old model, so the test file does not compile against it

The two serialization tests build the model directly instead of decoding first, so they exercise the encoder rather than passing for the wrong reason.

`:app:testStandardDebugUnitTest` for `data.credentials.*`, `ui.vault.feature.addedit.*` and `ui.vault.feature.itemlisting.*` is green at 956 tests, and `detekt` reports no findings.

### Out of scope

The round trip through this model is lossy beyond the fields above. `attestation`, `timeout`, `extensions` and `hints` are all dropped before the SDK sees the request, and real requests do carry them. That needs a different fix than renaming members, so I left it alone here.
