### PR TITLE
PM-43342, PM-43343, PM-43373: bug: Hide copy and share options from disabled Send

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SendViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SendViewExtensions.kt
@@ -39,19 +39,17 @@ fun SendView.toOverflowActions(
     this
         .id
         ?.let { sendId ->
+            val sendUrl = toSendUrl(baseWebSendUrl = baseWebSendUrl)
             listOfNotNull(
-                ListingItemOverflowAction.SendAction.CopyUrlClick(
-                    sendUrl = toSendUrl(baseWebSendUrl = baseWebSendUrl),
-                ),
-                ListingItemOverflowAction.SendAction.ShareUrlClick(
-                    sendUrl = toSendUrl(baseWebSendUrl = baseWebSendUrl),
-                ),
+                ListingItemOverflowAction.SendAction.CopyUrlClick(sendUrl = sendUrl)
+                    .takeUnless { this.disabled },
+                ListingItemOverflowAction.SendAction.ShareUrlClick(sendUrl = sendUrl)
+                    .takeUnless { this.disabled },
                 ListingItemOverflowAction.SendAction.ViewClick(sendId = sendId, sendType = type),
                 ListingItemOverflowAction.SendAction.EditClick(sendId = sendId, sendType = type)
                     .takeUnless { this.disabled },
-                ListingItemOverflowAction.SendAction.RemovePasswordClick(sendId = sendId).takeIf {
-                    hasPassword
-                },
+                ListingItemOverflowAction.SendAction.RemovePasswordClick(sendId = sendId)
+                    .takeIf { this.hasPassword && !this.disabled },
                 ListingItemOverflowAction.SendAction.DeleteClick(sendId = sendId),
             )
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
@@ -212,6 +212,7 @@ private fun ViewSendScreenContent(
             ViewStateContent(
                 state = viewState,
                 policyRestriction = state.policyRestriction,
+                isSendDisabled = state.isSendDisabled,
                 onCopyClick = onCopyClick,
                 onCopyNotesClick = onCopyNotesClick,
                 onDeleteClick = onDeleteClick,
@@ -239,6 +240,7 @@ private fun ViewSendScreenContent(
 private fun ViewStateContent(
     state: ViewSendState.ViewState.Content,
     policyRestriction: SendPolicyRestriction?,
+    isSendDisabled: Boolean,
     onCopyClick: () -> Unit,
     onCopyNotesClick: () -> Unit,
     onDeleteClick: () -> Unit,
@@ -273,37 +275,39 @@ private fun ViewStateContent(
             )
             Spacer(modifier = Modifier.height(height = 16.dp))
         }
-        ShareLinkSection(
-            shareLink = state.shareLink,
-            modifier = Modifier
-                .fillMaxWidth()
-                .standardHorizontalMargin(),
-        )
-        BitwardenFilledButton(
-            label = stringResource(id = BitwardenString.copy),
-            onClick = onCopyClick,
-            icon = rememberVectorPainter(id = BitwardenDrawable.ic_copy_small),
-            cardStyle = CardStyle.Middle(hasDivider = false),
-            cardInsets = PaddingValues(top = 16.dp, bottom = 6.dp, start = 16.dp, end = 16.dp),
-            modifier = Modifier
-                .fillMaxWidth()
-                .standardHorizontalMargin()
-                .testTag(tag = "ViewSendCopyButton"),
-        )
-        BitwardenOutlinedButton(
-            label = stringResource(id = BitwardenString.share),
-            onClick = onShareClick,
-            icon = rememberVectorPainter(id = BitwardenDrawable.ic_share_small),
-            isExternalLink = true,
-            cardStyle = CardStyle.Bottom,
-            cardInsets = PaddingValues(top = 6.dp, bottom = 16.dp, start = 16.dp, end = 16.dp),
-            modifier = Modifier
-                .fillMaxWidth()
-                .standardHorizontalMargin()
-                .testTag(tag = "ViewSendShareButton"),
-        )
+        if (!isSendDisabled) {
+            ShareLinkSection(
+                shareLink = state.shareLink,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+            BitwardenFilledButton(
+                label = stringResource(id = BitwardenString.copy),
+                onClick = onCopyClick,
+                icon = rememberVectorPainter(id = BitwardenDrawable.ic_copy_small),
+                cardStyle = CardStyle.Middle(hasDivider = false),
+                cardInsets = PaddingValues(top = 16.dp, bottom = 6.dp, start = 16.dp, end = 16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .testTag(tag = "ViewSendCopyButton"),
+            )
+            BitwardenOutlinedButton(
+                label = stringResource(id = BitwardenString.share),
+                onClick = onShareClick,
+                icon = rememberVectorPainter(id = BitwardenDrawable.ic_share_small),
+                isExternalLink = true,
+                cardStyle = CardStyle.Bottom,
+                cardInsets = PaddingValues(top = 6.dp, bottom = 16.dp, start = 16.dp, end = 16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .testTag(tag = "ViewSendShareButton"),
+            )
+            Spacer(modifier = Modifier.height(height = 16.dp))
+        }
 
-        Spacer(modifier = Modifier.height(height = 16.dp))
         BitwardenListHeaderText(
             label = stringResource(id = BitwardenString.send_details),
             modifier = Modifier

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SendViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SendViewExtensionsTest.kt
@@ -103,11 +103,11 @@ class SendViewExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `toOverflowActions should return overflow options without Edit when the send is disabled`() {
+    fun `toOverflowActions should return overflow options without Copy, Share, Edit, and RemovePassword when the send is disabled`() {
         val baseWebSendUrl = "www.test.com"
         val sendView = createMockSendView(
             number = 1,
-            // Make sure the send is disabled to remove the edit action
+            // Make sure the Send is disabled to remove the edit action
             disabled = true,
         )
 
@@ -115,7 +115,10 @@ class SendViewExtensionsTest {
 
         assertEquals(
             ALL_SEND_OVERFLOW_OPTIONS.filter {
-                it !is ListingItemOverflowAction.SendAction.EditClick
+                it !is ListingItemOverflowAction.SendAction.CopyUrlClick &&
+                    it !is ListingItemOverflowAction.SendAction.ShareUrlClick &&
+                    it !is ListingItemOverflowAction.SendAction.EditClick &&
+                    it !is ListingItemOverflowAction.SendAction.RemovePasswordClick
             },
             result,
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
@@ -447,6 +447,19 @@ class ViewSendScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `copy, share, and send link should be hidden when the send is disabled`() {
+        composeTestRule.onNodeWithText(text = "Copy").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText(text = "Share").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText(text = "Send link").performScrollTo().assertIsDisplayed()
+
+        mutableStateFlow.update { it.copy(isSendDisabled = true) }
+
+        composeTestRule.onNodeWithText(text = "Copy").assertDoesNotExist()
+        composeTestRule.onNodeWithText(text = "Share").assertDoesNotExist()
+        composeTestRule.onNodeWithText(text = "Send link").assertDoesNotExist()
+    }
+
+    @Test
     fun `on copy notes click should send CopyNotesClick`() {
         composeTestRule
             .onNodeWithText(text = "Additional options")


### PR DESCRIPTION
## 🎟️ Tracking

[PM-43342](https://bitwarden.atlassian.net/browse/PM-43342)
[PM-43343](https://bitwarden.atlassian.net/browse/PM-43343)
[PM-43373](https://bitwarden.atlassian.net/browse/PM-43373)

## 📔 Objective

This PR hides the options to copy and share a Send when the Send is disabled.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/d08c6262-9971-4b76-ba3b-b29ccb775a45" width="350" /> | <img src="https://github.com/user-attachments/assets/d82d65d9-6350-4860-8e50-8e1385232be8" width="350" /> |
| <img src="https://github.com/user-attachments/assets/90201c3f-1584-4064-8fc6-5ec8fcc89acc" width="350" /> | <img src="https://github.com/user-attachments/assets/a43717f3-dbb3-4988-bc7b-c1b6e21dd8ae" width="350" /> |


[PM-43342]: https://bitwarden.atlassian.net/browse/PM-43342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-43343]: https://bitwarden.atlassian.net/browse/PM-43343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-43373]: https://bitwarden.atlassian.net/browse/PM-43373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ