### PR TITLE
[PM-43211] Recognize HTML card hints in Android autofill

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensions.kt
@@ -19,6 +19,14 @@ private const val DEFAULT_SCHEME: String = "https"
  * The supported autofill Android View hints that predate identity autofill.
  */
 private val SUPPORTED_VIEW_HINTS: List<String> = listOf(
+    // Chromium can pass HTML autocomplete tokens directly as Android autofill hints.
+    "cc-exp-month",
+    "cc-exp-year",
+    "cc-exp",
+    "cc-number",
+    "cc-csc",
+    "cc-name",
+    "cc-type",
     View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_MONTH,
     View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_YEAR,
     View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE,
@@ -209,11 +217,28 @@ private fun AssistStructure.ViewNode.firstSupportedAutofillHintOrNull(
 
 private fun String.toBitwardenAutofillHintOrNull(): AutofillHint? =
     when (this) {
-        View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_MONTH -> AutofillHint.Card.EXPIRATION_MONTH
-        View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_YEAR -> AutofillHint.Card.EXPIRATION_YEAR
-        View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE -> AutofillHint.Card.EXPIRATION_DATE
-        View.AUTOFILL_HINT_CREDIT_CARD_NUMBER -> AutofillHint.Card.NUMBER
-        View.AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE -> AutofillHint.Card.SECURITY_CODE
+        View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_MONTH,
+        "cc-exp-month",
+            -> AutofillHint.Card.EXPIRATION_MONTH
+
+        View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_YEAR,
+        "cc-exp-year",
+            -> AutofillHint.Card.EXPIRATION_YEAR
+
+        View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE,
+        "cc-exp",
+            -> AutofillHint.Card.EXPIRATION_DATE
+
+        View.AUTOFILL_HINT_CREDIT_CARD_NUMBER,
+        "cc-number",
+            -> AutofillHint.Card.NUMBER
+
+        View.AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE,
+        "cc-csc",
+            -> AutofillHint.Card.SECURITY_CODE
+
+        "cc-name" -> AutofillHint.Card.CARDHOLDER
+        "cc-type" -> AutofillHint.Card.BRAND
         View.AUTOFILL_HINT_PASSWORD -> AutofillHint.Login.PASSWORD
         View.AUTOFILL_HINT_EMAIL_ADDRESS,
         View.AUTOFILL_HINT_USERNAME,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
@@ -62,6 +62,7 @@ class ViewNodeExtensionsTest {
         mockkStatic(Int::isUsernameInputType)
         mockkStatic(AutofillValue::extractMonthValue)
         mockkStatic(AutofillValue::extractYearValue)
+        mockkStatic(AutofillValue::extractCardBrandValue)
         mockkStatic(AutofillValue::extractTextValue)
         every {
             testAutofillValue.extractMonthValue(
@@ -85,7 +86,93 @@ class ViewNodeExtensionsTest {
         unmockkStatic(Int::isUsernameInputType)
         unmockkStatic(AutofillValue::extractMonthValue)
         unmockkStatic(AutofillValue::extractYearValue)
+        unmockkStatic(AutofillValue::extractCardBrandValue)
         unmockkStatic(AutofillValue::extractTextValue)
+    }
+
+    @Test
+    fun `HTML card autofill hints classify localized fields without heuristic hints`() {
+        setupUnsupportedInputFieldViewNode()
+        every { viewNode.hint } returns "رقم البطاقة"
+        every {
+            testAutofillValue.extractCardBrandValue(autofillOptions = AUTOFILL_OPTIONS_LIST)
+        } returns null
+        val cases = listOf(
+            "cc-number" to AutofillView.Card.Number(data = autofillViewData),
+            "cc-exp" to AutofillView.Card.ExpirationDate(data = autofillViewData),
+            "cc-exp-month" to AutofillView.Card.ExpirationMonth(
+                data = autofillViewData,
+                monthValue = MONTH_VALUE,
+            ),
+            "cc-exp-year" to AutofillView.Card.ExpirationYear(
+                data = autofillViewData,
+                yearValue = YEAR_VALUE,
+            ),
+            "cc-csc" to AutofillView.Card.SecurityCode(data = autofillViewData),
+            "cc-name" to AutofillView.Card.CardholderName(data = autofillViewData),
+            "cc-type" to AutofillView.Card.Brand(data = autofillViewData, brandValue = null),
+        )
+
+        cases.forEach { (hint, expected) ->
+            every { viewNode.autofillHints } returns arrayOf(hint)
+
+            listOf(false, true).forEach { identityAutofillEnabled ->
+                val actual = viewNode.toAutofillView(
+                    parentWebsite = null,
+                    isIdentityAutofillEnabled = identityAutofillEnabled,
+                )
+
+                assertEquals(expected, actual, "Failed for HTML hint: $hint")
+            }
+        }
+    }
+
+    @Test
+    fun `HTML security code hint takes precedence over password field heuristics`() {
+        setupUnsupportedInputFieldViewNode()
+        every { viewNode.autofillHints } returns arrayOf("cc-csc")
+        every { viewNode.htmlInfo.isPasswordField() } returns true
+        every { viewNode.htmlInfo.hints() } returns listOf("password")
+        val expected = AutofillView.Card.SecurityCode(
+            data = autofillViewData.copy(hasPasswordTerms = true),
+        )
+
+        val actual = viewNode.toAutofillView(
+            parentWebsite = null,
+            isIdentityAutofillEnabled = false,
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `unknown HTML card hint does not classify an otherwise unsupported field`() {
+        setupUnsupportedInputFieldViewNode()
+        every { viewNode.autofillHints } returns arrayOf("cc-unknown")
+
+        val actual = viewNode.toAutofillView(
+            parentWebsite = null,
+            isIdentityAutofillEnabled = false,
+        )
+
+        assertEquals(AutofillView.Unused(data = autofillViewData), actual)
+    }
+
+    @Test
+    fun `unsupported hints are skipped while supported hint order is preserved`() {
+        setupUnsupportedInputFieldViewNode()
+        every { viewNode.autofillHints } returns arrayOf(
+            "cc-unknown",
+            View.AUTOFILL_HINT_PASSWORD,
+            "cc-number",
+        )
+
+        val actual = viewNode.toAutofillView(
+            parentWebsite = null,
+            isIdentityAutofillEnabled = false,
+        )
+
+        assertEquals(AutofillView.Login.Password(data = autofillViewData), actual)
     }
 
     @Suppress("MaxLineLength")


### PR DESCRIPTION
## 🎟️ Tracking

Reproduced Android card-autofill failure on the Arabic Moamalat payment form (`npg.moamalat.net`). Switching the same form to English makes the card picker work. Related community report: https://community.bitwarden.com/t/credit-card-autofill-issue-with-website-in-language-other-than-english/93355 (not claiming identical underlying behavior).

## 📔 Objective

Recognize HTML card autocomplete tokens supplied directly in `AssistStructure.ViewNode.autofillHints`, without relying on an English label or placeholder.

On Pixel 10 Pro / Android 17, Bitwarden 2026.8.0, Chrome 152.0.7977.76, the Arabic card-number field offers no cards. Expiration/security-code fields open a login picker instead. Chrome's third-party autofill integration is enabled. Sanitized Android structure inspection confirms the card field reaches Android with `autofillHints=[cc-number]`, a localized hint, and HTML attributes `id=cc-number`, `name=cardNumber`, `type=text`.

The source HTML includes:

```html
<input type="ccnum" inputmode="numeric" name="cardNumber"
       autocomplete="cc-number" id="cc-number" placeholder="رقم البطاقة">
```

Chrome normalizes the unknown input type to text. Changing that type alone did not fix recognition. A fresh field with the English placeholder `Card number` opened the card picker, and the reporter independently confirmed that the site's normal English-language option works after refresh. No payment was submitted. These are observations of the released app, not validation of a patched APK.

The current explicit-hint allowlist accepts Android's `creditCardNumber`, but not the HTML `cc-number` token observed in the Android structure. Once rejected, matching falls back to heuristic labels. This patch accepts the seven standard HTML card hints (`cc-number`, `cc-exp`, `cc-exp-month`, `cc-exp-year`, `cc-csc`, `cc-name`, `cc-type`) and maps them to the existing Card partitions before those heuristics. It retains the order of supported hints and leaves unknown hints unsupported. No URI matching, vault schema, credential storage, or new dependency changes.

### Validation

- Added regression coverage for all seven HTML card hints with a localized label and both identity-autofill flag states.
- Added checks for security-code hints taking precedence over password heuristics, unknown hints, and supported-hint ordering.
- `git diff --check` passed.
- **Unit tests and detekt have not run successfully.** The local checkout lacks Android SDK 37 and the required build dependencies. The pinned Gradle 9.7.0 download was interrupted before completion; an explicitly offline attempt with installed Gradle 9.7.1 failed during configuration because Android Gradle Plugin 9.3.2 was not cached. No dependency versions or locks were changed to work around this.
- Intended targeted command: `./gradlew :app:testStandardDebugUnitTest --tests 'com.x8bit.bitwarden.data.autofill.util.ViewNodeExtensionsTest'`.
- Draft pending CI, review, and testing the patched app against the Arabic form. Does not claim every field on that form is fixed when it has no explicit hint.

Prepared with AI assistance from reporter-confirmed device behavior and sanitized field metadata. No vault contents, payment details, screenshots, or private diagnostics are included.
